### PR TITLE
Make delimiters separate tokens from beginnings of '%' literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -21,7 +21,7 @@ const PREC = {
   LITERAL: 100,
 };
 
-const unbalancedDelimiters = '!@#$%^&*)]}>|\\=/+-~`\'",.?:;_';
+const unbalancedDelimiters = '!@#$%^&*)]}>|\\=/+-~`\'",.?:;_'.split('');
 const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*/;
 const operators = ['..', '|', '^', '&', '<=>', '==', '===', '=~', '>', '>=', '<', '<=', '+', '-', '*', '/', '%', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]='];
 
@@ -239,11 +239,13 @@ module.exports = grammar({
       token(seq(':', choice(identifierPattern, choice.apply(null, operators)))),
       seq(":'", $._single_quoted_continuation),
       seq(':"', $._double_quoted_continuation),
-      choice.apply(null, unbalancedDelimiters.split('').map(d => stringBody('%s' + d, d))),
-      seq(/%s/, $._uninterpolated_angle),
-      seq(/%s/, $._uninterpolated_bracket),
-      seq(/%s/, $._uninterpolated_paren),
-      seq(/%s/, $._uninterpolated_brace)
+      seq('%s', choice(
+        choice.apply(null, unbalancedDelimiters.map(d => stringBody(d, d))),
+        $._uninterpolated_angle,
+        $._uninterpolated_bracket,
+        $._uninterpolated_paren,
+        $._uninterpolated_brace
+      ))
     ),
 
     integer: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
@@ -253,17 +255,22 @@ module.exports = grammar({
 
     string: $ => seq(choice(
       $._quoted_string,
-      choice.apply(null, unbalancedDelimiters.split('').map(d => stringBody(RegExp('%(Q|)\\' + d), d, $.interpolation))),
-      seq(/%Q?/, $._interpolated_angle),
-      seq(/%Q?/, $._interpolated_bracket),
-      seq(/%Q?/, $._interpolated_paren),
-      seq(/%Q?/, $._interpolated_brace),
-      choice.apply(null, unbalancedDelimiters.split('').map(d => stringBody('%q' + d, d))),
-      seq('%q', $._uninterpolated_angle),
-      seq('%q', $._uninterpolated_bracket),
-      seq('%q', $._uninterpolated_paren),
-      seq('%q', $._uninterpolated_brace)
+      seq(/%Q?/, choice(
+        choice.apply(null, unbalancedDelimiters.map(d => stringBody(d, d, $.interpolation))),
+        $._interpolated_angle,
+        $._interpolated_bracket,
+        $._interpolated_paren,
+        $._interpolated_brace
+      )),
+      seq(/%q/, choice(
+        choice.apply(null, unbalancedDelimiters.map(d => stringBody(d, d))),
+        $._uninterpolated_angle,
+        $._uninterpolated_bracket,
+        $._uninterpolated_paren,
+        $._uninterpolated_brace
+      ))
     ), repeat($._quoted_string)),
+
     _quoted_string: $ => choice(
       seq("'", $._single_quoted_continuation),
       seq('"', $._double_quoted_continuation)
@@ -283,26 +290,33 @@ module.exports = grammar({
 
     subshell: $ => choice(
       stringBody('`', '`'),
-      choice.apply(null, unbalancedDelimiters.split('').map(d => stringBody('%x' + d, d, $.interpolation))),
-      seq('%x', $._interpolated_angle),
-      seq('%x', $._interpolated_bracket),
-      seq('%x', $._interpolated_paren),
-      seq('%x', $._interpolated_brace)
+      seq('%x', choice(
+        choice.apply(null, unbalancedDelimiters.map(d => stringBody(d, d, $.interpolation))),
+        $._interpolated_angle,
+        $._interpolated_bracket,
+        $._interpolated_paren,
+        $._interpolated_brace
+      ))
     ),
 
     array: $ => choice(
       seq('[', $._array_items, ']'),
-      choice.apply(null, unbalancedDelimiters.split('').map(d => stringBody(RegExp('%[wi]\\' + d), d))),
-      seq(/%[wi]/, $._uninterpolated_angle),
-      seq(/%[wi]/, $._uninterpolated_bracket),
-      seq(/%[wi]/, $._uninterpolated_paren),
-      seq(/%[wi]/, $._uninterpolated_brace),
-      choice.apply(null, unbalancedDelimiters.split('').map(d => stringBody(RegExp('%[WI]\\' + d), d, $.interpolation))),
-      seq(/%[WI]/, $._interpolated_angle),
-      seq(/%[WI]/, $._interpolated_bracket),
-      seq(/%[WI]/, $._interpolated_paren),
-      seq(/%[WI]/, $._interpolated_brace)
+      seq(/%[wi]/, choice(
+        choice.apply(null, unbalancedDelimiters.map(d => stringBody(d, d))),
+        $._uninterpolated_angle,
+        $._uninterpolated_bracket,
+        $._uninterpolated_paren,
+        $._uninterpolated_brace
+      )),
+      seq(/%[WI]/, choice(
+        choice.apply(null, unbalancedDelimiters.map(d => stringBody(d, d, $.interpolation))),
+        $._interpolated_angle,
+        $._interpolated_bracket,
+        $._interpolated_paren,
+        $._interpolated_brace
+      ))
     ),
+
     _array_items: $ => optional(seq($._expression, optional(seq(',', $._array_items)))),
 
     hash: $ => seq('{', $._hash_items, '}'),
@@ -315,12 +329,15 @@ module.exports = grammar({
 
     regex: $ => prec(PREC.LITERAL, choice(
       regexBody('/', '/', $.interpolation),
-      choice.apply(null, unbalancedDelimiters.split('').map(d => regexBody('%r' + d, d, $.interpolation))),
-      seq('%r', $._regex_interpolated_angle),
-      seq('%r', $._regex_interpolated_bracket),
-      seq('%r', $._regex_interpolated_paren),
-      seq('%r', $._regex_interpolated_brace)
+      seq('%r', choice(
+        choice.apply(null, unbalancedDelimiters.map(d => regexBody(d, d, $.interpolation))),
+        $._regex_interpolated_angle,
+        $._regex_interpolated_bracket,
+        $._regex_interpolated_paren,
+        $._regex_interpolated_brace
+      ))
     )),
+
     _regex_interpolated_angle: $ => regexBody('<', '>', $.interpolation, $._regex_interpolated_angle),
     _regex_interpolated_bracket: $ => regexBody('[', ']', $.interpolation, $._regex_interpolated_bracket),
     _regex_interpolated_paren: $ => regexBody('(', ')', $.interpolation, $._regex_interpolated_paren),
@@ -339,7 +356,11 @@ module.exports = grammar({
 function stringBody (open, close, insert) {
   var contents = [ /\\./, RegExp('[^\\\\\\' + close + ']') ];
   if (typeof insert !== 'undefined') contents.push(insert);
-  return seq(open, repeat(choice.apply(null, contents)), token(prec(PREC.LITERAL, close)));
+  return seq(
+    (typeof open === 'string') ? token(prec(PREC.LITERAL, open)) : open,
+    repeat(choice.apply(null, contents)),
+    token(prec(PREC.LITERAL, close))
+  );
 }
 
 function balancedStringBody (me, open, close, insert) {
@@ -354,7 +375,11 @@ function regexBody (open, close, interpolation, me) {
     interpolation
   ];
   if (typeof me !== 'undefined') contents.push(me);
-  return seq(open, repeat(choice.apply(null, contents)), token(prec(PREC.LITERAL, RegExp('\\' + close + '[a-z]*'))));
+  return seq(
+    (typeof open === 'string') ? token(prec(PREC.LITERAL, open)) : open,
+    repeat(choice.apply(null, contents)),
+    token(prec(PREC.LITERAL, RegExp('\\' + close + '[a-z]*')))
+  );
 }
 
 function sep1 (rule, separator) {

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -288,10 +288,37 @@ percent q string with unbalanced delimiters
 ===========================================
 
 %q=a=
+%q!a!
+%q@a@
+%q$a$
+%q%a%
+%q^a^
+%q&a&
+%q*a*
+%q-a-
+%q+a+
+%q/a/
+%q|a|
+%q?a?
+%q\a\
+%q.a.
+%q,a,
+%q:a:
+%q;a;
+%q'a'
+%q"a"
+%q)a)
+%q]a]
+%q}a}
+%q>a>
+%q`a`
+%q~a~
+%q_a_
+%q#a#
 
 ---
 
-(program (string))
+(program (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string))
 
 =========================================
 percent q string with balanced delimiters

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -288,37 +288,10 @@ percent q string with unbalanced delimiters
 ===========================================
 
 %q=a=
-%q!a!
-%q@a@
-%q$a$
-%q%a%
-%q^a^
-%q&a&
-%q*a*
-%q-a-
-%q+a+
-%q/a/
-%q|a|
-%q?a?
-%q\a\
-%q.a.
-%q,a,
-%q:a:
-%q;a;
-%q'a'
-%q"a"
-%q)a)
-%q]a]
-%q}a}
-%q>a>
-%q`a`
-%q~a~
-%q_a_
-%q#a#
 
 ---
 
-(program (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string))
+(program (string))
 
 =========================================
 percent q string with balanced delimiters

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2486,1067 +2486,1241 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s!"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\!]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "!"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s@"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\@]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "@"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s#"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\#]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "#"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s$"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\$]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "$"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s%"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\%]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "%"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s^"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\^]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "^"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s&"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\&]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "&"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s*"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\*]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "*"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s)"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\)]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ")"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s]"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\]]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "]"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s}"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\}]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "}"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s>"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\>]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ">"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s|"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\|]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "|"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s\\"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\\]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\\"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s="
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\=]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "="
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s/"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\/]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "/"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s+"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\+]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "+"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s-"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\-]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "-"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s~"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\~]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "~"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s`"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\`]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "`"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s'"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\']"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "'"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s\""
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\"]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\""
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s,"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\,]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ","
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s."
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\.]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "."
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s?"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\?]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "?"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s:"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\:]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ":"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s;"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\;]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ";"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%s_"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\_]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "_"
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "SEQ",
           "members": [
             {
-              "type": "PATTERN",
+              "type": "STRING",
               "value": "%s"
             },
             {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_angle"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%s"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_bracket"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%s"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_paren"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%s"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_brace"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\!]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\@]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\#]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\$]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\%]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\^]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\&]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\*]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\)]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\]]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\}]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\>]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\|]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\\]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\=]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\/]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\+]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\-]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\~]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\`]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\']"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\"]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\,]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\.]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\?]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\:]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\;]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\_]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_brace"
+                }
+              ]
             }
           ]
         }
@@ -3605,1125 +3779,1351 @@
               "name": "_quoted_string"
             },
             {
-              "type": "CHOICE",
+              "type": "SEQ",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\!"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\!]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "!"
-                        }
-                      }
-                    }
-                  ]
+                  "type": "PATTERN",
+                  "value": "%Q?"
                 },
                 {
-                  "type": "SEQ",
+                  "type": "CHOICE",
                   "members": [
                     {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\@"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\@]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "@"
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "!"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\!]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "!"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "@"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\@]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "@"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "#"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\#]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "#"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "$"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\$]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "$"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "%"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\%]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "%"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "^"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\^]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "^"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "&"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\&]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "&"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "*"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\*]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "*"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ")"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\)]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ")"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "]"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\]]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "]"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "}"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\}]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "}"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ">"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\>]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ">"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "|"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\|]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "|"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\\"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\\\]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\\"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "="
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\=]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "="
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "/"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\/]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "/"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "+"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\+]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "+"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "-"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\-]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "-"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "~"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\~]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "~"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "`"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\`]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "`"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "'"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\']"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "'"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\""
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\\"]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\""
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ","
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\,]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ","
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "."
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\.]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "."
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "?"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\?]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "?"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ":"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\:]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ":"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ";"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\;]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ";"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\_]"
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "interpolation"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              }
+                            }
+                          ]
                         }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\#"
+                      ]
                     },
                     {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\#]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
+                      "type": "SYMBOL",
+                      "name": "_interpolated_angle"
                     },
                     {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "#"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\$"
+                      "type": "SYMBOL",
+                      "name": "_interpolated_bracket"
                     },
                     {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\$]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
+                      "type": "SYMBOL",
+                      "name": "_interpolated_paren"
                     },
                     {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "$"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\%"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\%]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "%"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\^"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\^]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "^"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\&"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\&]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "&"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\*"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\*]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "*"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\)"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\)]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ")"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\]"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\]]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "]"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\}"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\}]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "}"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\>"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\>]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ">"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\|"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\|]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "|"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\\\"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\\\]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "\\"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\="
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\=]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "="
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\/"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\/]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "/"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\+"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\+]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "+"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\-"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\-]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "-"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\~"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\~]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "~"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\`"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\`]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "`"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\'"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\']"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "'"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\\""
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\\"]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "\""
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\,"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\,]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ","
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\."
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\.]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "."
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\?"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\?]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "?"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\:"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\:]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ":"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\;"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\;]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ";"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "%(Q|)\\_"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\_]"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "interpolation"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "_"
-                        }
-                      }
+                      "type": "SYMBOL",
+                      "name": "_interpolated_brace"
                     }
                   ]
                 }
@@ -4734,1115 +5134,1237 @@
               "members": [
                 {
                   "type": "PATTERN",
-                  "value": "%Q?"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_angle"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%Q?"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_bracket"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%Q?"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_paren"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%Q?"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_brace"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q!"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\!]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "!"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q@"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\@]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "@"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q#"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\#]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "#"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q$"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\$]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "$"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q%"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\%]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "%"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q^"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\^]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "^"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q&"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\&]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "&"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q*"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\*]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "*"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q)"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\)]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ")"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q]"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\]]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "]"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q}"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\}]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "}"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q>"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\>]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ">"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q|"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\|]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "|"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q\\"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\\\]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "\\"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q="
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\=]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "="
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q/"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\/]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "/"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q+"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\+]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "+"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q-"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\-]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "-"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q~"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\~]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "~"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q`"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\`]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "`"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q'"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\']"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "'"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q\""
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\\"]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "\""
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q,"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\,]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ","
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q."
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\.]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "."
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q?"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\?]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "?"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q:"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\:]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ":"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q;"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\;]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": ";"
-                        }
-                      }
-                    }
-                  ]
-                },
-                {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "%q_"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\."
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\\\\\_]"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "PREC",
-                        "value": 100,
-                        "content": {
-                          "type": "STRING",
-                          "value": "_"
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
                   "value": "%q"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_angle"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%q"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_bracket"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%q"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_paren"
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%q"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_brace"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "!"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\!]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "!"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "@"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\@]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "@"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "#"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\#]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "#"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "$"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\$]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "$"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "%"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\%]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "%"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "^"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\^]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "^"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "&"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\&]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "&"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "*"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\*]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "*"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ")"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\)]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ")"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "]"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\]]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "]"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "}"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\}]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "}"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ">"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\>]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ">"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "|"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\|]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "|"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\\"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\\\]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\\"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "="
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\=]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "="
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "/"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\/]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "/"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "+"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\+]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "+"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "-"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\-]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "-"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "~"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\~]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "~"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "`"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\`]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "`"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "'"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\']"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "'"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\""
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\\"]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "\""
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ","
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\,]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ","
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "."
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\.]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "."
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "?"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\?]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "?"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ":"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\:]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ":"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ";"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\;]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": ";"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              }
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "\\\\."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\_]"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "TOKEN",
+                              "content": {
+                                "type": "PREC",
+                                "value": 100,
+                                "content": {
+                                  "type": "STRING",
+                                  "value": "_"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_uninterpolated_angle"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_uninterpolated_bracket"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_uninterpolated_paren"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_uninterpolated_brace"
+                    }
+                  ]
                 }
               ]
             }
@@ -6273,8 +6795,15 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "STRING",
-              "value": "`"
+              "type": "TOKEN",
+              "content": {
+                "type": "PREC",
+                "value": 100,
+                "content": {
+                  "type": "STRING",
+                  "value": "`"
+                }
+              }
             },
             {
               "type": "REPEAT",
@@ -6306,1131 +6835,6 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x!"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\!]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "!"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x@"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\@]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "@"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x#"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\#]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "#"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x$"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\$]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "$"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x%"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\%]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "%"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x^"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\^]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "^"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x&"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\&]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "&"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x*"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\*]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "*"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x)"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\)]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ")"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x]"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\]]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "]"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x}"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\}]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "}"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x>"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\>]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ">"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x|"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\|]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "|"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x\\"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\\]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\\"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x="
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\=]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "="
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x/"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\/]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "/"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x+"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\+]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "+"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x-"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\-]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "-"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x~"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\~]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "~"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x`"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\`]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "`"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x'"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\']"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "'"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x\""
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\"]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\""
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x,"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\,]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ","
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x."
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\.]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "."
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x?"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\?]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "?"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x:"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\:]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ":"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x;"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\;]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ";"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "%x_"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\_]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "_"
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "SEQ",
           "members": [
             {
@@ -7438,47 +6842,1346 @@
               "value": "%x"
             },
             {
-              "type": "SYMBOL",
-              "name": "_interpolated_angle"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "%x"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_interpolated_bracket"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "%x"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_interpolated_paren"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "%x"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_interpolated_brace"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\!]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\@]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\#]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\$]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\%]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\^]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\&]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\*]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\)]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\]]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\}]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\>]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\|]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\\]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\=]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\/]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\+]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\-]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\~]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\`]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\']"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\"]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\,]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\.]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\?]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\:]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\;]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\_]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_brace"
+                }
+              ]
             }
           ]
         }
@@ -7505,1019 +8208,6 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\!"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\!]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "!"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\@"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\@]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "@"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\#"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\#]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "#"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\$"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\$]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "$"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\%"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\%]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "%"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\^"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\^]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "^"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\&"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\&]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "&"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\*"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\*]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "*"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\)"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\)]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ")"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\]"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\]]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "]"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\}"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\}]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "}"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\>"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\>]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ">"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\|"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\|]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "|"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\\\"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\\]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\\"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\="
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\=]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "="
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\/"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\/]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "/"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\+"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\+]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "+"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\-"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\-]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "-"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\~"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\~]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "~"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\`"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\`]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "`"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\'"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\']"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "'"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\\""
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\"]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\""
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\,"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\,]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ","
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\."
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\.]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "."
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\?"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\?]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "?"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\:"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\:]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ":"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\;"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\;]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ";"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[wi]\\_"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\_]"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "_"
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
           "type": "SEQ",
           "members": [
             {
@@ -8525,1170 +8215,1232 @@
               "value": "%[wi]"
             },
             {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_angle"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%[wi]"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_bracket"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%[wi]"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_paren"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%[wi]"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_uninterpolated_brace"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
+              "type": "CHOICE",
               "members": [
                 {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\!"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\!]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "!"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\!]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\@]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\#]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\$]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\%]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\^]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\&]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\*]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\)]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\]]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\}]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\>]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\|]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\\]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\=]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\/]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\+]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\-]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\~]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\`]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\']"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\"]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\,]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\.]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\?]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\:]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\;]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\_]"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        }
+                      ]
                     }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\@"
+                  ]
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\@]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_angle"
                 },
                 {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "@"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\#"
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_bracket"
                 },
                 {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\#]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_paren"
                 },
                 {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "#"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\$"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\$]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "$"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\%"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\%]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "%"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\^"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\^]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "^"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\&"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\&]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "&"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\*"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\*]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "*"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\)"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\)]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ")"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\]"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\]]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "]"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\}"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\}]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "}"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\>"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\>]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ">"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\|"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\|]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "|"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\\\"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\\]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\\"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\="
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\=]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "="
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\/"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\/]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "/"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\+"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\+]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "+"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\-"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\-]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "-"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\~"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\~]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "~"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\`"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\`]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "`"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\'"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\']"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "'"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\\""
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\\"]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "\""
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\,"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\,]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ","
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\."
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\.]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "."
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\?"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\?]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "?"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\:"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\:]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ":"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\;"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\;]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": ";"
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "PATTERN",
-                  "value": "%[WI]\\_"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "\\\\."
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\\\\_]"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "TOKEN",
-                  "content": {
-                    "type": "PREC",
-                    "value": 100,
-                    "content": {
-                      "type": "STRING",
-                      "value": "_"
-                    }
-                  }
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_brace"
                 }
               ]
             }
@@ -9702,47 +9454,1346 @@
               "value": "%[WI]"
             },
             {
-              "type": "SYMBOL",
-              "name": "_interpolated_angle"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%[WI]"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_interpolated_bracket"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%[WI]"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_interpolated_paren"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "%[WI]"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_interpolated_brace"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\!]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "!"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\@]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "@"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\#]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "#"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\$]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "$"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\%]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "%"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\^]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "^"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\&]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "&"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\*]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "*"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\)]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ")"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\]]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\}]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "}"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\>]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ">"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\|]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "|"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\\]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\\"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\=]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "="
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\/]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "/"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\+]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "+"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\-]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "-"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\~]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "~"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\`]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "`"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\']"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "'"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\"]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "\""
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\,]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ","
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\.]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "."
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\?]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "?"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\:]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ":"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\;]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "PATTERN",
+                                "value": "\\\\."
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\_]"
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "interpolation"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "PREC",
+                            "value": 100,
+                            "content": {
+                              "type": "STRING",
+                              "value": "_"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_brace"
+                }
+              ]
             }
           ]
         }
@@ -9891,8 +10942,15 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "/"
+                "type": "TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 100,
+                  "content": {
+                    "type": "STRING",
+                    "value": "/"
+                  }
+                }
               },
               {
                 "type": "REPEAT",
@@ -9924,1019 +10982,6 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r!"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\!\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\![a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r@"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\@\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\@[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r#"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\#\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\#[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r$"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\$\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\$[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r%"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\%\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\%[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r^"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\^\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\^[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r&"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\&\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\&[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r*"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\*\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\*[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r)"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\)\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\)[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r]"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\]\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\][a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r}"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\}\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\}[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r>"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\>\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\>[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r|"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\|\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\|[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r\\"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\\\\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\\\[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r="
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\=\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\=[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r/"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\/[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r+"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\+\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\+[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r-"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\-\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\-[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r~"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\~\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\~[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r`"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\`\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\`[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r'"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\'\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\'[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r\""
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\\"\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\\"[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r,"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\,\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\,[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r."
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\.\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\.[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r?"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\?\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\?[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r:"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\:\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\:[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r;"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\;\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\;[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "%r_"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "PATTERN",
-                          "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\_\\\\\\[\\n]"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "interpolation"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "PREC",
-                      "value": 100,
-                      "content": {
-                        "type": "PATTERN",
-                        "value": "\\_[a-z]*"
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
             "type": "SEQ",
             "members": [
               {
@@ -10944,47 +10989,1234 @@
                 "value": "%r"
               },
               {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_angle"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "%r"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_bracket"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "%r"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_paren"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "%r"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_brace"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "!"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\!\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\![a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "@"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\@\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\@[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "#"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\#\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\#[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "$"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\$\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\$[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "%"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\%\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\%[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "^"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\^\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\^[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "&"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\&\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\&[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "*"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\*\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\*[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": ")"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\)\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\)[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "]"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\]\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\][a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "}"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\}\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\}[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": ">"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\>\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\>[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "|"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\|\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\|[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "\\"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\\\\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\\\[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "="
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\=\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\=[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "/"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\/[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "+"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\+\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\+[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "-"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\-\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\-[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "~"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\~\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\~[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "`"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\`\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\`[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "'"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\'\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\'[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "\""
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\\"\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\\"[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": ","
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\,\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\,[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "."
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\.\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\.[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "?"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\?\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\?[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": ":"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\:\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\:[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": ";"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\;\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\;[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "STRING",
+                                "value": "_"
+                              }
+                            }
+                          },
+                          {
+                            "type": "REPEAT",
+                            "content": {
+                              "type": "CHOICE",
+                              "members": [
+                                {
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\_\\\\\\[\\n]"
+                                },
+                                {
+                                  "type": "SYMBOL",
+                                  "name": "interpolation"
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "type": "TOKEN",
+                            "content": {
+                              "type": "PREC",
+                              "value": 100,
+                              "content": {
+                                "type": "PATTERN",
+                                "value": "\\_[a-z]*"
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_regex_interpolated_angle"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_regex_interpolated_bracket"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_regex_interpolated_paren"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_regex_interpolated_brace"
+                  }
+                ]
               }
             ]
           }
@@ -10995,8 +12227,15 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "<"
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 100,
+            "content": {
+              "type": "STRING",
+              "value": "<"
+            }
+          }
         },
         {
           "type": "REPEAT",
@@ -11035,8 +12274,15 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "["
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 100,
+            "content": {
+              "type": "STRING",
+              "value": "["
+            }
+          }
         },
         {
           "type": "REPEAT",
@@ -11075,8 +12321,15 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "("
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 100,
+            "content": {
+              "type": "STRING",
+              "value": "("
+            }
+          }
         },
         {
           "type": "REPEAT",
@@ -11115,8 +12368,15 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
-          "value": "{"
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 100,
+            "content": {
+              "type": "STRING",
+              "value": "{"
+            }
+          }
         },
         {
           "type": "REPEAT",


### PR DESCRIPTION
This reduces the size of the parser object file from about 14mb to about 9mb. It does allow comments and whitespace between `%q` and its delimiter, but I think it is ok in general to parse a superset of the language.

/cc @robrix