### PR TITLE
Bring ruby grammar up to date, green tests, faster generate/build

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -23,7 +23,11 @@ const PREC = {
   LITERAL: 100,
 };
 
-const unbalancedDelimiters = '!@#$%^&*)]}>|\\=/+-~`\'",.?:;_'.split('');
+// TODO: Enable rest of unbalanced delimiters. These are rarely used in real
+// Ruby code and cause an explosion of lex and parse states along with 20+ min
+// generate/build times.
+// const unbalancedDelimiters = '!@#$%^&*)]}>|\\=/+-~`\'",.?:;_'.split('');
+const unbalancedDelimiters = '#/\\'.split('');
 const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*\??/;
 const operators = ['..', '|', '^', '&', '<=>', '==', '===', '=~', '>', '>=', '<', '<=', '+', '-', '*', '/', '%', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]='];
 

--- a/grammar.js
+++ b/grammar.js
@@ -391,9 +391,9 @@ function stringBody (open, close, insert) {
   var contents = [ /\\./, RegExp('[^\\\\\\' + close + ']') ];
   if (typeof insert !== 'undefined') contents.push(insert);
   return seq(
-    (typeof open === 'string') ? token(prec(PREC.LITERAL, open)) : open,
+    open,
     repeat(choice.apply(null, contents)),
-    token(prec(PREC.LITERAL, close))
+    close
   );
 }
 
@@ -410,9 +410,9 @@ function regexBody (open, close, interpolation, me) {
   ];
   if (typeof me !== 'undefined') contents.push(me);
   return seq(
-    (typeof open === 'string') ? token(prec(PREC.LITERAL, open)) : open,
+    open,
     repeat(choice.apply(null, contents)),
-    token(prec(PREC.LITERAL, RegExp('\\' + close + '[a-z]*')))
+    token(seq(close, /[a-z]*/))
   );
 }
 

--- a/grammar.js
+++ b/grammar.js
@@ -258,7 +258,7 @@ module.exports = grammar({
 
     _literal: $ => choice(
       $.symbol,
-      $.fixnum,
+      $.integer,
       $.float,
       $.boolean,
       $.nil,
@@ -283,7 +283,7 @@ module.exports = grammar({
       ))
     ),
 
-    fixnum: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
+    integer: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
     float: $ => (/\d(_?\d)*\.\d(_?\d)*([eE]\d(_?\d)*)?/),
     boolean: $ => choice('true', 'false', 'TRUE', 'FALSE'),
     nil: $ => choice('nil', 'NIL'),

--- a/grammar.js
+++ b/grammar.js
@@ -289,8 +289,8 @@ module.exports = grammar({
 
     integer: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
     float: $ => (/\d(_?\d)*\.\d(_?\d)*([eE]\d(_?\d)*)?/),
-    boolean: $ => choice('true', 'false', 'TRUE', 'FALSE'),
-    nil: $ => choice('nil', 'NIL'),
+    boolean: $ => token(choice('true', 'false', 'TRUE', 'FALSE')),
+    nil: $ => token(choice('nil', 'NIL')),
 
     string: $ => seq(choice(
       $._quoted_string,

--- a/grammar.js
+++ b/grammar.js
@@ -394,14 +394,14 @@ function stringBody (open, close, interpolation) {
     repeat(
       choice(
         interpolation || choice(),
-        token(repeat1(choice(
+        choice(
           seq('\\', /./),                // escaped character
           noneOf(close, '#', '\\', '\n') // any character besides close, '\', '\n'
-        ))),
+        ),
         interpolation ? /#[^{]/ : '#' // '#' not followed by '{' (if we have interpolation).
       )
     ),
-    close
+    token(prec(PREC.LITERAL, close))
   );
 }
 
@@ -412,10 +412,10 @@ function balancedStringBody (me, open, close, interpolation) {
       choice(
         interpolation || choice(),
         me,
-        token(repeat1(choice(
+        choice(
           seq('\\', /./),                      // escaped character
           noneOf(open, close, '#', '\\', '\n') // any character besides open, close, '\', '\n'
-        ))),
+        ),
         interpolation ? /#[^{]/ : '#' // '#' not followed by '{' (if we have interpolation).
       )
     ),
@@ -430,15 +430,15 @@ function regexBody (open, close, interpolation, me) {
       choice(
         me || choice(),
         interpolation,
-        token(repeat1(choice(
+        choice(
           seq('[', /[^\]\n]*/, ']'),                // square-bracket-delimited character class
           seq('\\', /./),                           // escaped character
           noneOf(open, close, '#', '\\', '[', '\n') // any character besides open, close, '#', '\', '[', '\n'
-        ))),
+        ),
         /#[^{]/ // '#' not followed by '{'
       )
     ),
-    token(seq(close, /[a-z]*/)) // Close of regex with optional regex flags (e.g /[^\n]/gi)
+    token(prec(PREC.LITERAL, seq(close, /[a-z]*/))) // Close of regex with optional regex flags (e.g. /./gi)
   );
 }
 

--- a/grammar.js
+++ b/grammar.js
@@ -267,7 +267,8 @@ module.exports = grammar({
       $.array,
       $.hash,
       $.regex,
-      $.function
+      $.lambda_literal,
+      $.lambda_expression
     ),
 
     symbol: $ => choice(
@@ -378,7 +379,24 @@ module.exports = grammar({
     _regex_interpolated_paren: $ => regexBody('(', ')', $.interpolation, $._regex_interpolated_paren),
     _regex_interpolated_brace: $ => regexBody('{', '}', $.interpolation, $._regex_interpolated_brace),
 
-    function: $ => seq('->', optional(choice(seq('(', optional($.formal_parameters), ')'), $.identifier)), '{', optional($._statements), '}'),
+    lambda_literal: $ => seq(
+      '->',
+      optional(choice(
+        seq('(', optional($.formal_parameters), ')'),
+        $.identifier
+      )),
+      '{',
+      optional($._statements),
+      '}'
+    ),
+
+    lambda_expression: $ => seq(
+      'lambda',
+      '{',
+      optional(seq('|', optional($.formal_parameters), '|')),
+      optional($._statements),
+      '}'
+    ),
 
     _function_name: $ => choice($.identifier, choice.apply(null, operators)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -93,10 +93,10 @@ module.exports = grammar({
 
     module_declaration: $ => seq("module", $.identifier, $._terminator, optional($._statements), "end"),
 
-    while_statement: $ => seq("while", $.condition, $._statement_block),
-    until_statement: $ => seq("until", $.condition, $._statement_block),
-    if_statement: $ => seq("if", $.condition, $._then_elsif_else_block),
-    unless_statement: $ => seq("unless", $.condition, $._then_else_block),
+    while_statement: $ => seq("while", $._expression, $._statement_block),
+    until_statement: $ => seq("until", $._expression, $._statement_block),
+    if_statement: $ => seq("if", $._expression, $._then_elsif_else_block),
+    unless_statement: $ => seq("unless", $._expression, $._then_else_block),
     for_statement: $ => seq("for", $._lhs, "in", $._expression, $._statement_block),
     begin_statement: $ => seq(
       "begin",
@@ -124,8 +124,6 @@ module.exports = grammar({
     while_modifier: $ => seq($._statement, "while", $._expression),
     until_modifier: $ => seq($._statement, "until", $._expression),
 
-    condition: $ => $._expression,
-
     _statement_block: $ => choice(
       $._do_block,
       seq($._terminator, optional($._statements), "end")
@@ -133,6 +131,7 @@ module.exports = grammar({
     _do_block: $ => seq("do", optional($._statements), "end"),
 
     then_block: $ => seq(choice("then", $._terminator), optional($._statements)),
+    elsif_block: $ => seq("elsif", $._expression, $.then_block),
     else_block: $ => seq("else", optional($._statements)),
     rescue_block: $ => seq("rescue", commaSep($._primary), choice("do", $._terminator), optional($._statements)),
     ensure_block: $ => seq("ensure", optional($._statements)),
@@ -140,10 +139,7 @@ module.exports = grammar({
     _then_else_block: $ => seq($.then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(
       $.then_block,
-      repeat(seq(
-        "elsif", $.condition,
-        $.then_block
-      )),
+      repeat($.elsif_block),
       optional($.else_block),
       "end"
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -422,7 +422,7 @@ function stringBody (open, close, interpolation, self) {
         interpolation || choice(),
         token(repeat1(choice(
           escapedChar,
-          noneOf(...disallowedContentChars)
+          noneOf(disallowedContentChars)
         ))),
         allowedContentPattern
       )
@@ -457,7 +457,7 @@ function regexBody (open, close, interpolation, self) {
         token(repeat1(choice(
           seq('[', /[^\]\n]*/, ']'), // square-bracket-delimited character class
           escapedChar,
-          noneOf(...disallowedContentChars)
+          noneOf(disallowedContentChars)
         ))),
         allowedContentPattern
       )
@@ -482,7 +482,7 @@ function commaSep (rule) {
   return optional(commaSep1(rule));
 }
 
-function noneOf (...characters) {
+function noneOf (characters) {
   var pattern = '[^'
   for (let character of characters) {
     pattern += '\\' + character;

--- a/grammar.js
+++ b/grammar.js
@@ -82,7 +82,10 @@ module.exports = grammar({
     ),
 
     method_declaration: $ => seq(
-      "def", $._function_name, choice(seq("(", optional($.formal_parameters), ")"), seq(optional($.formal_parameters), $._terminator)),
+      "def",
+      optional(seq($.identifier,'.')),
+      $._function_name,
+      choice(seq("(", optional($.formal_parameters), ")"), seq(optional($.formal_parameters), $._terminator)),
       optional($._statements),
       "end"
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -20,7 +20,7 @@ const PREC = {
   EXPONENTIAL: 80,
   COMPLEMENT: 85,
   UNARY_PLUS: 85,
-  LITERAL: 100,
+  REGEX: 100,
 };
 
 // TODO: Enable rest of unbalanced delimiters. These are rarely used in real
@@ -366,7 +366,7 @@ module.exports = grammar({
       seq($.identifier, ':')
     ), $._expression),
 
-    regex: $ => prec(PREC.LITERAL, choice(
+    regex: $ => prec(PREC.REGEX, choice(
       regexBody('/', '/', $.interpolation),
       seq('%r', choice(
         choice.apply(null, unbalancedDelimiters.map(d => regexBody(d, d, $.interpolation))),
@@ -442,7 +442,7 @@ function regexBody (open, close, interpolation, me) {
         /#[^{]/ // '#' not followed by '{'
       )
     ),
-    token(prec(PREC.LITERAL, seq(close, /[a-z]*/))) // Close of regex with optional regex flags (e.g. /./gi)
+    token(prec(PREC.REGEX, seq(close, /[a-z]*/))) // Close of regex with optional regex flags (e.g. /./gi)
   );
 }
 

--- a/grammar.js
+++ b/grammar.js
@@ -181,7 +181,7 @@ module.exports = grammar({
     ),
 
     scope_resolution_expression: $ => prec.left(seq(optional($._primary), '::', $.identifier)),
-    subscript_expression: $ => prec.left(seq($._primary, "[", commaSep($._primary), "]")),
+    element_reference: $ => prec.left(seq($._primary, "[", $._argument_list, "]")),
     member_access: $ => prec.left(seq($._primary, ".", $.identifier)),
 
     function_call: $ => prec.left(-1, seq(
@@ -238,7 +238,7 @@ module.exports = grammar({
     _lhs: $ => choice(
       $._variable,
       $.scope_resolution_expression,
-      $.subscript_expression,
+      $.element_reference,
       $.member_access
     ),
     _variable: $ => choice($.identifier , 'self'),

--- a/grammar.js
+++ b/grammar.js
@@ -152,6 +152,8 @@ module.exports = grammar({
       $.not,
       $.defined,
       $.assignment,
+      $.math_assignment,
+      $.conditional_assignment,
       $.conditional,
       $.range,
       $.boolean_or,
@@ -197,6 +199,9 @@ module.exports = grammar({
     not: $ => prec.right(PREC.NOT, seq("not", $._expression)),
     defined: $ => prec(PREC.DEFINED, seq("defined?", $._expression)),
     assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, '=', $._expression)),
+    math_assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, choice('+=', '-=', '*=', '**=', '/='), $._expression)),
+    conditional_assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, choice('||=', '&&='), $._expression)),
+
     conditional: $ => prec.right(PREC.CONDITIONAL, seq($._expression, '?', $._expression, ':', $._expression)),
     range: $ => prec.right(PREC.RANGE, seq($._expression, choice('..', '...'), $._expression)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -240,7 +240,12 @@ module.exports = grammar({
       seq('#', /.*/),
       seq(
         '=begin\n',
-        repeat(/.*\n/),
+        repeat(choice(
+          /[^=]/,
+          /=[^e]/,
+          /=e[^n]/,
+          /=en[^d]/
+        )),
         '=end\n'
       )
     )),

--- a/grammar.js
+++ b/grammar.js
@@ -257,7 +257,7 @@ module.exports = grammar({
 
     _literal: $ => choice(
       $.symbol,
-      $.integer,
+      $.fixnum,
       $.float,
       $.boolean,
       $.nil,
@@ -282,7 +282,7 @@ module.exports = grammar({
       ))
     ),
 
-    integer: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
+    fixnum: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
     float: $ => (/\d(_?\d)*\.\d(_?\d)*([eE]\d(_?\d)*)?/),
     boolean: $ => choice('true', 'false', 'TRUE', 'FALSE'),
     nil: $ => choice('nil', 'NIL'),

--- a/grammar_test/comments.txt
+++ b/grammar_test/comments.txt
@@ -59,7 +59,7 @@ multiple lines of whatever
 (program (comment) (comment))
 
 =========================
-multi-line block comments with almost =end
+multi-line block comments with almost end
 =========================
 
 =begin

--- a/grammar_test/comments.txt
+++ b/grammar_test/comments.txt
@@ -57,3 +57,16 @@ multiple lines of whatever
 ---
 
 (program (comment) (comment))
+
+=========================
+multi-line block comments with almost =end
+=========================
+
+=begin
+=e
+=en
+=end
+
+---
+
+(program (comment))

--- a/grammar_test/comments.txt
+++ b/grammar_test/comments.txt
@@ -43,3 +43,17 @@ multiple lines of whatever
 ---
 
 (program (comment))
+
+=========================
+multi-line block comments followed by standard comment
+=========================
+
+=begin
+whatever
+multiple lines of whatever
+=end
+# Another comment
+
+---
+
+(program (comment) (comment))

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -7,7 +7,7 @@ end
 
 ---
 
-(program (while_statement (condition (identifier))))
+(program (while_statement (identifier)))
 
 ================
 while without do
@@ -18,7 +18,7 @@ end
 
 ---
 
-(program (while_statement (condition (identifier))))
+(program (while_statement (identifier)))
 
 =========================
 while statement with body
@@ -30,7 +30,7 @@ end
 
 ---
 
-(program (while_statement (condition (identifier)) (identifier)))
+(program (while_statement (identifier) (identifier)))
 
 =====================
 empty until statement
@@ -41,7 +41,7 @@ end
 
 ---
 
-(program (until_statement (condition (identifier))))
+(program (until_statement (identifier)))
 
 =========================
 until statement with body
@@ -53,7 +53,7 @@ end
 
 ---
 
-(program (until_statement (condition (identifier)) (identifier)))
+(program (until_statement (identifier) (identifier)))
 
 ==================
 empty if statement
@@ -64,7 +64,7 @@ end
 
 ---
 
-(program (if_statement (condition (identifier)) (then_block)))
+(program (if_statement (identifier) (then_block)))
 
 =======================
 empty if/else statement
@@ -76,7 +76,7 @@ end
 
 ---
 
-(program (if_statement (condition (identifier)) (then_block) (else_block)))
+(program (if_statement (identifier) (then_block) (else_block)))
 
 ==================================
 single-line if then else statement
@@ -86,7 +86,7 @@ if foo then bar else quux end
 
 ---
 
-(program (if_statement (condition (identifier)) (then_block (identifier)) (else_block (identifier))))
+(program (if_statement (identifier) (then_block (identifier)) (else_block (identifier))))
 
 ========
 if elsif
@@ -100,7 +100,9 @@ end
 
 ---
 
-(program (if_statement (condition (identifier)) (then_block (identifier)) (condition (identifier)) (then_block (identifier))))
+(program
+  (if_statement (identifier) (then_block (identifier))
+  (elsif_block (identifier) (then_block (identifier)))))
 
 =============
 if elsif else
@@ -116,7 +118,10 @@ end
 
 ---
 
-(program (if_statement (condition (identifier)) (then_block (identifier)) (condition (identifier)) (then_block (identifier)) (else_block (identifier))))
+(program
+  (if_statement (identifier) (then_block (identifier))
+  (elsif_block (identifier) (then_block (identifier)))
+  (else_block (identifier))))
 
 ======================
 empty unless statement
@@ -127,7 +132,7 @@ end
 
 ---
 
-(program (unless_statement (condition (identifier)) (then_block)))
+(program (unless_statement (identifier) (then_block)))
 
 ================================
 empty unless statement with then
@@ -138,7 +143,7 @@ end
 
 ---
 
-(program (unless_statement (condition (identifier)) (then_block)))
+(program (unless_statement (identifier) (then_block)))
 
 ================================
 empty unless statement with else
@@ -150,7 +155,7 @@ end
 
 ---
 
-(program (unless_statement (condition (identifier)) (then_block) (else_block)))
+(program (unless_statement (identifier) (then_block) (else_block)))
 
 ===
 for

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -65,6 +65,75 @@ end
 
 (program (method_declaration (identifier) (formal_parameters (identifier) (identifier))))
 
+=========================================
+singleton method
+=========================================
+
+def self.foo
+end
+
+---
+
+(program (method_declaration (identifier) (identifier)))
+
+=========================================
+singleton method with body
+=========================================
+
+def self.foo
+  bar
+end
+
+---
+
+(program (method_declaration (identifier) (identifier) (identifier)))
+
+
+=========================================
+singleton method with arg
+=========================================
+
+def self.foo(bar)
+end
+
+---
+
+(program (method_declaration (identifier) (identifier) (formal_parameters (identifier))))
+
+=========================================
+singleton method with un-parenthesized arg
+=========================================
+
+def self.foo bar
+end
+
+---
+
+(program (method_declaration (identifier) (identifier) (formal_parameters (identifier))))
+
+=========================================
+singleton method with args
+=========================================
+
+def self.foo(bar, baz)
+end
+
+---
+
+(program (method_declaration (identifier) (identifier) (formal_parameters (identifier) (identifier))))
+
+
+=========================================
+singleton method with un-parenthesized args
+=========================================
+
+def self.foo bar, baz
+end
+
+---
+
+(program (method_declaration (identifier) (identifier) (formal_parameters (identifier) (identifier))))
+
 ===========
 empty class
 ===========
@@ -161,6 +230,9 @@ module A
     def j
       k
     end
+
+    def self.l
+    end
   end
 end
 
@@ -178,4 +250,5 @@ end
     (function_call (identifier) (argument_list (symbol)))
 
     (comment)
+    (method_declaration (identifier) (identifier))
     (method_declaration (identifier) (identifier)))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -322,14 +322,42 @@ complement
 (program (complement (identifier)))
 
 ===============================
-function call with empty parens
+function call
 ===============================
 
+foo
 foo()
+print "hello"
+print("hello")
 
 ---
 
-(program (function_call (identifier) (argument_list)))
+(program
+  (function_call (identifier) (argument_list))
+  (function_call (identifier) (argument_list))
+  (function_call (identifier) (argument_list (string)))
+  (function_call (identifier) (argument_list (string))))
+
+===============================
+function call
+===============================
+
+foo.bar
+foo.bar()
+foo.bar "hi"
+foo.bar "hi", 2
+foo.bar("hi")
+foo.bar("hi", 2)
+
+---
+
+(program
+  (member_access (identifier) (identifier))
+  (function_call (member_access (identifier) (identifier)) (argument_list))
+  (function_call (member_access (identifier) (identifier)) (argument_list (string)))
+  (function_call (member_access (identifier) (identifier)) (argument_list (string) (fixnum)))
+  (function_call (member_access (identifier) (identifier)) (argument_list (string)))
+  (function_call (member_access (identifier) (identifier)) (argument_list (string) (fixnum))))
 
 ============================
 function call without parens

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -368,3 +368,46 @@ include D::E.f
 ---
 
 (program (function_call (identifier) (argument_list (member_access (scope_resolution_expression (identifier) (identifier)) (identifier)))))
+
+==============
+empty lambda expression
+==============
+
+lambda {}
+
+---
+
+(program (lambda_expression))
+
+==================
+lambda expression with body
+==================
+
+lambda { foo }
+
+---
+
+(program (lambda_expression (identifier)))
+
+====================
+lambda expression with an arg
+====================
+
+lambda { |foo| 1 }
+
+---
+
+(program (lambda_expression (formal_parameters (identifier)) (integer)))
+
+===========================
+lambda expression with multiple args
+===========================
+
+lambda { |a, b, c|
+	1
+	2
+}
+
+---
+
+(program (lambda_expression (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -194,21 +194,39 @@ a && b
 relational
 ==========
 
+a == b
+a != b
+a === b
 a <=> b
+a =~ b
+a !~ b
 
 ---
 
-(program (relational (identifier) (identifier)))
+(program
+  (relational (identifier) (identifier))
+  (relational (identifier) (identifier))
+  (relational (identifier) (identifier))
+  (relational (identifier) (identifier))
+  (relational (identifier) (identifier))
+  (relational (identifier) (identifier)))
 
 ==========
 comparison
 ==========
 
 a < b
+a <= b
+a > b
+a >= b
 
 ---
 
-(program (comparison (identifier) (identifier)))
+(program
+  (comparison (identifier) (identifier))
+  (comparison (identifier) (identifier))
+  (comparison (identifier) (identifier))
+  (comparison (identifier) (identifier)))
 
 ==========
 bitwise or
@@ -245,10 +263,13 @@ shift
 =====
 
 a >> b
+a << b
 
 ---
 
-(program (shift (identifier) (identifier)))
+(program
+  (shift (identifier) (identifier))
+  (shift (identifier) (identifier)))
 
 ========
 additive

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -355,9 +355,9 @@ foo.bar("hi", 2)
   (member_access (identifier) (identifier))
   (function_call (member_access (identifier) (identifier)) (argument_list))
   (function_call (member_access (identifier) (identifier)) (argument_list (string)))
-  (function_call (member_access (identifier) (identifier)) (argument_list (string) (fixnum)))
+  (function_call (member_access (identifier) (identifier)) (argument_list (string) (integer)))
   (function_call (member_access (identifier) (identifier)) (argument_list (string)))
-  (function_call (member_access (identifier) (identifier)) (argument_list (string) (fixnum))))
+  (function_call (member_access (identifier) (identifier)) (argument_list (string) (integer))))
 
 ============================
 function call without parens

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -38,6 +38,16 @@ foo[:bar]
 
 (program (element_reference (identifier) (symbol)))
 
+============
+element assignment
+============
+
+foo[bar] = 1
+
+---
+
+(program (assignment (element_reference (identifier) (identifier)) (integer)))
+
 ===============
 vacuous literal
 ===============

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -9,14 +9,34 @@ Foo::bar
 (program (scope_resolution_expression (identifier) (identifier)))
 
 ============
-subscripting
+element reference
 ============
 
 foo[bar]
 
 ---
 
-(program (subscript_expression (identifier) (identifier)))
+(program (element_reference (identifier) (identifier)))
+
+============
+element reference with string
+============
+
+foo["bar"]
+
+---
+
+(program (element_reference (identifier) (string)))
+
+============
+element reference with symbol
+============
+
+foo[:bar]
+
+---
+
+(program (element_reference (identifier) (symbol)))
 
 ===============
 vacuous literal

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -108,6 +108,38 @@ x = y
 
 (program (assignment (identifier) (identifier)))
 
+==========
+math assignment
+==========
+
+x += y
+x -= y
+x *= y
+x **= y
+x /= y
+
+---
+
+(program
+  (math_assignment (identifier) (identifier))
+  (math_assignment (identifier) (identifier))
+  (math_assignment (identifier) (identifier))
+  (math_assignment (identifier) (identifier))
+  (math_assignment (identifier) (identifier)))
+
+==========
+conditional assignment
+==========
+
+x ||= y
+x &&= y
+
+---
+
+(program
+  (conditional_assignment (identifier) (identifier))
+  (conditional_assignment (identifier) (identifier)))
+
 ===========
 conditional
 ===========

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -628,10 +628,13 @@ regular expression with interpolation
 =====================================
 
 /word#{foo}word/
+/word#word/
 
 ---
 
-(program (regex (interpolation (identifier))))
+(program
+	(regex (interpolation (identifier)))
+	(regex))
 
 =======================================================
 percent r regular expression with unbalanced delimiters

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -589,30 +589,30 @@ empty function
 
 ---
 
-(program (function))
+(program (lambda_literal))
 
 ==================
-function with body
+lambda literal with body
 ==================
 
 -> { foo }
 
 ---
 
-(program (function (identifier)))
+(program (lambda_literal (identifier)))
 
 ====================
-function with an arg
+lambda literal with an arg
 ====================
 
 -> foo { 1 }
 
 ---
 
-(program (function (identifier) (integer)))
+(program (lambda_literal (identifier) (integer)))
 
 ===========================
-function with multiple args
+lambda literal with multiple args
 ===========================
 
 -> (a, b, c) {
@@ -622,4 +622,4 @@ function with multiple args
 
 ---
 
-(program (function (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
+(program (lambda_literal (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -89,47 +89,47 @@ percent symbol with balanced delimiters
 (program (symbol) (symbol) (symbol) (symbol))
 
 =======
-fixnum
+integer
 =======
 
 1234
 
 ---
 
-(program (fixnum))
+(program (integer))
 
 =======================
-fixnum with underscore
+integer with underscore
 =======================
 
 1_234
 
 ---
 
-(program (fixnum))
+(program (integer))
 
 ===========================
-fixnum with decimal prefix
+integer with decimal prefix
 ===========================
 
 0d1_234
 
 ---
 
-(program (fixnum))
+(program (integer))
 
 ===============================
-fixnum with hexadecimal prefix
+integer with hexadecimal prefix
 ===============================
 
 0xa_bcd_ef0_123_456_789
 
 ---
 
-(program (fixnum))
+(program (integer))
 
 =========================
-fixnum with octal prefix
+integer with octal prefix
 =========================
 
 01234567
@@ -137,17 +137,17 @@ fixnum with octal prefix
 
 ---
 
-(program (fixnum) (fixnum))
+(program (integer) (integer))
 
 ==========================
-fixnum with binary prefix
+integer with binary prefix
 ==========================
 
 0b1_0
 
 ---
 
-(program (fixnum))
+(program (integer))
 
 =====
 float
@@ -591,7 +591,7 @@ hash with expression keys
 
 ---
 
-(program (hash (pair (string) (fixnum)) (pair (string) (fixnum))))
+(program (hash (pair (string) (integer)) (pair (string) (integer))))
 
 ======================
 hash with keyword keys
@@ -601,7 +601,7 @@ hash with keyword keys
 
 ---
 
-(program (hash (pair (identifier) (fixnum)) (pair (identifier) (fixnum))))
+(program (hash (pair (identifier) (integer)) (pair (identifier) (integer))))
 
 ========================
 hash with trailing comma
@@ -611,7 +611,7 @@ hash with trailing comma
 
 ---
 
-(program (hash (pair (identifier) (fixnum))))
+(program (hash (pair (identifier) (integer))))
 
 ==================
 regular expression
@@ -731,7 +731,7 @@ function with an arg
 
 ---
 
-(program (function (identifier) (fixnum)))
+(program (function (identifier) (integer)))
 
 ===========================
 function with multiple args
@@ -744,4 +744,4 @@ function with multiple args
 
 ---
 
-(program (function (formal_parameters (identifier) (identifier) (identifier)) (fixnum) (fixnum)))
+(program (function (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -42,38 +42,13 @@ double quoted symbol with interpolation
 percent symbol with unbalanced delimiters
 =========================================
 
-%s=a=
-%s!a!
-%s@a@
-%s$a$
-%s%a%
-%s^a^
-%s&a&
-%s*a*
-%s-a-
-%s+a+
 %s/a/
-%s|a|
-%s?a?
 %s\a\
-%s.a.
-%s,a,
-%s:a:
-%s;a;
-%s'a'
-%s"a"
-%s)a)
-%s]a]
-%s}a}
-%s>a>
-%s`a`
-%s~a~
-%s_a_
 %s#a#
 
 ---
 
-(program (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol) (symbol))
+(program (symbol) (symbol) (symbol))
 
 =======================================
 percent symbol with balanced delimiters
@@ -287,38 +262,13 @@ escaped interpolation
 percent q string with unbalanced delimiters
 ===========================================
 
-%q=a=
-%q!a!
-%q@a@
-%q$a$
-%q%a%
-%q^a^
-%q&a&
-%q*a*
-%q-a-
-%q+a+
 %q/a/
-%q|a|
-%q?a?
 %q\a\
-%q.a.
-%q,a,
-%q:a:
-%q;a;
-%q'a'
-%q"a"
-%q)a)
-%q]a]
-%q}a}
-%q>a>
-%q`a`
-%q~a~
-%q_a_
 %q#a#
 
 ---
 
-(program (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string))
+(program (string) (string) (string))
 
 =========================================
 percent q string with balanced delimiters
@@ -337,75 +287,25 @@ percent q string with balanced delimiters
 percent string with unbalanced delimiters
 =========================================
 
-%=a=
-%!a!
-%@a@
-%$a$
-%%a%
-%^a^
-%&a&
-%*a*
-%-a-
-%+a+
 %/a/
-%|a|
-%?a?
 %\a\
-%.a.
-%,a,
-%:a:
-%;a;
-%'a'
-%"a"
-%)a)
-%]a]
-%}a}
-%>a>
-%`a`
-%~a~
-%_a_
 %#a#
 
 ---
 
-(program (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string))
+(program (string) (string) (string))
 
 ===========================================
 percent Q string with unbalanced delimiters
 ===========================================
 
-%Q=a=
-%Q!a!
-%Q@a@
-%Q$a$
-%Q%a%
-%Q^a^
-%Q&a&
-%Q*a*
-%Q-a-
-%Q+a+
-%Q/a/
-%Q|a|
-%Q?a?
-%Q\a\
-%Q.a.
-%Q,a,
-%Q:a:
-%Q;a;
-%Q'a'
-%Q"a"
-%Q)a)
-%Q]a]
-%Q}a}
-%Q>a>
-%Q`a`
-%Q~a~
-%Q_a_
 %Q#a#
+%Q/a/
+%Q\a\
 
 ---
 
-(program (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string) (string))
+(program (string) (string) (string))
 
 =========================================
 percent string with balanced delimiters
@@ -517,7 +417,7 @@ percent w array
 unbalanced percent w array
 ==========================
 
-%w|one two|
+%w/one two/
 
 ---
 
@@ -557,7 +457,7 @@ percent i array
 unbalanced percent i array
 ==========================
 
-%i|one two|
+%i/one two/
 
 ---
 
@@ -640,38 +540,13 @@ regular expression with interpolation
 percent r regular expression with unbalanced delimiters
 =======================================================
 
-%r=a=
-%r!a!
-%r@a@
-%r$a$
-%r%a%
-%r^a^
-%r&a&
-%r*a*
-%r-a-
-%r+a+
 %r/a/
-%r|a|
-%r?a?
 %r\a\
-%r.a.
-%r,a,
-%r:a:
-%r;a;
-%r'a'
-%r"a"
-%r)a)
-%r]a]
-%r}a}
-%r>a>
-%r`a`
-%r~a~
-%r_a_
 %r#a#
 
 ---
 
-(program (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex) (regex))
+(program (regex) (regex) (regex))
 
 =====================================================
 percent r regular expression with balanced delimiters
@@ -690,7 +565,7 @@ percent r regular expression with balanced delimiters
 percent r regular expression with unbalanced delimiters and interpolation
 =========================================================================
 
-%r|a#{b}c|
+%r/a#{b}c/
 
 ---
 

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -89,47 +89,47 @@ percent symbol with balanced delimiters
 (program (symbol) (symbol) (symbol) (symbol))
 
 =======
-integer
+fixnum
 =======
 
 1234
 
 ---
 
-(program (integer))
+(program (fixnum))
 
 =======================
-integer with underscore
+fixnum with underscore
 =======================
 
 1_234
 
 ---
 
-(program (integer))
+(program (fixnum))
 
 ===========================
-integer with decimal prefix
+fixnum with decimal prefix
 ===========================
 
 0d1_234
 
 ---
 
-(program (integer))
+(program (fixnum))
 
 ===============================
-integer with hexadecimal prefix
+fixnum with hexadecimal prefix
 ===============================
 
 0xa_bcd_ef0_123_456_789
 
 ---
 
-(program (integer))
+(program (fixnum))
 
 =========================
-integer with octal prefix
+fixnum with octal prefix
 =========================
 
 01234567
@@ -137,17 +137,17 @@ integer with octal prefix
 
 ---
 
-(program (integer) (integer))
+(program (fixnum) (fixnum))
 
 ==========================
-integer with binary prefix
+fixnum with binary prefix
 ==========================
 
 0b1_0
 
 ---
 
-(program (integer))
+(program (fixnum))
 
 =====
 float
@@ -591,7 +591,7 @@ hash with expression keys
 
 ---
 
-(program (hash (pair (string) (integer)) (pair (string) (integer))))
+(program (hash (pair (string) (fixnum)) (pair (string) (fixnum))))
 
 ======================
 hash with keyword keys
@@ -601,7 +601,7 @@ hash with keyword keys
 
 ---
 
-(program (hash (pair (identifier) (integer)) (pair (identifier) (integer))))
+(program (hash (pair (identifier) (fixnum)) (pair (identifier) (fixnum))))
 
 ========================
 hash with trailing comma
@@ -611,7 +611,7 @@ hash with trailing comma
 
 ---
 
-(program (hash (pair (identifier) (integer))))
+(program (hash (pair (identifier) (fixnum))))
 
 ==================
 regular expression
@@ -731,7 +731,7 @@ function with an arg
 
 ---
 
-(program (function (identifier) (integer)))
+(program (function (identifier) (fixnum)))
 
 ===========================
 function with multiple args
@@ -744,4 +744,4 @@ function with multiple args
 
 ---
 
-(program (function (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
+(program (function (formal_parameters (identifier) (identifier) (identifier)) (fixnum) (fixnum)))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -459,7 +459,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "condition"
+          "name": "_expression"
         },
         {
           "type": "SYMBOL",
@@ -476,7 +476,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "condition"
+          "name": "_expression"
         },
         {
           "type": "SYMBOL",
@@ -493,7 +493,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "condition"
+          "name": "_expression"
         },
         {
           "type": "SYMBOL",
@@ -510,7 +510,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "condition"
+          "name": "_expression"
         },
         {
           "type": "SYMBOL",
@@ -749,10 +749,6 @@
         }
       ]
     },
-    "condition": {
-      "type": "SYMBOL",
-      "name": "_expression"
-    },
     "_statement_block": {
       "type": "CHOICE",
       "members": [
@@ -839,6 +835,23 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "elsif_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "elsif"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "then_block"
         }
       ]
     },
@@ -986,21 +999,8 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "elsif"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "condition"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "then_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "elsif_block"
           }
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4648,43 +4648,49 @@
                       "name": "interpolation"
                     },
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SEQ",
+                      "type": "TOKEN",
+                      "content": {
+                        "type": "REPEAT1",
+                        "content": {
+                          "type": "CHOICE",
                           "members": [
                             {
-                              "type": "STRING",
-                              "value": "["
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "["
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "[^\\]\\n]*"
+                                },
+                                {
+                                  "type": "STRING",
+                                  "value": "]"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "\\"
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "."
+                                }
+                              ]
                             },
                             {
                               "type": "PATTERN",
-                              "value": "[^\\]\\n]*"
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "]"
+                              "value": "[^\\/\\/\\[\\\\\\\n\\#]"
                             }
                           ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            },
-                            {
-                              "type": "PATTERN",
-                              "value": "."
-                            }
-                          ]
-                        },
-                        {
-                          "type": "PATTERN",
-                          "value": "[^\\/\\/\\#\\\\\\[\\\n]"
                         }
-                      ]
+                      }
                     },
                     {
                       "type": "PATTERN",
@@ -4696,21 +4702,17 @@
               {
                 "type": "TOKEN",
                 "content": {
-                  "type": "PREC",
-                  "value": 100,
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "/"
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[a-z]*"
-                      }
-                    ]
-                  }
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "/"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "[a-z]*"
+                    }
+                  ]
                 }
               }
             ]
@@ -4745,51 +4747,57 @@
                                   "members": []
                                 },
                                 {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
+                                  "type": "CHOICE",
+                                  "members": []
+                                },
+                                {
+                                  "type": "TOKEN",
+                                  "content": {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
+                                      "members": [
+                                        {
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "["
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "[^\\]\\n]*"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "]"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "\\"
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "."
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\#\\#\\[\\\\\\\n]"
+                                        }
+                                      ]
+                                    }
+                                  }
                                 },
                                 {
                                   "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\#\\#\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
+                                  "members": []
                                 }
                               ]
                             }
@@ -4797,21 +4805,17 @@
                           {
                             "type": "TOKEN",
                             "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "#"
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "[a-z]*"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -4837,43 +4841,49 @@
                                   "name": "interpolation"
                                 },
                                 {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
+                                  "type": "TOKEN",
+                                  "content": {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
                                       "members": [
                                         {
-                                          "type": "STRING",
-                                          "value": "["
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "["
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "[^\\]\\n]*"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "]"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "\\"
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "."
+                                            }
+                                          ]
                                         },
                                         {
                                           "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
+                                          "value": "[^\\/\\/\\[\\\\\\\n\\#]"
                                         }
                                       ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\/\\/\\#\\\\\\[\\\n]"
                                     }
-                                  ]
+                                  }
                                 },
                                 {
                                   "type": "PATTERN",
@@ -4885,21 +4895,17 @@
                           {
                             "type": "TOKEN",
                             "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "/"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "/"
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "[a-z]*"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -4925,43 +4931,40 @@
                                   "name": "interpolation"
                                 },
                                 {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
+                                  "type": "TOKEN",
+                                  "content": {
+                                    "type": "REPEAT1",
+                                    "content": {
+                                      "type": "CHOICE",
                                       "members": [
                                         {
-                                          "type": "STRING",
-                                          "value": "["
+                                          "type": "SEQ",
+                                          "members": [
+                                            {
+                                              "type": "STRING",
+                                              "value": "["
+                                            },
+                                            {
+                                              "type": "PATTERN",
+                                              "value": "[^\\]\\n]*"
+                                            },
+                                            {
+                                              "type": "STRING",
+                                              "value": "]"
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": []
                                         },
                                         {
                                           "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
+                                          "value": "[^\\\\\\\\\\[\\\\\\\n\\#]"
                                         }
                                       ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\\\\\\\\\#\\\\\\[\\\n]"
                                     }
-                                  ]
+                                  }
                                 },
                                 {
                                   "type": "PATTERN",
@@ -4973,21 +4976,17 @@
                           {
                             "type": "TOKEN",
                             "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "\\"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
+                              "type": "SEQ",
+                              "members": [
+                                {
+                                  "type": "STRING",
+                                  "value": "\\"
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "[a-z]*"
+                                }
+                              ]
                             }
                           }
                         ]
@@ -5038,43 +5037,49 @@
                 "name": "interpolation"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "["
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "["
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[^\\]\\n]*"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "]"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "[^\\]\\n]*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "]"
+                        "value": "[^\\<\\>\\[\\\\\\\n\\#]"
                       }
                     ]
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "\\"
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "."
-                      }
-                    ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\<\\>\\#\\\\\\[\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -5086,21 +5091,17 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ">"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[a-z]*"
-                }
-              ]
-            }
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ">"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[a-z]*"
+              }
+            ]
           }
         }
       ]
@@ -5126,43 +5127,49 @@
                 "name": "interpolation"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "["
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "["
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[^\\]\\n]*"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "]"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "[^\\]\\n]*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "]"
+                        "value": "[^\\[\\]\\[\\\\\\\n\\#]"
                       }
                     ]
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "\\"
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "."
-                      }
-                    ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\[\\]\\#\\\\\\[\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -5174,21 +5181,17 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "]"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[a-z]*"
-                }
-              ]
-            }
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[a-z]*"
+              }
+            ]
           }
         }
       ]
@@ -5214,43 +5217,49 @@
                 "name": "interpolation"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "["
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "["
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[^\\]\\n]*"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "]"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "[^\\]\\n]*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "]"
+                        "value": "[^\\(\\)\\[\\\\\\\n\\#]"
                       }
                     ]
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "\\"
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "."
-                      }
-                    ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\(\\)\\#\\\\\\[\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -5262,21 +5271,17 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ")"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[a-z]*"
-                }
-              ]
-            }
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ")"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[a-z]*"
+              }
+            ]
           }
         }
       ]
@@ -5302,43 +5307,49 @@
                 "name": "interpolation"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "["
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "["
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "[^\\]\\n]*"
+                          },
+                          {
+                            "type": "STRING",
+                            "value": "]"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "[^\\]\\n]*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "]"
+                        "value": "[^\\{\\}\\[\\\\\\\n\\#]"
                       }
                     ]
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": "\\"
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "."
-                      }
-                    ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\{\\}\\#\\\\\\[\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -5350,21 +5361,17 @@
         {
           "type": "TOKEN",
           "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "}"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "[a-z]*"
-                }
-              ]
-            }
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[a-z]*"
+              }
+            ]
           }
         }
       ]

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -193,6 +193,27 @@
           "value": "def"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "STRING",
+                  "value": "."
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "_function_name"
         },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2445,44 +2445,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\#\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "\\\\.|[^\\#\\\\\\\n]"
                               }
                             ]
                           }
@@ -2506,44 +2470,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\/\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "\\\\.|[^\\/\\\\\\\n]"
                               }
                             ]
                           }
@@ -2567,35 +2495,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "CHOICE",
-                                        "members": []
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\\\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\\\\\n]"
                               }
                             ]
                           }
@@ -2714,44 +2615,8 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "REPEAT1",
-                                      "content": {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "SEQ",
-                                            "members": [
-                                              {
-                                                "type": "STRING",
-                                                "value": "\\"
-                                              },
-                                              {
-                                                "type": "PATTERN",
-                                                "value": "."
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "[^\\#\\\n\\\\]"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
+                                    "type": "PATTERN",
+                                    "value": "\\\\.|[^\\#\\\\\\\n]"
                                   }
                                 ]
                               }
@@ -2775,44 +2640,16 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
                                   },
                                   {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "REPEAT1",
-                                      "content": {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "SEQ",
-                                            "members": [
-                                              {
-                                                "type": "STRING",
-                                                "value": "\\"
-                                              },
-                                              {
-                                                "type": "PATTERN",
-                                                "value": "."
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "[^\\/\\\n\\\\\\#]"
-                                          }
-                                        ]
-                                      }
-                                    }
+                                    "type": "PATTERN",
+                                    "value": "#[^{}]"
                                   },
                                   {
                                     "type": "PATTERN",
-                                    "value": "#[^{]"
+                                    "value": "\\\\.|[^\\/\\\\\\\n\\#]"
                                   }
                                 ]
                               }
@@ -2836,35 +2673,16 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
                                   },
                                   {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "REPEAT1",
-                                      "content": {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "CHOICE",
-                                            "members": []
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "[^\\\\\\\n\\\\\\#]"
-                                          }
-                                        ]
-                                      }
-                                    }
+                                    "type": "PATTERN",
+                                    "value": "#[^{}]"
                                   },
                                   {
                                     "type": "PATTERN",
-                                    "value": "#[^{]"
+                                    "value": "[^\\\\\\\\\\\n\\#]"
                                   }
                                 ]
                               }
@@ -2923,44 +2741,8 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "REPEAT1",
-                                      "content": {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "SEQ",
-                                            "members": [
-                                              {
-                                                "type": "STRING",
-                                                "value": "\\"
-                                              },
-                                              {
-                                                "type": "PATTERN",
-                                                "value": "."
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "[^\\#\\\n\\\\]"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
+                                    "type": "PATTERN",
+                                    "value": "\\\\.|[^\\#\\\\\\\n]"
                                   }
                                 ]
                               }
@@ -2984,44 +2766,8 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "REPEAT1",
-                                      "content": {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "SEQ",
-                                            "members": [
-                                              {
-                                                "type": "STRING",
-                                                "value": "\\"
-                                              },
-                                              {
-                                                "type": "PATTERN",
-                                                "value": "."
-                                              }
-                                            ]
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "[^\\/\\\n\\\\]"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
+                                    "type": "PATTERN",
+                                    "value": "\\\\.|[^\\/\\\\\\\n]"
                                   }
                                 ]
                               }
@@ -3045,35 +2791,8 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "TOKEN",
-                                    "content": {
-                                      "type": "REPEAT1",
-                                      "content": {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "CHOICE",
-                                            "members": []
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "[^\\\\\\\n\\\\]"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\\\\\\n]"
                                   }
                                 ]
                               }
@@ -3160,44 +2879,8 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\'\\\n\\\\]"
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": []
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\'\\\\\\\n]"
               }
             ]
           }
@@ -3220,44 +2903,16 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
                 "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\\"\\\n\\\\\\#]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\\\.|[^\\\"\\\\\\\n\\#]"
               }
             ]
           }
@@ -3282,43 +2937,19 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_interpolated_angle"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\>\\\n\\\\\\#\\<]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_angle"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\\\.|[^\\>\\\\\\\n\\#\\<]"
               }
             ]
           }
@@ -3343,43 +2974,19 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_interpolated_bracket"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\]\\\n\\\\\\#\\[]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_bracket"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\\\.|[^\\]\\\\\\\n\\#\\[]"
               }
             ]
           }
@@ -3404,43 +3011,19 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_interpolated_paren"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\)\\\n\\\\\\#\\(]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_paren"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\\\.|[^\\)\\\\\\\n\\#\\(]"
               }
             ]
           }
@@ -3465,43 +3048,19 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_interpolated_brace"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\}\\\n\\\\\\#\\{]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_brace"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\\\.|[^\\}\\\\\\\n\\#\\{]"
               }
             ]
           }
@@ -3529,40 +3088,8 @@
                 "name": "_uninterpolated_angle"
               },
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\>\\\n\\\\\\<]"
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": []
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\>\\\\\\\n\\<]"
               }
             ]
           }
@@ -3590,40 +3117,8 @@
                 "name": "_uninterpolated_bracket"
               },
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\]\\\n\\\\\\[]"
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": []
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\]\\\\\\\n\\[]"
               }
             ]
           }
@@ -3651,40 +3146,8 @@
                 "name": "_uninterpolated_paren"
               },
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\)\\\n\\\\\\(]"
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": []
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\)\\\\\\\n\\(]"
               }
             ]
           }
@@ -3712,40 +3175,8 @@
                 "name": "_uninterpolated_brace"
               },
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\}\\\n\\\\\\{]"
-                      }
-                    ]
-                  }
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": []
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\}\\\\\\\n\\{]"
               }
             ]
           }
@@ -3789,44 +3220,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
-                    "members": []
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": []
-                  },
-                  {
-                    "type": "TOKEN",
-                    "content": {
-                      "type": "REPEAT1",
-                      "content": {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SEQ",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "\\"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "."
-                              }
-                            ]
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\`\\\n\\\\]"
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": []
+                    "type": "PATTERN",
+                    "value": "\\\\.|[^\\`\\\\\\\n]"
                   }
                 ]
               }
@@ -3863,44 +3258,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\#\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "\\\\.|[^\\#\\\\\\\n]"
                               }
                             ]
                           }
@@ -3924,44 +3283,16 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\/\\\n\\\\\\#]"
-                                      }
-                                    ]
-                                  }
-                                }
+                                "type": "PATTERN",
+                                "value": "#[^{}]"
                               },
                               {
                                 "type": "PATTERN",
-                                "value": "#[^{]"
+                                "value": "\\\\.|[^\\/\\\\\\\n\\#]"
                               }
                             ]
                           }
@@ -3985,35 +3316,16 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "CHOICE",
-                                        "members": []
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\\\\\n\\\\\\#]"
-                                      }
-                                    ]
-                                  }
-                                }
+                                "type": "PATTERN",
+                                "value": "#[^{}]"
                               },
                               {
                                 "type": "PATTERN",
-                                "value": "#[^{]"
+                                "value": "[^\\\\\\\\\\\n\\#]"
                               }
                             ]
                           }
@@ -4094,44 +3406,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\#\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "\\\\.|[^\\#\\\\\\\n]"
                               }
                             ]
                           }
@@ -4155,44 +3431,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\/\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "\\\\.|[^\\/\\\\\\\n]"
                               }
                             ]
                           }
@@ -4216,35 +3456,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "CHOICE",
-                                        "members": []
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\\\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "[^\\\\\\\\\\\n]"
                               }
                             ]
                           }
@@ -4303,44 +3516,8 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\#\\\n\\\\]"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": []
+                                "type": "PATTERN",
+                                "value": "\\\\.|[^\\#\\\\\\\n]"
                               }
                             ]
                           }
@@ -4364,44 +3541,16 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\/\\\n\\\\\\#]"
-                                      }
-                                    ]
-                                  }
-                                }
+                                "type": "PATTERN",
+                                "value": "#[^{}]"
                               },
                               {
                                 "type": "PATTERN",
-                                "value": "#[^{]"
+                                "value": "\\\\.|[^\\/\\\\\\\n\\#]"
                               }
                             ]
                           }
@@ -4425,35 +3574,16 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "TOKEN",
-                                "content": {
-                                  "type": "REPEAT1",
-                                  "content": {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "CHOICE",
-                                        "members": []
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\\\\\n\\\\\\#]"
-                                      }
-                                    ]
-                                  }
-                                }
+                                "type": "PATTERN",
+                                "value": "#[^{}]"
                               },
                               {
                                 "type": "PATTERN",
-                                "value": "#[^{]"
+                                "value": "[^\\\\\\\\\\\n\\#]"
                               }
                             ]
                           }
@@ -4640,80 +3770,23 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": []
-                    },
-                    {
                       "type": "SYMBOL",
                       "name": "interpolation"
                     },
                     {
-                      "type": "TOKEN",
-                      "content": {
-                        "type": "REPEAT1",
-                        "content": {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "["
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "[^\\]\\n]*"
-                                },
-                                {
-                                  "type": "STRING",
-                                  "value": "]"
-                                }
-                              ]
-                            },
-                            {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "\\"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "."
-                                }
-                              ]
-                            },
-                            {
-                              "type": "PATTERN",
-                              "value": "[^\\/\\/\\[\\\\\\\n\\#]"
-                            }
-                          ]
-                        }
-                      }
+                      "type": "PATTERN",
+                      "value": "#[^{}]"
                     },
                     {
                       "type": "PATTERN",
-                      "value": "#[^{]"
+                      "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\/\\[\\\\\\\n\\#]"
                     }
                   ]
                 }
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "/"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "[a-z]*"
-                    }
-                  ]
-                }
+                "type": "PATTERN",
+                "value": "\\/[a-z]*"
               }
             ]
           },
@@ -4743,80 +3816,15 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "TOKEN",
-                                  "content": {
-                                    "type": "REPEAT1",
-                                    "content": {
-                                      "type": "CHOICE",
-                                      "members": [
-                                        {
-                                          "type": "SEQ",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "["
-                                            },
-                                            {
-                                              "type": "PATTERN",
-                                              "value": "[^\\]\\n]*"
-                                            },
-                                            {
-                                              "type": "STRING",
-                                              "value": "]"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "SEQ",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "\\"
-                                            },
-                                            {
-                                              "type": "PATTERN",
-                                              "value": "."
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\#\\#\\[\\\\\\\n]"
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
+                                  "type": "PATTERN",
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\#\\#\\[\\\\\\\n]"
                                 }
                               ]
                             }
                           },
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "#"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "[a-z]*"
-                                }
-                              ]
-                            }
+                            "type": "PATTERN",
+                            "value": "\\#[a-z]*"
                           }
                         ]
                       },
@@ -4833,80 +3841,23 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
                                 },
                                 {
-                                  "type": "TOKEN",
-                                  "content": {
-                                    "type": "REPEAT1",
-                                    "content": {
-                                      "type": "CHOICE",
-                                      "members": [
-                                        {
-                                          "type": "SEQ",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "["
-                                            },
-                                            {
-                                              "type": "PATTERN",
-                                              "value": "[^\\]\\n]*"
-                                            },
-                                            {
-                                              "type": "STRING",
-                                              "value": "]"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "SEQ",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "\\"
-                                            },
-                                            {
-                                              "type": "PATTERN",
-                                              "value": "."
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\/\\/\\[\\\\\\\n\\#]"
-                                        }
-                                      ]
-                                    }
-                                  }
+                                  "type": "PATTERN",
+                                  "value": "#[^{}]"
                                 },
                                 {
                                   "type": "PATTERN",
-                                  "value": "#[^{]"
+                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\/\\[\\\\\\\n\\#]"
                                 }
                               ]
                             }
                           },
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "/"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "[a-z]*"
-                                }
-                              ]
-                            }
+                            "type": "PATTERN",
+                            "value": "\\/[a-z]*"
                           }
                         ]
                       },
@@ -4923,71 +3874,23 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
                                 },
                                 {
-                                  "type": "TOKEN",
-                                  "content": {
-                                    "type": "REPEAT1",
-                                    "content": {
-                                      "type": "CHOICE",
-                                      "members": [
-                                        {
-                                          "type": "SEQ",
-                                          "members": [
-                                            {
-                                              "type": "STRING",
-                                              "value": "["
-                                            },
-                                            {
-                                              "type": "PATTERN",
-                                              "value": "[^\\]\\n]*"
-                                            },
-                                            {
-                                              "type": "STRING",
-                                              "value": "]"
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "type": "CHOICE",
-                                          "members": []
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\\\\\\\\\[\\\\\\\n\\#]"
-                                        }
-                                      ]
-                                    }
-                                  }
+                                  "type": "PATTERN",
+                                  "value": "#[^{}]"
                                 },
                                 {
                                   "type": "PATTERN",
-                                  "value": "#[^{]"
+                                  "value": "\\[[^\\]\\n]*\\]|[^\\\\\\\\\\[\\\\\\\n\\#]"
                                 }
                               ]
                             }
                           },
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "STRING",
-                                  "value": "\\"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "[a-z]*"
-                                }
-                              ]
-                            }
+                            "type": "PATTERN",
+                            "value": "\\\\[a-z]*"
                           }
                         ]
                       }
@@ -5030,79 +3933,26 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_regex_interpolated_angle"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "["
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\]\\n]*"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "]"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\<\\>\\[\\\\\\\n\\#]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_angle"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\<\\>\\[\\\\\\\n\\#]"
               }
             ]
           }
         },
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ">"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[a-z]*"
-              }
-            ]
-          }
+          "type": "PATTERN",
+          "value": "\\>[a-z]*"
         }
       ]
     },
@@ -5120,79 +3970,26 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_regex_interpolated_bracket"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "["
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\]\\n]*"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "]"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\[\\]\\[\\\\\\\n\\#]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_bracket"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\[\\]\\[\\\\\\\n\\#]"
               }
             ]
           }
         },
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "]"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[a-z]*"
-              }
-            ]
-          }
+          "type": "PATTERN",
+          "value": "\\][a-z]*"
         }
       ]
     },
@@ -5210,79 +4007,26 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_regex_interpolated_paren"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "["
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\]\\n]*"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "]"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\(\\)\\[\\\\\\\n\\#]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_paren"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\(\\)\\[\\\\\\\n\\#]"
               }
             ]
           }
         },
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": ")"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[a-z]*"
-              }
-            ]
-          }
+          "type": "PATTERN",
+          "value": "\\)[a-z]*"
         }
       ]
     },
@@ -5300,79 +4044,26 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_regex_interpolated_brace"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "REPEAT1",
-                  "content": {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "["
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "[^\\]\\n]*"
-                          },
-                          {
-                            "type": "STRING",
-                            "value": "]"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "."
-                          }
-                        ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\{\\}\\[\\\\\\\n\\#]"
-                      }
-                    ]
-                  }
-                }
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_brace"
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{]"
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\{\\}\\[\\\\\\\n\\#]"
               }
             ]
           }
         },
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "}"
-              },
-              {
-                "type": "PATTERN",
-                "value": "[a-z]*"
-              }
-            ]
-          }
+          "type": "PATTERN",
+          "value": "\\}[a-z]*"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1210,7 +1210,7 @@
         ]
       }
     },
-    "subscript_expression": {
+    "element_reference": {
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
@@ -1225,37 +1225,8 @@
             "value": "["
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_primary"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "_primary"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_argument_list"
           },
           {
             "type": "STRING",
@@ -2125,7 +2096,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "subscript_expression"
+          "name": "element_reference"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2260,7 +2260,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "function"
+          "name": "lambda_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda_expression"
         }
       ]
     },
@@ -4067,7 +4071,7 @@
         }
       ]
     },
-    "function": {
+    "lambda_literal": {
       "type": "SEQ",
       "members": [
         {
@@ -4119,6 +4123,68 @@
         {
           "type": "STRING",
           "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "lambda_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "lambda"
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "|"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "formal_parameters"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "|"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2437,122 +2437,6 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "!"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\!\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "@"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\@\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
                           "value": "#"
                         },
                         {
@@ -2566,739 +2450,46 @@
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\#\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "$"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
                                 "members": []
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\#\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\$\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "%"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
                               {
                                 "type": "CHOICE",
                                 "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\%\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
                               }
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "^"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\^\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "&"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\&\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "*"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\*\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\)\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "]"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\]\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "}"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\}\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ">"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\>\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "|"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\|\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\=\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "value": "#"
                         }
                       ]
                     },
@@ -3320,43 +2511,46 @@
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "members": []
+                              },
+                              {
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\/\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\/\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
-                                "type": "STRING",
-                                "value": "#"
+                                "type": "CHOICE",
+                                "members": []
                               }
                             ]
                           }
                         },
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         }
                       ]
                     },
@@ -3365,7 +2559,7 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "+"
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -3378,681 +2572,37 @@
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\+\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "-"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
                                 "members": []
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "CHOICE",
+                                        "members": []
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\\\\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\-\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "~"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
                               {
                                 "type": "CHOICE",
                                 "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\~\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
                               }
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "`"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\`\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "'"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\'\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\""
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\"\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\,\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "."
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\.\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "?"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\?\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ":"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\:\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\;\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "_"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\_\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "value": "\\"
                         }
                       ]
                     }
@@ -4089,38 +2639,44 @@
       "value": "\\d(_?\\d)*\\.\\d(_?\\d)*([eE]\\d(_?\\d)*)?"
     },
     "boolean": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "true"
-        },
-        {
-          "type": "STRING",
-          "value": "false"
-        },
-        {
-          "type": "STRING",
-          "value": "TRUE"
-        },
-        {
-          "type": "STRING",
-          "value": "FALSE"
-        }
-      ]
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "true"
+          },
+          {
+            "type": "STRING",
+            "value": "false"
+          },
+          {
+            "type": "STRING",
+            "value": "TRUE"
+          },
+          {
+            "type": "STRING",
+            "value": "FALSE"
+          }
+        ]
+      }
     },
     "nil": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "nil"
-        },
-        {
-          "type": "STRING",
-          "value": "NIL"
-        }
-      ]
+      "type": "TOKEN",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "nil"
+          },
+          {
+            "type": "STRING",
+            "value": "NIL"
+          }
+        ]
+      }
     },
     "string": {
       "type": "SEQ",
@@ -4150,122 +2706,6 @@
                           "members": [
                             {
                               "type": "STRING",
-                              "value": "!"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\!\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "!"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "@"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\@\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "@"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
                               "value": "#"
                             },
                             {
@@ -4274,744 +2714,51 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
                                     "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
+                                    "members": []
+                                  },
+                                  {
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "REPEAT1",
+                                      "content": {
+                                        "type": "CHOICE",
                                         "members": [
                                           {
-                                            "type": "STRING",
-                                            "value": "\\"
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "\\"
+                                              },
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "."
+                                              }
+                                            ]
                                           },
                                           {
                                             "type": "PATTERN",
-                                            "value": "."
+                                            "value": "[^\\#\\\n\\\\]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\#\\#\\\\\\\n]"
                                       }
-                                    ]
+                                    }
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
+                                    "type": "CHOICE",
+                                    "members": []
                                   }
                                 ]
                               }
                             },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "#"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
                             {
                               "type": "STRING",
-                              "value": "$"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\$\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "$"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "%"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\%\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "%"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "^"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\^\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "^"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "&"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\&\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "&"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "*"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\*\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "*"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ")"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\)\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ")"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "]"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\]\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "]"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "}"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\}\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "}"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ">"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\>\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ">"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "|"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\|\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "|"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\\\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\\"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "="
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\=\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "="
-                                }
-                              }
+                              "value": "#"
                             }
                           ]
                         },
@@ -5028,30 +2775,40 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
+                                    "type": "CHOICE",
+                                    "members": []
+                                  },
+                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
                                   },
                                   {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "REPEAT1",
+                                      "content": {
+                                        "type": "CHOICE",
                                         "members": [
                                           {
-                                            "type": "STRING",
-                                            "value": "\\"
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "\\"
+                                              },
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "."
+                                              }
+                                            ]
                                           },
                                           {
                                             "type": "PATTERN",
-                                            "value": "."
+                                            "value": "[^\\/\\\n\\\\\\#]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\/\\#\\\\\\\n]"
                                       }
-                                    ]
+                                    }
                                   },
                                   {
                                     "type": "PATTERN",
@@ -5061,15 +2818,8 @@
                               }
                             },
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "/"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "/"
                             }
                           ]
                         },
@@ -5078,7 +2828,7 @@
                           "members": [
                             {
                               "type": "STRING",
-                              "value": "+"
+                              "value": "\\"
                             },
                             {
                               "type": "REPEAT",
@@ -5086,30 +2836,31 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
+                                    "type": "CHOICE",
+                                    "members": []
+                                  },
+                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
                                   },
                                   {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "REPEAT1",
+                                      "content": {
+                                        "type": "CHOICE",
                                         "members": [
                                           {
-                                            "type": "STRING",
-                                            "value": "\\"
+                                            "type": "CHOICE",
+                                            "members": []
                                           },
                                           {
                                             "type": "PATTERN",
-                                            "value": "."
+                                            "value": "[^\\\\\\\n\\\\\\#]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\+\\#\\\\\\\n]"
                                       }
-                                    ]
+                                    }
                                   },
                                   {
                                     "type": "PATTERN",
@@ -5118,654 +2869,9 @@
                                 ]
                               }
                             },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "+"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
                             {
                               "type": "STRING",
-                              "value": "-"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\-\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "-"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "~"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\~\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "~"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "`"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\`\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "`"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "'"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\'\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "'"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\""
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\"\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\""
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\,\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ","
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "."
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\.\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "."
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "?"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\?\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "?"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ":"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\:\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ":"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ";"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\;\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ";"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "_"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\_\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "_"
-                                }
-                              }
+                              "value": "\\"
                             }
                           ]
                         }
@@ -5809,122 +2915,6 @@
                           "members": [
                             {
                               "type": "STRING",
-                              "value": "!"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\!\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "!"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "@"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\@\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "@"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
                               "value": "#"
                             },
                             {
@@ -5938,739 +2928,46 @@
                                   },
                                   {
                                     "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\#\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "#"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "$"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
                                     "members": []
                                   },
                                   {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "REPEAT1",
+                                      "content": {
+                                        "type": "CHOICE",
                                         "members": [
                                           {
-                                            "type": "STRING",
-                                            "value": "\\"
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "\\"
+                                              },
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "."
+                                              }
+                                            ]
                                           },
                                           {
                                             "type": "PATTERN",
-                                            "value": "."
+                                            "value": "[^\\#\\\n\\\\]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\$\\#\\\\\\\n]"
                                       }
-                                    ]
+                                    }
                                   },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "$"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "%"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
                                   {
                                     "type": "CHOICE",
                                     "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\%\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
                                   }
                                 ]
                               }
                             },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "%"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
                             {
                               "type": "STRING",
-                              "value": "^"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\^\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "^"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "&"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\&\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "&"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "*"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\*\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "*"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ")"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\)\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ")"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "]"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\]\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "]"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "}"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\}\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "}"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ">"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\>\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ">"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "|"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\|\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "|"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\\\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\\"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "="
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\=\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "="
-                                }
-                              }
+                              "value": "#"
                             }
                           ]
                         },
@@ -6692,43 +2989,46 @@
                                   },
                                   {
                                     "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
+                                    "members": []
+                                  },
+                                  {
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "REPEAT1",
+                                      "content": {
+                                        "type": "CHOICE",
                                         "members": [
                                           {
-                                            "type": "STRING",
-                                            "value": "\\"
+                                            "type": "SEQ",
+                                            "members": [
+                                              {
+                                                "type": "STRING",
+                                                "value": "\\"
+                                              },
+                                              {
+                                                "type": "PATTERN",
+                                                "value": "."
+                                              }
+                                            ]
                                           },
                                           {
                                             "type": "PATTERN",
-                                            "value": "."
+                                            "value": "[^\\/\\\n\\\\]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\/\\#\\\\\\\n]"
                                       }
-                                    ]
+                                    }
                                   },
                                   {
-                                    "type": "STRING",
-                                    "value": "#"
+                                    "type": "CHOICE",
+                                    "members": []
                                   }
                                 ]
                               }
                             },
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "/"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "/"
                             }
                           ]
                         },
@@ -6737,7 +3037,7 @@
                           "members": [
                             {
                               "type": "STRING",
-                              "value": "+"
+                              "value": "\\"
                             },
                             {
                               "type": "REPEAT",
@@ -6750,681 +3050,37 @@
                                   },
                                   {
                                     "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\+\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "+"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "-"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
                                     "members": []
                                   },
                                   {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
+                                    "type": "TOKEN",
+                                    "content": {
+                                      "type": "REPEAT1",
+                                      "content": {
+                                        "type": "CHOICE",
                                         "members": [
                                           {
-                                            "type": "STRING",
-                                            "value": "\\"
+                                            "type": "CHOICE",
+                                            "members": []
                                           },
                                           {
                                             "type": "PATTERN",
-                                            "value": "."
+                                            "value": "[^\\\\\\\n\\\\]"
                                           }
                                         ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\-\\#\\\\\\\n]"
                                       }
-                                    ]
+                                    }
                                   },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "-"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "~"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
                                   {
                                     "type": "CHOICE",
                                     "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\~\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
                                   }
                                 ]
                               }
                             },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "~"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
                             {
                               "type": "STRING",
-                              "value": "`"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\`\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "`"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "'"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\'\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "'"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\""
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\\"\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\""
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ","
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\,\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ","
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "."
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\.\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "."
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "?"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\?\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "?"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ":"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\:\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ":"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": ";"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\;\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ";"
-                                }
-                              }
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "_"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "CHOICE",
-                                    "members": []
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SEQ",
-                                        "members": [
-                                          {
-                                            "type": "STRING",
-                                            "value": "\\"
-                                          },
-                                          {
-                                            "type": "PATTERN",
-                                            "value": "."
-                                          }
-                                        ]
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "[^\\_\\#\\\\\\\n]"
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "#"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "_"
-                                }
-                              }
+                              "value": "\\"
                             }
                           ]
                         }
@@ -7509,43 +3165,46 @@
               },
               {
                 "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "members": []
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\'\\\n\\\\]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\'\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
-                "type": "STRING",
-                "value": "#"
+                "type": "CHOICE",
+                "members": []
               }
             ]
           }
         },
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "'"
-            }
-          }
+          "type": "STRING",
+          "value": "'"
         }
       ]
     },
@@ -7561,30 +3220,40 @@
             "type": "CHOICE",
             "members": [
               {
+                "type": "CHOICE",
+                "members": []
+              },
+              {
                 "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\\"\\\n\\\\\\#]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\\"\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -7594,15 +3263,8 @@
           }
         },
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "\""
-            }
-          }
+          "type": "STRING",
+          "value": "\""
         }
       ]
     },
@@ -7620,33 +3282,39 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "_interpolated_angle"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\>\\\n\\\\\\#\\<]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\<\\>\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -7675,33 +3343,39 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "_interpolated_bracket"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\]\\\n\\\\\\#\\[]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\[\\]\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -7730,33 +3404,39 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "_interpolated_paren"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\)\\\n\\\\\\#\\(]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\(\\)\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -7785,33 +3465,39 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "SYMBOL",
                 "name": "_interpolated_brace"
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\}\\\n\\\\\\#\\{]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\{\\}\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
                 "type": "PATTERN",
@@ -7839,38 +3525,44 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_angle"
               },
               {
                 "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "members": []
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\>\\\n\\\\\\<]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\<\\>\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
-                "type": "STRING",
-                "value": "#"
+                "type": "CHOICE",
+                "members": []
               }
             ]
           }
@@ -7894,38 +3586,44 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_bracket"
               },
               {
                 "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "members": []
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\]\\\n\\\\\\[]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\[\\]\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
-                "type": "STRING",
-                "value": "#"
+                "type": "CHOICE",
+                "members": []
               }
             ]
           }
@@ -7949,38 +3647,44 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_paren"
               },
               {
                 "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "members": []
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\)\\\n\\\\\\(]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\(\\)\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
-                "type": "STRING",
-                "value": "#"
+                "type": "CHOICE",
+                "members": []
               }
             ]
           }
@@ -8004,38 +3708,44 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": []
-              },
-              {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_brace"
               },
               {
                 "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
+                "members": []
+              },
+              {
+                "type": "TOKEN",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "CHOICE",
                     "members": [
                       {
-                        "type": "STRING",
-                        "value": "\\"
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
                       },
                       {
                         "type": "PATTERN",
-                        "value": "."
+                        "value": "[^\\}\\\n\\\\\\{]"
                       }
                     ]
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[^\\{\\}\\#\\\\\\\n]"
                   }
-                ]
+                }
               },
               {
-                "type": "STRING",
-                "value": "#"
+                "type": "CHOICE",
+                "members": []
               }
             ]
           }
@@ -8084,43 +3794,46 @@
                   },
                   {
                     "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
+                    "members": []
+                  },
+                  {
+                    "type": "TOKEN",
+                    "content": {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "CHOICE",
                         "members": [
                           {
-                            "type": "STRING",
-                            "value": "\\"
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "\\"
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "."
+                              }
+                            ]
                           },
                           {
                             "type": "PATTERN",
-                            "value": "."
+                            "value": "[^\\`\\\n\\\\]"
                           }
                         ]
-                      },
-                      {
-                        "type": "PATTERN",
-                        "value": "[^\\`\\#\\\\\\\n]"
                       }
-                    ]
+                    }
                   },
                   {
-                    "type": "STRING",
-                    "value": "#"
+                    "type": "CHOICE",
+                    "members": []
                   }
                 ]
               }
             },
             {
-              "type": "TOKEN",
-              "content": {
-                "type": "PREC",
-                "value": 100,
-                "content": {
-                  "type": "STRING",
-                  "value": "`"
-                }
-              }
+              "type": "STRING",
+              "value": "`"
             }
           ]
         },
@@ -8142,122 +3855,6 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "!"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\!\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "@"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\@\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
                           "value": "#"
                         },
                         {
@@ -8266,744 +3863,51 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "members": []
+                              },
+                              {
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\#\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\#\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
+                                "type": "CHOICE",
+                                "members": []
                               }
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "$"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\$\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "%"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\%\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "^"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\^\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "&"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\&\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "*"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\*\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\)\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "]"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\]\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "}"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\}\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ">"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\>\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "|"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\|\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\=\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "value": "#"
                         }
                       ]
                     },
@@ -9020,30 +3924,40 @@
                             "type": "CHOICE",
                             "members": [
                               {
+                                "type": "CHOICE",
+                                "members": []
+                              },
+                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\/\\\n\\\\\\#]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\/\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
                                 "type": "PATTERN",
@@ -9053,15 +3967,8 @@
                           }
                         },
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         }
                       ]
                     },
@@ -9070,7 +3977,7 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "+"
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -9078,30 +3985,31 @@
                             "type": "CHOICE",
                             "members": [
                               {
+                                "type": "CHOICE",
+                                "members": []
+                              },
+                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "CHOICE",
+                                        "members": []
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\\\\\\n\\\\\\#]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\+\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
                                 "type": "PATTERN",
@@ -9110,654 +4018,9 @@
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "-"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\-\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "~"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\~\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "`"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\`\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "'"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\'\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\""
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\"\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\,\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "."
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\.\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "?"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\?\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ":"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\:\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\;\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "_"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\_\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "value": "\\"
                         }
                       ]
                     }
@@ -9823,122 +4086,6 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "!"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\!\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "@"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\@\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
                           "value": "#"
                         },
                         {
@@ -9952,739 +4099,46 @@
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\#\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "$"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
                                 "members": []
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\#\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\$\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "%"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
                               {
                                 "type": "CHOICE",
                                 "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\%\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
                               }
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "^"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\^\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "&"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\&\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "*"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\*\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\)\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "]"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\]\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "}"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\}\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ">"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\>\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "|"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\|\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\=\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "value": "#"
                         }
                       ]
                     },
@@ -10706,43 +4160,46 @@
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "members": []
+                              },
+                              {
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\/\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\/\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
-                                "type": "STRING",
-                                "value": "#"
+                                "type": "CHOICE",
+                                "members": []
                               }
                             ]
                           }
                         },
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         }
                       ]
                     },
@@ -10751,7 +4208,7 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "+"
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -10764,681 +4221,37 @@
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\+\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "-"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
                                 "members": []
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "CHOICE",
+                                        "members": []
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\\\\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\-\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "~"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
                               {
                                 "type": "CHOICE",
                                 "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\~\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
                               }
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "`"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\`\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "'"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\'\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\""
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\"\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\,\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "."
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\.\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "?"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\?\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ":"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\:\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\;\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "_"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "CHOICE",
-                                "members": []
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\_\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "value": "\\"
                         }
                       ]
                     }
@@ -11482,122 +4295,6 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "!"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\!\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "@"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\@\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
                           "value": "#"
                         },
                         {
@@ -11606,744 +4303,51 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
                                 "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "members": []
+                              },
+                              {
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\#\\\n\\\\]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\#\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
+                                "type": "CHOICE",
+                                "members": []
                               }
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "$"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\$\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "%"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\%\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "^"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\^\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "&"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\&\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "*"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\*\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\)\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "]"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\]\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "}"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\}\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ">"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\>\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "|"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\|\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\=\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "value": "#"
                         }
                       ]
                     },
@@ -12360,30 +4364,40 @@
                             "type": "CHOICE",
                             "members": [
                               {
+                                "type": "CHOICE",
+                                "members": []
+                              },
+                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\/\\\n\\\\\\#]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\/\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
                                 "type": "PATTERN",
@@ -12393,15 +4407,8 @@
                           }
                         },
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         }
                       ]
                     },
@@ -12410,7 +4417,7 @@
                       "members": [
                         {
                           "type": "STRING",
-                          "value": "+"
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -12418,30 +4425,31 @@
                             "type": "CHOICE",
                             "members": [
                               {
+                                "type": "CHOICE",
+                                "members": []
+                              },
+                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
                               },
                               {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
+                                "type": "TOKEN",
+                                "content": {
+                                  "type": "REPEAT1",
+                                  "content": {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": "\\"
+                                        "type": "CHOICE",
+                                        "members": []
                                       },
                                       {
                                         "type": "PATTERN",
-                                        "value": "."
+                                        "value": "[^\\\\\\\n\\\\\\#]"
                                       }
                                     ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\+\\#\\\\\\\n]"
                                   }
-                                ]
+                                }
                               },
                               {
                                 "type": "PATTERN",
@@ -12450,654 +4458,9 @@
                             ]
                           }
                         },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
                         {
                           "type": "STRING",
-                          "value": "-"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\-\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "~"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\~\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "`"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\`\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "'"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\'\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\""
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\"\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ","
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\,\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "."
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\.\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "?"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\?\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ":"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\:\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\;\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "_"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SEQ",
-                                    "members": [
-                                      {
-                                        "type": "STRING",
-                                        "value": "\\"
-                                      },
-                                      {
-                                        "type": "PATTERN",
-                                        "value": "."
-                                      }
-                                    ]
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\_\\#\\\\\\\n]"
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "value": "\\"
                         }
                       ]
                     }
@@ -13370,182 +4733,6 @@
                         "members": [
                           {
                             "type": "STRING",
-                            "value": "!"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\!\\!\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "!"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "@"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\@\\@\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "@"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
                             "value": "#"
                           },
                           {
@@ -13618,1062 +4805,6 @@
                                   {
                                     "type": "STRING",
                                     "value": "#"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "$"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\$\\$\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "$"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "%"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\%\\%\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "%"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "^"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\^\\^\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "^"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "&"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\&\\&\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "&"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "*"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\*\\*\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "*"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ")"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\)\\)\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ")"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "]"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\]\\]\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "]"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "}"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\}\\}\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "}"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ">"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\>\\>\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ">"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "|"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\|\\|\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "|"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\\\\\\\\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "\\"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "="
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\=\\=\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "="
                                   },
                                   {
                                     "type": "PATTERN",
@@ -14778,7 +4909,7 @@
                         "members": [
                           {
                             "type": "STRING",
-                            "value": "+"
+                            "value": "\\"
                           },
                           {
                             "type": "REPEAT",
@@ -14828,7 +4959,7 @@
                                     },
                                     {
                                       "type": "PATTERN",
-                                      "value": "[^\\+\\+\\#\\\\\\[\\\n]"
+                                      "value": "[^\\\\\\\\\\#\\\\\\[\\\n]"
                                     }
                                   ]
                                 },
@@ -14849,975 +4980,7 @@
                                 "members": [
                                   {
                                     "type": "STRING",
-                                    "value": "+"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "-"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\-\\-\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "-"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "~"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\~\\~\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "~"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "`"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\`\\`\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "`"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "'"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\'\\'\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "'"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\""
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\\"\\\"\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "\""
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\,\\,\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ","
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "."
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\.\\.\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "?"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\?\\?\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "?"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ":"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\:\\:\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ":"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ";"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\;\\;\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ";"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[a-z]*"
-                                  }
-                                ]
-                              }
-                            }
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "_"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": []
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "["
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "[^\\]\\n]*"
-                                        },
-                                        {
-                                          "type": "STRING",
-                                          "value": "]"
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "STRING",
-                                          "value": "\\"
-                                        },
-                                        {
-                                          "type": "PATTERN",
-                                          "value": "."
-                                        }
-                                      ]
-                                    },
-                                    {
-                                      "type": "PATTERN",
-                                      "value": "[^\\_\\_\\#\\\\\\[\\\n]"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "_"
+                                    "value": "\\"
                                   },
                                   {
                                     "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2156,59 +2156,63 @@
     "comment": {
       "type": "TOKEN",
       "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "#"
-              },
-              {
-                "type": "PATTERN",
-                "value": ".*"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "=begin\n"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "PATTERN",
-                      "value": "[^=]"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "=[^e]"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "=e[^n]"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "=en[^d]"
-                    }
-                  ]
+        "type": "PREC",
+        "value": -1,
+        "content": {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "#"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": ".*"
                 }
-              },
-              {
-                "type": "STRING",
-                "value": "=end\n"
-              }
-            ]
-          }
-        ]
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "=begin\n"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[^=]"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "=[^e]"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "=e[^n]"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "=en[^d]"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "=end\n"
+                }
+              ]
+            }
+          ]
+        }
       }
     },
     "_literal": {
@@ -2220,7 +2224,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "fixnum"
+          "name": "integer"
         },
         {
           "type": "SYMBOL",
@@ -2432,15 +2436,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "!"
                         },
                         {
                           "type": "REPEAT",
@@ -2448,12 +2445,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\!]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\!\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2475,15 +2494,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "@"
                         },
                         {
                           "type": "REPEAT",
@@ -2491,12 +2503,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\@]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\@\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2518,15 +2552,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "#"
                         },
                         {
                           "type": "REPEAT",
@@ -2534,12 +2561,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\#]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\#\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2561,15 +2610,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "$"
                         },
                         {
                           "type": "REPEAT",
@@ -2577,12 +2619,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\$]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\$\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2604,15 +2668,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "%"
                         },
                         {
                           "type": "REPEAT",
@@ -2620,12 +2677,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\%]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\%\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2647,15 +2726,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "^"
                         },
                         {
                           "type": "REPEAT",
@@ -2663,12 +2735,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\^]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\^\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2690,15 +2784,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "&"
                         },
                         {
                           "type": "REPEAT",
@@ -2706,12 +2793,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\&]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\&\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2733,15 +2842,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "*"
                         },
                         {
                           "type": "REPEAT",
@@ -2749,12 +2851,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\*]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\*\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2776,15 +2900,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ")"
                         },
                         {
                           "type": "REPEAT",
@@ -2792,12 +2909,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\)]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\)\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2819,15 +2958,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "]"
                         },
                         {
                           "type": "REPEAT",
@@ -2835,12 +2967,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\]]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\]\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2862,15 +3016,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "}"
                         },
                         {
                           "type": "REPEAT",
@@ -2878,12 +3025,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\}]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\}\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2905,15 +3074,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ">"
                         },
                         {
                           "type": "REPEAT",
@@ -2921,12 +3083,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\>]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\>\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2948,15 +3132,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "|"
                         },
                         {
                           "type": "REPEAT",
@@ -2964,12 +3141,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\|]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\|\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -2991,15 +3190,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -3007,12 +3199,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3034,15 +3248,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "="
                         },
                         {
                           "type": "REPEAT",
@@ -3050,12 +3257,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\=]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\=\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3077,15 +3306,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         },
                         {
                           "type": "REPEAT",
@@ -3093,12 +3315,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\/]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\/\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3120,15 +3364,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "+"
                         },
                         {
                           "type": "REPEAT",
@@ -3136,12 +3373,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\+]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\+\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3163,15 +3422,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "-"
                         },
                         {
                           "type": "REPEAT",
@@ -3179,12 +3431,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\-]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\-\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3206,15 +3480,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "~"
                         },
                         {
                           "type": "REPEAT",
@@ -3222,12 +3489,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\~]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\~\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3249,15 +3538,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "`"
                         },
                         {
                           "type": "REPEAT",
@@ -3265,12 +3547,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\`]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\`\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3292,15 +3596,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "'"
                         },
                         {
                           "type": "REPEAT",
@@ -3308,12 +3605,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\']"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\'\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3335,15 +3654,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\""
                         },
                         {
                           "type": "REPEAT",
@@ -3351,12 +3663,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\"]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\"\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3378,15 +3712,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ","
                         },
                         {
                           "type": "REPEAT",
@@ -3394,12 +3721,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\,]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\,\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3421,15 +3770,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "."
                         },
                         {
                           "type": "REPEAT",
@@ -3437,12 +3779,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\.]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\.\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3464,15 +3828,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "?"
                         },
                         {
                           "type": "REPEAT",
@@ -3480,12 +3837,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\?]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\?\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3507,15 +3886,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ":"
                         },
                         {
                           "type": "REPEAT",
@@ -3523,12 +3895,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\:]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\:\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3550,15 +3944,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ";"
                         },
                         {
                           "type": "REPEAT",
@@ -3566,12 +3953,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\;]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\;\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3593,15 +4002,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "_"
                         },
                         {
                           "type": "REPEAT",
@@ -3609,12 +4011,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\_]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\_\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -3656,7 +4080,7 @@
         }
       ]
     },
-    "fixnum": {
+    "integer": {
       "type": "PATTERN",
       "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
     },
@@ -3725,15 +4149,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "!"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "!"
                             },
                             {
                               "type": "REPEAT",
@@ -3741,16 +4158,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\!]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\!\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -3772,15 +4207,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "@"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "@"
                             },
                             {
                               "type": "REPEAT",
@@ -3788,16 +4216,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\@]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\@\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -3819,15 +4265,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "#"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "#"
                             },
                             {
                               "type": "REPEAT",
@@ -3835,16 +4274,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\#]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\#\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -3866,15 +4323,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "$"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "$"
                             },
                             {
                               "type": "REPEAT",
@@ -3882,16 +4332,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\$]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\$\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -3913,15 +4381,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "%"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "%"
                             },
                             {
                               "type": "REPEAT",
@@ -3929,16 +4390,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\%]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\%\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -3960,15 +4439,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "^"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "^"
                             },
                             {
                               "type": "REPEAT",
@@ -3976,16 +4448,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\^]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\^\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4007,15 +4497,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "&"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "&"
                             },
                             {
                               "type": "REPEAT",
@@ -4023,16 +4506,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\&]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\&\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4054,15 +4555,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "*"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "*"
                             },
                             {
                               "type": "REPEAT",
@@ -4070,16 +4564,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\*]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\*\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4101,15 +4613,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ")"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ")"
                             },
                             {
                               "type": "REPEAT",
@@ -4117,16 +4622,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\)]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\)\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4148,15 +4671,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "]"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "]"
                             },
                             {
                               "type": "REPEAT",
@@ -4164,16 +4680,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\]]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\]\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4195,15 +4729,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "}"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "}"
                             },
                             {
                               "type": "REPEAT",
@@ -4211,16 +4738,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\}]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\}\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4242,15 +4787,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ">"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ">"
                             },
                             {
                               "type": "REPEAT",
@@ -4258,16 +4796,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\>]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\>\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4289,15 +4845,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "|"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "|"
                             },
                             {
                               "type": "REPEAT",
@@ -4305,16 +4854,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\|]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\|\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4336,15 +4903,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\\"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "\\"
                             },
                             {
                               "type": "REPEAT",
@@ -4352,16 +4912,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\\\]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\\\\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4383,15 +4961,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "="
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "="
                             },
                             {
                               "type": "REPEAT",
@@ -4399,16 +4970,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\=]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\=\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4430,15 +5019,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "/"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "/"
                             },
                             {
                               "type": "REPEAT",
@@ -4446,16 +5028,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\/]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\/\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4477,15 +5077,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "+"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "+"
                             },
                             {
                               "type": "REPEAT",
@@ -4493,16 +5086,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\+]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\+\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4524,15 +5135,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "-"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "-"
                             },
                             {
                               "type": "REPEAT",
@@ -4540,16 +5144,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\-]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\-\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4571,15 +5193,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "~"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "~"
                             },
                             {
                               "type": "REPEAT",
@@ -4587,16 +5202,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\~]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\~\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4618,15 +5251,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "`"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "`"
                             },
                             {
                               "type": "REPEAT",
@@ -4634,16 +5260,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\`]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\`\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4665,15 +5309,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "'"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "'"
                             },
                             {
                               "type": "REPEAT",
@@ -4681,16 +5318,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\']"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\'\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4712,15 +5367,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\""
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "\""
                             },
                             {
                               "type": "REPEAT",
@@ -4728,16 +5376,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\\"]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\\"\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4759,15 +5425,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ","
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ","
                             },
                             {
                               "type": "REPEAT",
@@ -4775,16 +5434,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\,]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\,\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4806,15 +5483,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "."
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "."
                             },
                             {
                               "type": "REPEAT",
@@ -4822,16 +5492,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\.]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\.\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4853,15 +5541,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "?"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "?"
                             },
                             {
                               "type": "REPEAT",
@@ -4869,16 +5550,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\?]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\?\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4900,15 +5599,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ":"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ":"
                             },
                             {
                               "type": "REPEAT",
@@ -4916,16 +5608,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\:]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\:\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4947,15 +5657,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ";"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ";"
                             },
                             {
                               "type": "REPEAT",
@@ -4963,16 +5666,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\;]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\;\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -4994,15 +5715,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "_"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "_"
                             },
                             {
                               "type": "REPEAT",
@@ -5010,16 +5724,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\_]"
-                                  },
-                                  {
                                     "type": "SYMBOL",
                                     "name": "interpolation"
+                                  },
+                                  {
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\_\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "#[^{]"
                                   }
                                 ]
                               }
@@ -5076,15 +5808,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "!"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "!"
                             },
                             {
                               "type": "REPEAT",
@@ -5092,12 +5817,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\!]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\!\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5119,15 +5866,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "@"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "@"
                             },
                             {
                               "type": "REPEAT",
@@ -5135,12 +5875,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\@]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\@\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5162,15 +5924,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "#"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "#"
                             },
                             {
                               "type": "REPEAT",
@@ -5178,12 +5933,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\#]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\#\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5205,15 +5982,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "$"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "$"
                             },
                             {
                               "type": "REPEAT",
@@ -5221,12 +5991,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\$]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\$\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5248,15 +6040,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "%"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "%"
                             },
                             {
                               "type": "REPEAT",
@@ -5264,12 +6049,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\%]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\%\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5291,15 +6098,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "^"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "^"
                             },
                             {
                               "type": "REPEAT",
@@ -5307,12 +6107,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\^]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\^\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5334,15 +6156,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "&"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "&"
                             },
                             {
                               "type": "REPEAT",
@@ -5350,12 +6165,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\&]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\&\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5377,15 +6214,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "*"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "*"
                             },
                             {
                               "type": "REPEAT",
@@ -5393,12 +6223,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\*]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\*\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5420,15 +6272,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ")"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ")"
                             },
                             {
                               "type": "REPEAT",
@@ -5436,12 +6281,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\)]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\)\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5463,15 +6330,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "]"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "]"
                             },
                             {
                               "type": "REPEAT",
@@ -5479,12 +6339,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\]]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\]\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5506,15 +6388,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "}"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "}"
                             },
                             {
                               "type": "REPEAT",
@@ -5522,12 +6397,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\}]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\}\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5549,15 +6446,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ">"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ">"
                             },
                             {
                               "type": "REPEAT",
@@ -5565,12 +6455,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\>]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\>\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5592,15 +6504,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "|"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "|"
                             },
                             {
                               "type": "REPEAT",
@@ -5608,12 +6513,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\|]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\|\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5635,15 +6562,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\\"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "\\"
                             },
                             {
                               "type": "REPEAT",
@@ -5651,12 +6571,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\\\]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\\\\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5678,15 +6620,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "="
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "="
                             },
                             {
                               "type": "REPEAT",
@@ -5694,12 +6629,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\=]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\=\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5721,15 +6678,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "/"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "/"
                             },
                             {
                               "type": "REPEAT",
@@ -5737,12 +6687,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\/]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\/\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5764,15 +6736,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "+"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "+"
                             },
                             {
                               "type": "REPEAT",
@@ -5780,12 +6745,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\+]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\+\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5807,15 +6794,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "-"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "-"
                             },
                             {
                               "type": "REPEAT",
@@ -5823,12 +6803,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\-]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\-\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5850,15 +6852,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "~"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "~"
                             },
                             {
                               "type": "REPEAT",
@@ -5866,12 +6861,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\~]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\~\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5893,15 +6910,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "`"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "`"
                             },
                             {
                               "type": "REPEAT",
@@ -5909,12 +6919,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\`]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\`\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5936,15 +6968,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "'"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "'"
                             },
                             {
                               "type": "REPEAT",
@@ -5952,12 +6977,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\']"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\'\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -5979,15 +7026,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "\""
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "\""
                             },
                             {
                               "type": "REPEAT",
@@ -5995,12 +7035,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\\"]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\\"\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6022,15 +7084,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ","
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ","
                             },
                             {
                               "type": "REPEAT",
@@ -6038,12 +7093,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\,]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\,\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6065,15 +7142,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "."
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "."
                             },
                             {
                               "type": "REPEAT",
@@ -6081,12 +7151,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\.]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\.\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6108,15 +7200,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "?"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "?"
                             },
                             {
                               "type": "REPEAT",
@@ -6124,12 +7209,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\?]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\?\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6151,15 +7258,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ":"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ":"
                             },
                             {
                               "type": "REPEAT",
@@ -6167,12 +7267,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\:]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\:\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6194,15 +7316,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": ";"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": ";"
                             },
                             {
                               "type": "REPEAT",
@@ -6210,12 +7325,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\;]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\;\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6237,15 +7374,8 @@
                           "type": "SEQ",
                           "members": [
                             {
-                              "type": "TOKEN",
-                              "content": {
-                                "type": "PREC",
-                                "value": 100,
-                                "content": {
-                                  "type": "STRING",
-                                  "value": "_"
-                                }
-                              }
+                              "type": "STRING",
+                              "value": "_"
                             },
                             {
                               "type": "REPEAT",
@@ -6253,12 +7383,34 @@
                                 "type": "CHOICE",
                                 "members": [
                                   {
-                                    "type": "PATTERN",
-                                    "value": "\\\\."
+                                    "type": "CHOICE",
+                                    "members": []
                                   },
                                   {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\_]"
+                                    "type": "CHOICE",
+                                    "members": [
+                                      {
+                                        "type": "SEQ",
+                                        "members": [
+                                          {
+                                            "type": "STRING",
+                                            "value": "\\"
+                                          },
+                                          {
+                                            "type": "PATTERN",
+                                            "value": "."
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "[^\\_\\#\\\\\\\n]"
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
                                   }
                                 ]
                               }
@@ -6352,12 +7504,34 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "CHOICE",
+                "members": []
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\']"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\'\\#\\\\\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "#"
               }
             ]
           }
@@ -6387,16 +7561,34 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
-              },
-              {
-                "type": "PATTERN",
-                "value": "[^\\\\\\\"]"
-              },
-              {
                 "type": "SYMBOL",
                 "name": "interpolation"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\\"\\#\\\\\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -6427,20 +7619,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "SYMBOL",
+                "name": "interpolation"
               },
               {
                 "type": "SYMBOL",
                 "name": "_interpolated_angle"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\<\\>]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\<\\>\\#\\\\\\\n]"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "interpolation"
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -6464,20 +7674,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "SYMBOL",
+                "name": "interpolation"
               },
               {
                 "type": "SYMBOL",
                 "name": "_interpolated_bracket"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\[\\]]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\[\\]\\#\\\\\\\n]"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "interpolation"
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -6501,20 +7729,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "SYMBOL",
+                "name": "interpolation"
               },
               {
                 "type": "SYMBOL",
                 "name": "_interpolated_paren"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\(\\)]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\(\\)\\#\\\\\\\n]"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "interpolation"
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -6538,20 +7784,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "SYMBOL",
+                "name": "interpolation"
               },
               {
                 "type": "SYMBOL",
                 "name": "_interpolated_brace"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\{\\}]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\{\\}\\#\\\\\\\n]"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "interpolation"
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -6575,16 +7839,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "CHOICE",
+                "members": []
               },
               {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_angle"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\<\\>]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\<\\>\\#\\\\\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "#"
               }
             ]
           }
@@ -6608,16 +7894,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "CHOICE",
+                "members": []
               },
               {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_bracket"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\[\\]]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\[\\]\\#\\\\\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "#"
               }
             ]
           }
@@ -6641,16 +7949,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "CHOICE",
+                "members": []
               },
               {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_paren"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\(\\)]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\(\\)\\#\\\\\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "#"
               }
             ]
           }
@@ -6674,16 +8004,38 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\\\."
+                "type": "CHOICE",
+                "members": []
               },
               {
                 "type": "SYMBOL",
                 "name": "_uninterpolated_brace"
               },
               {
-                "type": "PATTERN",
-                "value": "[^\\\\\\{\\}]"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\{\\}\\#\\\\\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "#"
               }
             ]
           }
@@ -6698,15 +8050,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "#{"
-            }
-          }
+          "type": "STRING",
+          "value": "#{"
         },
         {
           "type": "SYMBOL",
@@ -6725,15 +8070,8 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "TOKEN",
-              "content": {
-                "type": "PREC",
-                "value": 100,
-                "content": {
-                  "type": "STRING",
-                  "value": "`"
-                }
-              }
+              "type": "STRING",
+              "value": "`"
             },
             {
               "type": "REPEAT",
@@ -6741,12 +8079,34 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "\\\\."
+                    "type": "CHOICE",
+                    "members": []
                   },
                   {
-                    "type": "PATTERN",
-                    "value": "[^\\\\\\`]"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "\\"
+                          },
+                          {
+                            "type": "PATTERN",
+                            "value": "."
+                          }
+                        ]
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\`\\#\\\\\\\n]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "#"
                   }
                 ]
               }
@@ -6781,15 +8141,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "!"
                         },
                         {
                           "type": "REPEAT",
@@ -6797,16 +8150,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\!]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\!\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -6828,15 +8199,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "@"
                         },
                         {
                           "type": "REPEAT",
@@ -6844,16 +8208,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\@]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\@\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -6875,15 +8257,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "#"
                         },
                         {
                           "type": "REPEAT",
@@ -6891,16 +8266,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\#]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\#\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -6922,15 +8315,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "$"
                         },
                         {
                           "type": "REPEAT",
@@ -6938,16 +8324,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\$]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\$\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -6969,15 +8373,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "%"
                         },
                         {
                           "type": "REPEAT",
@@ -6985,16 +8382,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\%]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\%\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7016,15 +8431,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "^"
                         },
                         {
                           "type": "REPEAT",
@@ -7032,16 +8440,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\^]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\^\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7063,15 +8489,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "&"
                         },
                         {
                           "type": "REPEAT",
@@ -7079,16 +8498,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\&]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\&\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7110,15 +8547,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "*"
                         },
                         {
                           "type": "REPEAT",
@@ -7126,16 +8556,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\*]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\*\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7157,15 +8605,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ")"
                         },
                         {
                           "type": "REPEAT",
@@ -7173,16 +8614,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\)]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\)\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7204,15 +8663,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "]"
                         },
                         {
                           "type": "REPEAT",
@@ -7220,16 +8672,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\]]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\]\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7251,15 +8721,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "}"
                         },
                         {
                           "type": "REPEAT",
@@ -7267,16 +8730,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\}]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\}\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7298,15 +8779,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ">"
                         },
                         {
                           "type": "REPEAT",
@@ -7314,16 +8788,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\>]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\>\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7345,15 +8837,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "|"
                         },
                         {
                           "type": "REPEAT",
@@ -7361,16 +8846,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\|]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\|\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7392,15 +8895,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -7408,16 +8904,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7439,15 +8953,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "="
                         },
                         {
                           "type": "REPEAT",
@@ -7455,16 +8962,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\=]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\=\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7486,15 +9011,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         },
                         {
                           "type": "REPEAT",
@@ -7502,16 +9020,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\/]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\/\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7533,15 +9069,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "+"
                         },
                         {
                           "type": "REPEAT",
@@ -7549,16 +9078,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\+]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\+\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7580,15 +9127,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "-"
                         },
                         {
                           "type": "REPEAT",
@@ -7596,16 +9136,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\-]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\-\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7627,15 +9185,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "~"
                         },
                         {
                           "type": "REPEAT",
@@ -7643,16 +9194,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\~]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\~\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7674,15 +9243,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "`"
                         },
                         {
                           "type": "REPEAT",
@@ -7690,16 +9252,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\`]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\`\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7721,15 +9301,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "'"
                         },
                         {
                           "type": "REPEAT",
@@ -7737,16 +9310,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\']"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\'\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7768,15 +9359,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\""
                         },
                         {
                           "type": "REPEAT",
@@ -7784,16 +9368,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\"]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\"\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7815,15 +9417,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ","
                         },
                         {
                           "type": "REPEAT",
@@ -7831,16 +9426,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\,]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\,\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7862,15 +9475,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "."
                         },
                         {
                           "type": "REPEAT",
@@ -7878,16 +9484,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\.]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\.\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7909,15 +9533,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "?"
                         },
                         {
                           "type": "REPEAT",
@@ -7925,16 +9542,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\?]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\?\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -7956,15 +9591,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ":"
                         },
                         {
                           "type": "REPEAT",
@@ -7972,16 +9600,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\:]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\:\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -8003,15 +9649,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ";"
                         },
                         {
                           "type": "REPEAT",
@@ -8019,16 +9658,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\;]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\;\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -8050,15 +9707,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "_"
                         },
                         {
                           "type": "REPEAT",
@@ -8066,16 +9716,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\_]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\_\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -8154,15 +9822,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "!"
                         },
                         {
                           "type": "REPEAT",
@@ -8170,12 +9831,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\!]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\!\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8197,15 +9880,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "@"
                         },
                         {
                           "type": "REPEAT",
@@ -8213,12 +9889,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\@]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\@\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8240,15 +9938,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "#"
                         },
                         {
                           "type": "REPEAT",
@@ -8256,12 +9947,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\#]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\#\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8283,15 +9996,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "$"
                         },
                         {
                           "type": "REPEAT",
@@ -8299,12 +10005,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\$]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\$\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8326,15 +10054,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "%"
                         },
                         {
                           "type": "REPEAT",
@@ -8342,12 +10063,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\%]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\%\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8369,15 +10112,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "^"
                         },
                         {
                           "type": "REPEAT",
@@ -8385,12 +10121,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\^]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\^\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8412,15 +10170,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "&"
                         },
                         {
                           "type": "REPEAT",
@@ -8428,12 +10179,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\&]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\&\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8455,15 +10228,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "*"
                         },
                         {
                           "type": "REPEAT",
@@ -8471,12 +10237,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\*]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\*\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8498,15 +10286,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ")"
                         },
                         {
                           "type": "REPEAT",
@@ -8514,12 +10295,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\)]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\)\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8541,15 +10344,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "]"
                         },
                         {
                           "type": "REPEAT",
@@ -8557,12 +10353,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\]]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\]\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8584,15 +10402,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "}"
                         },
                         {
                           "type": "REPEAT",
@@ -8600,12 +10411,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\}]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\}\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8627,15 +10460,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ">"
                         },
                         {
                           "type": "REPEAT",
@@ -8643,12 +10469,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\>]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\>\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8670,15 +10518,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "|"
                         },
                         {
                           "type": "REPEAT",
@@ -8686,12 +10527,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\|]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\|\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8713,15 +10576,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -8729,12 +10585,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8756,15 +10634,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "="
                         },
                         {
                           "type": "REPEAT",
@@ -8772,12 +10643,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\=]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\=\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8799,15 +10692,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         },
                         {
                           "type": "REPEAT",
@@ -8815,12 +10701,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\/]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\/\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8842,15 +10750,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "+"
                         },
                         {
                           "type": "REPEAT",
@@ -8858,12 +10759,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\+]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\+\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8885,15 +10808,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "-"
                         },
                         {
                           "type": "REPEAT",
@@ -8901,12 +10817,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\-]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\-\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8928,15 +10866,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "~"
                         },
                         {
                           "type": "REPEAT",
@@ -8944,12 +10875,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\~]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\~\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -8971,15 +10924,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "`"
                         },
                         {
                           "type": "REPEAT",
@@ -8987,12 +10933,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\`]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\`\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9014,15 +10982,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "'"
                         },
                         {
                           "type": "REPEAT",
@@ -9030,12 +10991,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\']"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\'\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9057,15 +11040,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\""
                         },
                         {
                           "type": "REPEAT",
@@ -9073,12 +11049,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\"]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\"\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9100,15 +11098,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ","
                         },
                         {
                           "type": "REPEAT",
@@ -9116,12 +11107,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\,]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\,\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9143,15 +11156,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "."
                         },
                         {
                           "type": "REPEAT",
@@ -9159,12 +11165,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\.]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\.\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9186,15 +11214,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "?"
                         },
                         {
                           "type": "REPEAT",
@@ -9202,12 +11223,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\?]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\?\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9229,15 +11272,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ":"
                         },
                         {
                           "type": "REPEAT",
@@ -9245,12 +11281,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\:]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\:\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9272,15 +11330,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ";"
                         },
                         {
                           "type": "REPEAT",
@@ -9288,12 +11339,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\;]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\;\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9315,15 +11388,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "_"
                         },
                         {
                           "type": "REPEAT",
@@ -9331,12 +11397,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
+                                "type": "CHOICE",
+                                "members": []
                               },
                               {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\_]"
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\_\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "#"
                               }
                             ]
                           }
@@ -9393,15 +11481,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "!"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "!"
                         },
                         {
                           "type": "REPEAT",
@@ -9409,16 +11490,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\!]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\!\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9440,15 +11539,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "@"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "@"
                         },
                         {
                           "type": "REPEAT",
@@ -9456,16 +11548,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\@]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\@\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9487,15 +11597,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "#"
                         },
                         {
                           "type": "REPEAT",
@@ -9503,16 +11606,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\#]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\#\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9534,15 +11655,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "$"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "$"
                         },
                         {
                           "type": "REPEAT",
@@ -9550,16 +11664,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\$]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\$\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9581,15 +11713,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "%"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "%"
                         },
                         {
                           "type": "REPEAT",
@@ -9597,16 +11722,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\%]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\%\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9628,15 +11771,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "^"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "^"
                         },
                         {
                           "type": "REPEAT",
@@ -9644,16 +11780,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\^]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\^\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9675,15 +11829,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "&"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "&"
                         },
                         {
                           "type": "REPEAT",
@@ -9691,16 +11838,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\&]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\&\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9722,15 +11887,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "*"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "*"
                         },
                         {
                           "type": "REPEAT",
@@ -9738,16 +11896,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\*]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\*\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9769,15 +11945,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ")"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ")"
                         },
                         {
                           "type": "REPEAT",
@@ -9785,16 +11954,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\)]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\)\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9816,15 +12003,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "]"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "]"
                         },
                         {
                           "type": "REPEAT",
@@ -9832,16 +12012,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\]]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\]\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9863,15 +12061,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "}"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "}"
                         },
                         {
                           "type": "REPEAT",
@@ -9879,16 +12070,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\}]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\}\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9910,15 +12119,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ">"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ">"
                         },
                         {
                           "type": "REPEAT",
@@ -9926,16 +12128,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\>]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\>\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -9957,15 +12177,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "|"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "|"
                         },
                         {
                           "type": "REPEAT",
@@ -9973,16 +12186,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\|]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\|\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10004,15 +12235,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\\"
                         },
                         {
                           "type": "REPEAT",
@@ -10020,16 +12244,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\\\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10051,15 +12293,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "="
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "="
                         },
                         {
                           "type": "REPEAT",
@@ -10067,16 +12302,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\=]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\=\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10098,15 +12351,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "/"
                         },
                         {
                           "type": "REPEAT",
@@ -10114,16 +12360,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\/]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\/\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10145,15 +12409,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "+"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "+"
                         },
                         {
                           "type": "REPEAT",
@@ -10161,16 +12418,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\+]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\+\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10192,15 +12467,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "-"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "-"
                         },
                         {
                           "type": "REPEAT",
@@ -10208,16 +12476,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\-]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\-\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10239,15 +12525,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "~"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "~"
                         },
                         {
                           "type": "REPEAT",
@@ -10255,16 +12534,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\~]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\~\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10286,15 +12583,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "`"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "`"
                         },
                         {
                           "type": "REPEAT",
@@ -10302,16 +12592,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\`]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\`\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10333,15 +12641,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "'"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "'"
                         },
                         {
                           "type": "REPEAT",
@@ -10349,16 +12650,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\']"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\'\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10380,15 +12699,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "\""
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "\""
                         },
                         {
                           "type": "REPEAT",
@@ -10396,16 +12708,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\"]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\\"\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10427,15 +12757,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ","
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ","
                         },
                         {
                           "type": "REPEAT",
@@ -10443,16 +12766,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\,]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\,\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10474,15 +12815,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "."
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "."
                         },
                         {
                           "type": "REPEAT",
@@ -10490,16 +12824,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\.]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\.\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10521,15 +12873,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "?"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "?"
                         },
                         {
                           "type": "REPEAT",
@@ -10537,16 +12882,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\?]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\?\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10568,15 +12931,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ":"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ":"
                         },
                         {
                           "type": "REPEAT",
@@ -10584,16 +12940,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\:]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\:\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10615,15 +12989,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": ";"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": ";"
                         },
                         {
                           "type": "REPEAT",
@@ -10631,16 +12998,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\;]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\;\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10662,15 +13047,8 @@
                       "type": "SEQ",
                       "members": [
                         {
-                          "type": "TOKEN",
-                          "content": {
-                            "type": "PREC",
-                            "value": 100,
-                            "content": {
-                              "type": "STRING",
-                              "value": "_"
-                            }
-                          }
+                          "type": "STRING",
+                          "value": "_"
                         },
                         {
                           "type": "REPEAT",
@@ -10678,16 +13056,34 @@
                             "type": "CHOICE",
                             "members": [
                               {
-                                "type": "PATTERN",
-                                "value": "\\\\."
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\_]"
-                              },
-                              {
                                 "type": "SYMBOL",
                                 "name": "interpolation"
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "STRING",
+                                        "value": "\\"
+                                      },
+                                      {
+                                        "type": "PATTERN",
+                                        "value": "."
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[^\\_\\#\\\\\\\n]"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "PATTERN",
+                                "value": "#[^{]"
                               }
                             ]
                           }
@@ -10872,15 +13268,8 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": 100,
-                  "content": {
-                    "type": "STRING",
-                    "value": "/"
-                  }
-                }
+                "type": "STRING",
+                "value": "/"
               },
               {
                 "type": "REPEAT",
@@ -10888,12 +13277,55 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "PATTERN",
-                      "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\\\\\[\\n]"
+                      "type": "CHOICE",
+                      "members": []
                     },
                     {
                       "type": "SYMBOL",
                       "name": "interpolation"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "["
+                            },
+                            {
+                              "type": "PATTERN",
+                              "value": "[^\\]\\n]*"
+                            },
+                            {
+                              "type": "STRING",
+                              "value": "]"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": "\\"
+                            },
+                            {
+                              "type": "PATTERN",
+                              "value": "."
+                            }
+                          ]
+                        },
+                        {
+                          "type": "PATTERN",
+                          "value": "[^\\/\\/\\#\\\\\\[\\\n]"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "#[^{]"
                     }
                   ]
                 }
@@ -10904,8 +13336,17 @@
                   "type": "PREC",
                   "value": 100,
                   "content": {
-                    "type": "PATTERN",
-                    "value": "\\/[a-z]*"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "/"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[a-z]*"
+                      }
+                    ]
                   }
                 }
               }
@@ -10928,15 +13369,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "!"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "!"
                           },
                           {
                             "type": "REPEAT",
@@ -10944,12 +13378,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\!\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\!\\!\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -10960,8 +13437,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\![a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "!"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -10971,15 +13457,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "@"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "@"
                           },
                           {
                             "type": "REPEAT",
@@ -10987,12 +13466,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\@\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\@\\@\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11003,8 +13525,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\@[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "@"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11014,15 +13545,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "#"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "#"
                           },
                           {
                             "type": "REPEAT",
@@ -11030,12 +13554,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\#\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\#\\#\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11046,8 +13613,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\#[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "#"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11057,15 +13633,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "$"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "$"
                           },
                           {
                             "type": "REPEAT",
@@ -11073,12 +13642,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\$\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\$\\$\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11089,8 +13701,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\$[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "$"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11100,15 +13721,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "%"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "%"
                           },
                           {
                             "type": "REPEAT",
@@ -11116,12 +13730,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\%\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\%\\%\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11132,8 +13789,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\%[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "%"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11143,15 +13809,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "^"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "^"
                           },
                           {
                             "type": "REPEAT",
@@ -11159,12 +13818,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\^\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\^\\^\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11175,8 +13877,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\^[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "^"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11186,15 +13897,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "&"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "&"
                           },
                           {
                             "type": "REPEAT",
@@ -11202,12 +13906,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\&\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\&\\&\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11218,8 +13965,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\&[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "&"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11229,15 +13985,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "*"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "*"
                           },
                           {
                             "type": "REPEAT",
@@ -11245,12 +13994,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\*\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\*\\*\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11261,8 +14053,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\*[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "*"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11272,15 +14073,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": ")"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": ")"
                           },
                           {
                             "type": "REPEAT",
@@ -11288,12 +14082,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\)\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\)\\)\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11304,8 +14141,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\)[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ")"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11315,15 +14161,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "]"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "]"
                           },
                           {
                             "type": "REPEAT",
@@ -11331,12 +14170,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\]\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\]\\]\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11347,8 +14229,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\][a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "]"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11358,15 +14249,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "}"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "}"
                           },
                           {
                             "type": "REPEAT",
@@ -11374,12 +14258,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\}\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\}\\}\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11390,8 +14317,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\}[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "}"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11401,15 +14337,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": ">"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": ">"
                           },
                           {
                             "type": "REPEAT",
@@ -11417,12 +14346,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\>\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\>\\>\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11433,8 +14405,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\>[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ">"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11444,15 +14425,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "|"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "|"
                           },
                           {
                             "type": "REPEAT",
@@ -11460,12 +14434,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\|\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\|\\|\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11476,8 +14493,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\|[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "|"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11487,15 +14513,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "\\"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "\\"
                           },
                           {
                             "type": "REPEAT",
@@ -11503,12 +14522,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\\\\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\\\\\\\\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11519,8 +14581,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\\\[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "\\"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11530,15 +14601,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "="
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "="
                           },
                           {
                             "type": "REPEAT",
@@ -11546,12 +14610,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\=\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\=\\=\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11562,8 +14669,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\=[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "="
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11573,15 +14689,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "/"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "/"
                           },
                           {
                             "type": "REPEAT",
@@ -11589,12 +14698,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\/\\/\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11605,8 +14757,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\/[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "/"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11616,15 +14777,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "+"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "+"
                           },
                           {
                             "type": "REPEAT",
@@ -11632,12 +14786,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\+\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\+\\+\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11648,8 +14845,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\+[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "+"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11659,15 +14865,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "-"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "-"
                           },
                           {
                             "type": "REPEAT",
@@ -11675,12 +14874,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\-\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\-\\-\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11691,8 +14933,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\-[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "-"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11702,15 +14953,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "~"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "~"
                           },
                           {
                             "type": "REPEAT",
@@ -11718,12 +14962,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\~\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\~\\~\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11734,8 +15021,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\~[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "~"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11745,15 +15041,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "`"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "`"
                           },
                           {
                             "type": "REPEAT",
@@ -11761,12 +15050,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\`\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\`\\`\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11777,8 +15109,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\`[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "`"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11788,15 +15129,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "'"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "'"
                           },
                           {
                             "type": "REPEAT",
@@ -11804,12 +15138,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\'\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\'\\'\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11820,8 +15197,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\'[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "'"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11831,15 +15217,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "\""
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "\""
                           },
                           {
                             "type": "REPEAT",
@@ -11847,12 +15226,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\\"\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\\"\\\"\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11863,8 +15285,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\\"[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "\""
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11874,15 +15305,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": ","
-                              }
-                            }
+                            "type": "STRING",
+                            "value": ","
                           },
                           {
                             "type": "REPEAT",
@@ -11890,12 +15314,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\,\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\,\\,\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11906,8 +15373,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\,[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ","
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11917,15 +15393,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "."
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "."
                           },
                           {
                             "type": "REPEAT",
@@ -11933,12 +15402,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\.\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\.\\.\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11949,8 +15461,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\.[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "."
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -11960,15 +15481,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "?"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "?"
                           },
                           {
                             "type": "REPEAT",
@@ -11976,12 +15490,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\?\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\?\\?\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -11992,8 +15549,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\?[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "?"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -12003,15 +15569,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": ":"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": ":"
                           },
                           {
                             "type": "REPEAT",
@@ -12019,12 +15578,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\:\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\:\\:\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -12035,8 +15637,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\:[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ":"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -12046,15 +15657,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": ";"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": ";"
                           },
                           {
                             "type": "REPEAT",
@@ -12062,12 +15666,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\;\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\;\\;\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -12078,8 +15725,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\;[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ";"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -12089,15 +15745,8 @@
                         "type": "SEQ",
                         "members": [
                           {
-                            "type": "TOKEN",
-                            "content": {
-                              "type": "PREC",
-                              "value": 100,
-                              "content": {
-                                "type": "STRING",
-                                "value": "_"
-                              }
-                            }
+                            "type": "STRING",
+                            "value": "_"
                           },
                           {
                             "type": "REPEAT",
@@ -12105,12 +15754,55 @@
                               "type": "CHOICE",
                               "members": [
                                 {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\_\\\\\\[\\n]"
+                                  "type": "CHOICE",
+                                  "members": []
                                 },
                                 {
                                   "type": "SYMBOL",
                                   "name": "interpolation"
+                                },
+                                {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "["
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "[^\\]\\n]*"
+                                        },
+                                        {
+                                          "type": "STRING",
+                                          "value": "]"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": "\\"
+                                        },
+                                        {
+                                          "type": "PATTERN",
+                                          "value": "."
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "PATTERN",
+                                      "value": "[^\\_\\_\\#\\\\\\[\\\n]"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "PATTERN",
+                                  "value": "#[^{]"
                                 }
                               ]
                             }
@@ -12121,8 +15813,17 @@
                               "type": "PREC",
                               "value": 100,
                               "content": {
-                                "type": "PATTERN",
-                                "value": "\\_[a-z]*"
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": "_"
+                                  },
+                                  {
+                                    "type": "PATTERN",
+                                    "value": "[a-z]*"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -12157,15 +15858,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "<"
-            }
-          }
+          "type": "STRING",
+          "value": "<"
         },
         {
           "type": "REPEAT",
@@ -12173,16 +15867,55 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\>\\\\\\[\\n]"
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_angle"
               },
               {
                 "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_angle"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\]\\n]*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\<\\>\\#\\\\\\[\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -12193,8 +15926,17 @@
             "type": "PREC",
             "value": 100,
             "content": {
-              "type": "PATTERN",
-              "value": "\\>[a-z]*"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ">"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[a-z]*"
+                }
+              ]
             }
           }
         }
@@ -12204,15 +15946,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "["
-            }
-          }
+          "type": "STRING",
+          "value": "["
         },
         {
           "type": "REPEAT",
@@ -12220,16 +15955,55 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\]\\\\\\[\\n]"
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_bracket"
               },
               {
                 "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_bracket"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\]\\n]*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\[\\]\\#\\\\\\[\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -12240,8 +16014,17 @@
             "type": "PREC",
             "value": 100,
             "content": {
-              "type": "PATTERN",
-              "value": "\\][a-z]*"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "]"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[a-z]*"
+                }
+              ]
             }
           }
         }
@@ -12251,15 +16034,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "("
-            }
-          }
+          "type": "STRING",
+          "value": "("
         },
         {
           "type": "REPEAT",
@@ -12267,16 +16043,55 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\)\\\\\\[\\n]"
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_paren"
               },
               {
                 "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_paren"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\]\\n]*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\(\\)\\#\\\\\\[\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -12287,8 +16102,17 @@
             "type": "PREC",
             "value": 100,
             "content": {
-              "type": "PATTERN",
-              "value": "\\)[a-z]*"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ")"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[a-z]*"
+                }
+              ]
             }
           }
         }
@@ -12298,15 +16122,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "TOKEN",
-          "content": {
-            "type": "PREC",
-            "value": 100,
-            "content": {
-              "type": "STRING",
-              "value": "{"
-            }
-          }
+          "type": "STRING",
+          "value": "{"
         },
         {
           "type": "REPEAT",
@@ -12314,16 +16131,55 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\}\\\\\\[\\n]"
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_brace"
               },
               {
                 "type": "SYMBOL",
                 "name": "interpolation"
               },
               {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_brace"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "["
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "[^\\]\\n]*"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "]"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": "\\"
+                      },
+                      {
+                        "type": "PATTERN",
+                        "value": "."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "[^\\{\\}\\#\\\\\\[\\\n]"
+                  }
+                ]
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{]"
               }
             ]
           }
@@ -12334,8 +16190,17 @@
             "type": "PREC",
             "value": 100,
             "content": {
-              "type": "PATTERN",
-              "value": "\\}[a-z]*"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "}"
+                },
+                {
+                  "type": "PATTERN",
+                  "value": "[a-z]*"
+                }
+              ]
             }
           }
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8,29 +8,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -63,6 +42,40 @@
     "uninterpreted": {
       "type": "PATTERN",
       "value": ".*"
+    },
+    "_statements": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_statement"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statement"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     "_statement": {
       "type": "CHOICE",
@@ -238,29 +251,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -411,29 +403,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -465,29 +436,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -604,29 +554,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -842,29 +771,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_statement"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_terminator"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_statement"
-                          }
-                        ]
-                      }
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_statements"
                 },
                 {
                   "type": "BLANK"
@@ -890,29 +798,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -945,29 +832,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -987,29 +853,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -1075,29 +920,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -1117,29 +941,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -1329,29 +1132,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_statement"
-                    },
-                    {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "_terminator"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_statement"
-                          }
-                        ]
-                      }
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_statements"
                 },
                 {
                   "type": "BLANK"
@@ -12519,29 +12301,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statement"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_terminator"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_statement"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_statements"
             },
             {
               "type": "BLANK"
@@ -12692,12 +12453,8 @@
       "name": "comment"
     },
     {
-      "type": "SYMBOL",
-      "name": "_line_break"
-    },
-    {
       "type": "PATTERN",
-      "value": "[ \\t\\r]"
+      "value": "\\s"
     }
   ],
   "conflicts": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2220,7 +2220,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "integer"
+          "name": "fixnum"
         },
         {
           "type": "SYMBOL",
@@ -3656,7 +3656,7 @@
         }
       ]
     },
-    "integer": {
+    "fixnum": {
       "type": "PATTERN",
       "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2101,8 +2101,25 @@
               {
                 "type": "REPEAT",
                 "content": {
-                  "type": "PATTERN",
-                  "value": ".*\\n"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "PATTERN",
+                      "value": "[^=]"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "=[^e]"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "=e[^n]"
+                    },
+                    {
+                      "type": "PATTERN",
+                      "value": "=en[^d]"
+                    }
+                  ]
                 }
               },
               {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1058,6 +1058,14 @@
         },
         {
           "type": "SYMBOL",
+          "name": "math_assignment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "conditional_assignment"
+        },
+        {
+          "type": "SYMBOL",
           "name": "conditional"
         },
         {
@@ -1468,6 +1476,78 @@
           {
             "type": "STRING",
             "value": "="
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
+    },
+    "math_assignment": {
+      "type": "PREC_RIGHT",
+      "value": 15,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_lhs"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "+="
+              },
+              {
+                "type": "STRING",
+                "value": "-="
+              },
+              {
+                "type": "STRING",
+                "value": "*="
+              },
+              {
+                "type": "STRING",
+                "value": "**="
+              },
+              {
+                "type": "STRING",
+                "value": "/="
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
+    },
+    "conditional_assignment": {
+      "type": "PREC_RIGHT",
+      "value": 15,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_lhs"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "||="
+              },
+              {
+                "type": "STRING",
+                "value": "&&="
+              }
+            ]
           },
           {
             "type": "SYMBOL",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -43,7 +43,7 @@ typedef struct {
       TSSymbol symbol;
       unsigned short child_count;
     };
-  };
+  } params;
   TSParseActionType type : 4;
   bool extra : 1;
   bool fragile : 1;
@@ -103,14 +103,18 @@ typedef struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SHIFT(to_state_value)                                      \
-  {                                                                \
-    { .type = TSParseActionTypeShift, .to_state = to_state_value } \
+#define SHIFT(to_state_value)                                                 \
+  {                                                                           \
+    {                                                                         \
+      .type = TSParseActionTypeShift, .params = {.to_state = to_state_value } \
+    }                                                                         \
   }
 
-#define RECOVER(to_state_value)                                      \
-  {                                                                  \
-    { .type = TSParseActionTypeRecover, .to_state = to_state_value } \
+#define RECOVER(to_state_value)                                                 \
+  {                                                                             \
+    {                                                                           \
+      .type = TSParseActionTypeRecover, .params = {.to_state = to_state_value } \
+    }                                                                           \
   }
 
 #define SHIFT_EXTRA()                                 \
@@ -118,20 +122,20 @@ typedef struct TSLanguage {
     { .type = TSParseActionTypeShift, .extra = true } \
   }
 
-#define REDUCE(symbol_val, child_count_val)                  \
-  {                                                          \
-    {                                                        \
-      .type = TSParseActionTypeReduce, .symbol = symbol_val, \
-      .child_count = child_count_val,                        \
-    }                                                        \
+#define REDUCE(symbol_val, child_count_val)                             \
+  {                                                                     \
+    {                                                                   \
+      .type = TSParseActionTypeReduce,                                  \
+      .params = {.symbol = symbol_val, .child_count = child_count_val } \
+    }                                                                   \
   }
 
-#define REDUCE_FRAGILE(symbol_val, child_count_val)          \
-  {                                                          \
-    {                                                        \
-      .type = TSParseActionTypeReduce, .symbol = symbol_val, \
-      .child_count = child_count_val, .fragile = true,       \
-    }                                                        \
+#define REDUCE_FRAGILE(symbol_val, child_count_val)                     \
+  {                                                                     \
+    {                                                                   \
+      .type = TSParseActionTypeReduce, .fragile = true,                 \
+      .params = {.symbol = symbol_val, .child_count = child_count_val } \
+    }                                                                   \
   }
 
 #define ACCEPT_INPUT()                  \


### PR DESCRIPTION
Going to track work as I go to bring tree-sitter-ruby up-to-date and get the tests passing again. ~~~With a couple of fixes here and in tree-sitter, tests are currently passing, but generate times are very slow (on the order of 20mins).~~~ EDIT: Back to acceptable generate/build times.
- [X] Depends on https://github.com/tree-sitter/tree-sitter/pull/42

cc @maxbrunsfeld 
