### PR TITLE
Parsing improvements for control flow block

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -5,6 +5,7 @@ const PREC = {
   NOT: 5,
   DEFINED: 10,
   ASSIGN: 15,
+  RESCUE: 16,
   CONDITIONAL: 20,
   RANGE: 25,
   BOOLEAN_OR: 30,
@@ -72,6 +73,7 @@ module.exports = grammar({
       $.unless_modifier,
       $.while_modifier,
       $.until_modifier,
+      $.rescue_modifier,
       $._expression
     ),
 
@@ -126,6 +128,7 @@ module.exports = grammar({
     unless_modifier: $ => seq($._statement, "unless", $._expression),
     while_modifier: $ => seq($._statement, "while", $._expression),
     until_modifier: $ => seq($._statement, "until", $._expression),
+    rescue_modifier: $ => prec(PREC.RESCUE, seq($._statement, "rescue", $._expression)),
 
     _statement_block: $ => choice(
       $._do_block,

--- a/grammar.js
+++ b/grammar.js
@@ -118,7 +118,7 @@ module.exports = grammar({
       optional($.else_block),
       "end"
     ),
-    when_block: $ => seq("when", $.pattern, $.then_block),
+    when_block: $ => seq("when", $.pattern, $._then_block),
 
     pattern: $ => $._statement,
 
@@ -133,15 +133,15 @@ module.exports = grammar({
     ),
     _do_block: $ => seq("do", optional($._statements), "end"),
 
-    then_block: $ => seq(choice("then", $._terminator), optional($._statements)),
-    elsif_block: $ => seq("elsif", $._expression, $.then_block),
+    _then_block: $ => seq(choice("then", $._terminator), optional($._statements)),
+    elsif_block: $ => seq("elsif", $._expression, $._then_block),
     else_block: $ => seq("else", optional($._statements)),
     rescue_block: $ => seq("rescue", commaSep($._primary), choice("do", $._terminator), optional($._statements)),
     ensure_block: $ => seq("ensure", optional($._statements)),
 
-    _then_else_block: $ => seq($.then_block, optional($.else_block), "end"),
+    _then_else_block: $ => seq($._then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(
-      $.then_block,
+      $._then_block,
       repeat($.elsif_block),
       optional($.else_block),
       "end"

--- a/grammar.js
+++ b/grammar.js
@@ -136,8 +136,15 @@ module.exports = grammar({
     _then_block: $ => seq(choice("then", $._terminator), optional($._statements)),
     elsif_block: $ => seq("elsif", $._expression, $._then_block),
     else_block: $ => seq("else", optional($._statements)),
-    rescue_block: $ => seq("rescue", commaSep($._primary), choice("do", $._terminator), optional($._statements)),
     ensure_block: $ => seq("ensure", optional($._statements)),
+
+    rescue_block: $ => seq(
+      "rescue",
+      optional($.argument_list),
+      optional(seq("=>", $.identifier)),
+      choice("then", $._terminator),
+      optional($._statements)
+    ),
 
     _then_else_block: $ => seq($._then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(
@@ -241,7 +248,7 @@ module.exports = grammar({
       $.element_reference,
       $.member_access
     ),
-    _variable: $ => choice($.identifier , 'self'),
+    _variable: $ => choice($.identifier, 'self'),
 
     identifier: $ => token(seq(repeat(choice('@', '$')), identifierPattern)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -141,10 +141,12 @@ module.exports = grammar({
     rescue_block: $ => seq(
       "rescue",
       optional($.argument_list),
-      optional(seq("=>", $.identifier)),
+      optional($.last_exception),
       choice("then", $._terminator),
       optional($._statements)
     ),
+
+    last_exception: $ => seq("=>", $.identifier),
 
     _then_else_block: $ => seq($._then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -216,7 +216,9 @@ end
 
 ---
 
-(program (begin_statement (identifier) (else_block (identifier))))
+(program
+  (begin_statement (identifier)
+    (else_block (identifier))))
 
 ===============
 begin with ensure
@@ -230,7 +232,9 @@ end
 
 ---
 
-(program (begin_statement (identifier) (ensure_block (identifier))))
+(program
+  (begin_statement (identifier)
+    (ensure_block (identifier))))
 
 =======================
 begin with empty rescue
@@ -252,9 +256,44 @@ begin
 rescue x
 end
 
+begin
+rescue x then
+end
+
+begin
+rescue
+  bar
+end
+
+begin
+rescue x
+  bar
+end
+
+begin
+rescue x, y
+  bar
+end
+
+begin
+rescue Error => x
+end
+
+begin
+rescue Error => x
+  bar
+end
+
 ---
 
-(program (begin_statement (rescue_block (identifier))))
+(program
+  (begin_statement (rescue_block (argument_list (identifier))))
+  (begin_statement (rescue_block (argument_list (identifier))))
+  (begin_statement (rescue_block (identifier)))
+  (begin_statement (rescue_block (argument_list (identifier)) (identifier)))
+  (begin_statement (rescue_block (argument_list (identifier) (identifier)) (identifier)))
+  (begin_statement (rescue_block (argument_list (identifier)) (identifier)))
+  (begin_statement (rescue_block (argument_list (identifier)) (identifier) (identifier))))
 
 ============================
 begin with all the trimmings
@@ -272,7 +311,11 @@ end
 
 ---
 
-(program (begin_statement (identifier) (rescue_block (identifier) (identifier)) (else_block (identifier)) (ensure_block (identifier))))
+(program
+  (begin_statement (identifier)
+    (rescue_block (argument_list (identifier)) (identifier))
+    (else_block (identifier))
+    (ensure_block (identifier))))
 
 ======
 return
@@ -304,7 +347,9 @@ end
 
 ---
 
-(program (case_statement (identifier) (when_block (pattern (identifier)))))
+(program
+  (case_statement (identifier)
+  (when_block (pattern (identifier)))))
 
 ==============
 case with else
@@ -317,7 +362,10 @@ end
 
 ---
 
-(program (case_statement (identifier) (when_block (pattern (identifier))) (else_block)))
+(program
+  (case_statement (identifier)
+    (when_block (pattern (identifier)))
+    (else_block)))
 
 ==============================
 case with multiple when blocks
@@ -334,4 +382,8 @@ end
 
 ---
 
-(program (case_statement (identifier) (when_block (pattern (identifier)) (identifier)) (when_block (pattern (identifier)) (identifier)) (else_block (identifier))))
+(program
+  (case_statement (identifier)
+    (when_block (pattern (identifier)) (identifier))
+    (when_block (pattern (identifier)) (identifier))
+    (else_block (identifier))))

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -64,7 +64,7 @@ end
 
 ---
 
-(program (if_statement (identifier) (then_block)))
+(program (if_statement (identifier)))
 
 =======================
 empty if/else statement
@@ -76,7 +76,7 @@ end
 
 ---
 
-(program (if_statement (identifier) (then_block) (else_block)))
+(program (if_statement (identifier) (else_block)))
 
 ==================================
 single-line if then else statement
@@ -86,7 +86,7 @@ if foo then bar else quux end
 
 ---
 
-(program (if_statement (identifier) (then_block (identifier)) (else_block (identifier))))
+(program (if_statement (identifier) (identifier) (else_block (identifier))))
 
 ========
 if elsif
@@ -101,8 +101,8 @@ end
 ---
 
 (program
-  (if_statement (identifier) (then_block (identifier))
-  (elsif_block (identifier) (then_block (identifier)))))
+  (if_statement (identifier) (identifier)
+  (elsif_block (identifier) (identifier))))
 
 =============
 if elsif else
@@ -119,8 +119,8 @@ end
 ---
 
 (program
-  (if_statement (identifier) (then_block (identifier))
-  (elsif_block (identifier) (then_block (identifier)))
+  (if_statement (identifier) (identifier)
+  (elsif_block (identifier) (identifier))
   (else_block (identifier))))
 
 ======================
@@ -132,7 +132,7 @@ end
 
 ---
 
-(program (unless_statement (identifier) (then_block)))
+(program (unless_statement (identifier)))
 
 ================================
 empty unless statement with then
@@ -143,7 +143,7 @@ end
 
 ---
 
-(program (unless_statement (identifier) (then_block)))
+(program (unless_statement (identifier)))
 
 ================================
 empty unless statement with else
@@ -155,7 +155,7 @@ end
 
 ---
 
-(program (unless_statement (identifier) (then_block) (else_block)))
+(program (unless_statement (identifier) (else_block)))
 
 ===
 for
@@ -304,7 +304,7 @@ end
 
 ---
 
-(program (case_statement (identifier) (when_block (pattern (identifier)) (then_block))))
+(program (case_statement (identifier) (when_block (pattern (identifier)))))
 
 ==============
 case with else
@@ -317,7 +317,7 @@ end
 
 ---
 
-(program (case_statement (identifier) (when_block (pattern (identifier)) (then_block)) (else_block)))
+(program (case_statement (identifier) (when_block (pattern (identifier))) (else_block)))
 
 ==============================
 case with multiple when blocks
@@ -334,4 +334,4 @@ end
 
 ---
 
-(program (case_statement (identifier) (when_block (pattern (identifier)) (then_block (identifier))) (when_block (pattern (identifier)) (then_block (identifier))) (else_block (identifier))))
+(program (case_statement (identifier) (when_block (pattern (identifier)) (identifier)) (when_block (pattern (identifier)) (identifier)) (else_block (identifier))))

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -295,6 +295,16 @@ end
   (begin_statement (rescue_block (argument_list (identifier)) (last_exception (identifier))))
   (begin_statement (rescue_block (argument_list (identifier)) (last_exception (identifier)) (identifier))))
 
+=================
+rescue modifier
+=================
+
+foo rescue nil
+
+---
+
+(program (rescue_modifier (identifier) (nil)))
+
 ============================
 begin with all the trimmings
 ============================

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -292,8 +292,8 @@ end
   (begin_statement (rescue_block (identifier)))
   (begin_statement (rescue_block (argument_list (identifier)) (identifier)))
   (begin_statement (rescue_block (argument_list (identifier) (identifier)) (identifier)))
-  (begin_statement (rescue_block (argument_list (identifier)) (identifier)))
-  (begin_statement (rescue_block (argument_list (identifier)) (identifier) (identifier))))
+  (begin_statement (rescue_block (argument_list (identifier)) (last_exception (identifier))))
+  (begin_statement (rescue_block (argument_list (identifier)) (last_exception (identifier)) (identifier))))
 
 ============================
 begin with all the trimmings

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -897,58 +897,12 @@
         }
       ]
     },
-    "rescue_block": {
+    "ensure_block": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "rescue"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_primary"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_primary"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "do"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_terminator"
-            }
-          ]
+          "value": "ensure"
         },
         {
           "type": "CHOICE",
@@ -964,12 +918,58 @@
         }
       ]
     },
-    "ensure_block": {
+    "rescue_block": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "ensure"
+          "value": "rescue"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "=>"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "then"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -941,17 +941,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "=>"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "last_exception"
             },
             {
               "type": "BLANK"
@@ -982,6 +973,19 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "last_exception": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -164,6 +164,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "rescue_modifier"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_expression"
         }
       ]
@@ -769,6 +773,27 @@
           "name": "_expression"
         }
       ]
+    },
+    "rescue_modifier": {
+      "type": "PREC",
+      "value": 16,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_statement"
+          },
+          {
+            "type": "STRING",
+            "value": "rescue"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        ]
+      }
     },
     "_statement_block": {
       "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -694,7 +694,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "then_block"
+          "name": "_then_block"
         }
       ]
     },
@@ -829,7 +829,7 @@
         }
       ]
     },
-    "then_block": {
+    "_then_block": {
       "type": "SEQ",
       "members": [
         {
@@ -872,7 +872,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "then_block"
+          "name": "_then_block"
         }
       ]
     },
@@ -990,7 +990,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "then_block"
+          "name": "_then_block"
         },
         {
           "type": "CHOICE",
@@ -1015,7 +1015,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "then_block"
+          "name": "_then_block"
         },
         {
           "type": "REPEAT",


### PR DESCRIPTION
Some minor changes to the way we parse control flow blocks.

- Removed `then_block` production to rely on primary production instead (like `if_statement` or `begin_statement`, etc)
- Improved parsing of `rescue_block`:
  - `s/do/then`
  - Handle argument list to rescue multiple exception types.
  - Production for capturing last exception into a local variable.
  - Parse rescue modifiers (e.g. `foo rescue nil`). Fixes #13 