### PR TITLE
Better handling of exception capture in rescue blocks

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -286,7 +286,7 @@ module.exports = grammar({
     ),
 
     symbol: $ => choice(
-      token(seq(':', choice(identifierPattern, choice.apply(null, operators)))),
+      token(seq(':', choice(seq(identifierPattern, optional(choice('?', '!'))), choice.apply(null, operators)))),
       seq(":'", $._single_quoted_continuation),
       seq(':"', $._double_quoted_continuation),
       seq('%s', choice(

--- a/grammar.js
+++ b/grammar.js
@@ -144,12 +144,12 @@ module.exports = grammar({
     rescue_block: $ => seq(
       "rescue",
       optional($.argument_list),
-      optional($.last_exception),
+      optional(seq("=>", $.last_exception)),
       choice("then", $._terminator),
       optional($._statements)
     ),
 
-    last_exception: $ => seq("=>", /[a-zA-Z0-9_]*/),
+    last_exception: $ => (/[a-zA-Z_][a-zA-Z0-9_]*/),
 
     _then_else_block: $ => seq($._then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -29,7 +29,7 @@ const PREC = {
 // generate/build times.
 // const unbalancedDelimiters = '!@#$%^&*)]}>|\\=/+-~`\'",.?:;_'.split('');
 const unbalancedDelimiters = '#/\\'.split('');
-const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*\??/;
+const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*/;
 const operators = ['..', '|', '^', '&', '<=>', '==', '===', '=~', '>', '>=', '<', '<=', '+', '-', '*', '/', '%', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]='];
 
 module.exports = grammar({
@@ -144,12 +144,11 @@ module.exports = grammar({
     rescue_block: $ => seq(
       "rescue",
       optional($.argument_list),
-      optional(seq("=>", $.last_exception)),
-      choice("then", $._terminator),
-      optional($._statements)
+      optional(seq("=>", $.rescued_exception)),
+      $._then_block
     ),
 
-    last_exception: $ => (/[a-zA-Z_][a-zA-Z0-9_]*/),
+    rescued_exception: $ => (identifierPattern),
 
     _then_else_block: $ => seq($._then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(
@@ -413,7 +412,7 @@ module.exports = grammar({
       '}'
     ),
 
-    _function_name: $ => choice($.identifier, choice.apply(null, operators)),
+    _function_name: $ => choice(seq($.identifier, optional(choice('?', '!'))), choice.apply(null, operators)),
 
     _line_break: $ => '\n',
     _terminator: $ => choice($._line_break, ';'),

--- a/grammar.js
+++ b/grammar.js
@@ -149,7 +149,7 @@ module.exports = grammar({
       optional($._statements)
     ),
 
-    last_exception: $ => seq("=>", $.identifier),
+    last_exception: $ => seq("=>", /[a-zA-Z0-9_]*/),
 
     _then_else_block: $ => seq($._then_block, optional($.else_block), "end"),
     _then_elsif_else_block: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -29,7 +29,7 @@ const PREC = {
 // generate/build times.
 // const unbalancedDelimiters = '!@#$%^&*)]}>|\\=/+-~`\'",.?:;_'.split('');
 const unbalancedDelimiters = '#/\\'.split('');
-const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*/;
+const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*(\?|\!)?/;
 const operators = ['..', '|', '^', '&', '<=>', '==', '===', '=~', '>', '>=', '<', '<=', '+', '-', '*', '/', '%', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]='];
 
 module.exports = grammar({
@@ -286,7 +286,7 @@ module.exports = grammar({
     ),
 
     symbol: $ => choice(
-      token(seq(':', choice(seq(identifierPattern, optional(choice('?', '!'))), choice.apply(null, operators)))),
+      token(seq(':', choice(identifierPattern, choice.apply(null, operators)))),
       seq(":'", $._single_quoted_continuation),
       seq(':"', $._double_quoted_continuation),
       seq('%s', choice(
@@ -412,7 +412,7 @@ module.exports = grammar({
       '}'
     ),
 
-    _function_name: $ => choice(seq($.identifier, optional(choice('?', '!'))), choice.apply(null, operators)),
+    _function_name: $ => choice($.identifier, choice.apply(null, operators)),
 
     _line_break: $ => '\n',
     _terminator: $ => choice($._line_break, ';'),

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -271,6 +271,11 @@ rescue x
 end
 
 begin
+rescue => x
+  bar
+end
+
+begin
 rescue x, y
   bar
 end
@@ -291,9 +296,10 @@ end
   (begin_statement (rescue_block (argument_list (identifier))))
   (begin_statement (rescue_block (identifier)))
   (begin_statement (rescue_block (argument_list (identifier)) (identifier)))
+  (begin_statement (rescue_block (last_exception) (identifier)))
   (begin_statement (rescue_block (argument_list (identifier) (identifier)) (identifier)))
-  (begin_statement (rescue_block (argument_list (identifier)) (last_exception (identifier))))
-  (begin_statement (rescue_block (argument_list (identifier)) (last_exception (identifier)) (identifier))))
+  (begin_statement (rescue_block (argument_list (identifier)) (last_exception)))
+  (begin_statement (rescue_block (argument_list (identifier)) (last_exception) (identifier))))
 
 =================
 rescue modifier

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -244,9 +244,22 @@ begin
 rescue
 end
 
+begin
+rescue then
+end
+
+begin
+rescue
+  bar
+end
+
+
 ---
 
-(program (begin_statement (rescue_block)))
+(program
+  (begin_statement (rescue_block))
+  (begin_statement (rescue_block))
+  (begin_statement (rescue_block (identifier))))
 
 ===========================
 begin with rescue with args
@@ -258,11 +271,6 @@ end
 
 begin
 rescue x then
-end
-
-begin
-rescue
-  bar
 end
 
 begin
@@ -294,12 +302,11 @@ end
 (program
   (begin_statement (rescue_block (argument_list (identifier))))
   (begin_statement (rescue_block (argument_list (identifier))))
-  (begin_statement (rescue_block (identifier)))
   (begin_statement (rescue_block (argument_list (identifier)) (identifier)))
-  (begin_statement (rescue_block (last_exception) (identifier)))
+  (begin_statement (rescue_block (rescued_exception) (identifier)))
   (begin_statement (rescue_block (argument_list (identifier) (identifier)) (identifier)))
-  (begin_statement (rescue_block (argument_list (identifier)) (last_exception)))
-  (begin_statement (rescue_block (argument_list (identifier)) (last_exception) (identifier))))
+  (begin_statement (rescue_block (argument_list (identifier)) (rescued_exception)))
+  (begin_statement (rescue_block (argument_list (identifier)) (rescued_exception) (identifier))))
 
 =================
 rescue modifier

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -9,6 +9,28 @@ end
 
 (program (method_declaration (identifier)))
 
+============
+method ending in question mark
+============
+
+def foo?
+end
+
+---
+
+(program (method_declaration (identifier)))
+
+============
+method ending in exclamation point
+============
+
+def foo!
+end
+
+---
+
+(program (method_declaration (identifier)))
+
 ================
 method with body
 ================

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -5,31 +5,18 @@ empty method
 def foo
 end
 
----
-
-(program (method_declaration (identifier)))
-
-============
-method ending in question mark
-============
-
 def foo?
 end
-
----
-
-(program (method_declaration (identifier)))
-
-============
-method ending in exclamation point
-============
 
 def foo!
 end
 
 ---
 
-(program (method_declaration (identifier)))
+(program
+  (method_declaration (identifier))
+  (method_declaration (identifier))
+  (method_declaration (identifier)))
 
 ================
 method with body

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -363,13 +363,13 @@ print("hello")
 ---
 
 (program
-  (function_call (identifier) (argument_list))
+  (identifier)
   (function_call (identifier) (argument_list))
   (function_call (identifier) (argument_list (string)))
   (function_call (identifier) (argument_list (string))))
 
 ===============================
-function call
+method call with receiver
 ===============================
 
 foo.bar

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -3,10 +3,15 @@ symbol
 ======
 
 :foo
+:foo!
+:foo?
 
 ---
 
-(program (symbol))
+(program
+	(symbol)
+	(symbol)
+	(symbol))
 
 ====================
 single quoted symbol

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -991,7 +991,7 @@
     },
     "rescued_exception": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_][a-zA-Z0-9_]*"
+      "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
     },
     "_then_else_block": {
       "type": "SEQ",
@@ -2148,7 +2148,7 @@
           },
           {
             "type": "PATTERN",
-            "value": "[a-zA-Z_][a-zA-Z0-9_]*"
+            "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
           }
         ]
       }
@@ -2284,34 +2284,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[a-zA-Z_][a-zA-Z0-9_]*"
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": "?"
-                              },
-                              {
-                                "type": "STRING",
-                                "value": "!"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      }
-                    ]
+                    "type": "PATTERN",
+                    "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
                   },
                   {
                     "type": "CHOICE",
@@ -4234,34 +4208,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": "?"
-                    },
-                    {
-                      "type": "STRING",
-                      "value": "!"
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "identifier"
         },
         {
           "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2284,8 +2284,34 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "PATTERN",
-                    "value": "[a-zA-Z_][a-zA-Z0-9_]*"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[a-zA-Z_][a-zA-Z0-9_]*"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "?"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "!"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
                     "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -966,8 +966,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "last_exception"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "=>"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "last_exception"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1002,17 +1011,8 @@
       ]
     },
     "last_exception": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "PATTERN",
-          "value": "[a-zA-Z0-9_]*"
-        }
-      ]
+      "type": "PATTERN",
+      "value": "[a-zA-Z_][a-zA-Z0-9_]*"
     },
     "_then_else_block": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -974,7 +974,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "last_exception"
+                  "name": "rescued_exception"
                 }
               ]
             },
@@ -984,33 +984,12 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "then"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_terminator"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_then_block"
         }
       ]
     },
-    "last_exception": {
+    "rescued_exception": {
       "type": "PATTERN",
       "value": "[a-zA-Z_][a-zA-Z0-9_]*"
     },
@@ -2169,7 +2148,7 @@
           },
           {
             "type": "PATTERN",
-            "value": "[a-zA-Z_][a-zA-Z0-9_]*\\??"
+            "value": "[a-zA-Z_][a-zA-Z0-9_]*"
           }
         ]
       }
@@ -2306,7 +2285,7 @@
                 "members": [
                   {
                     "type": "PATTERN",
-                    "value": "[a-zA-Z_][a-zA-Z0-9_]*\\??"
+                    "value": "[a-zA-Z_][a-zA-Z0-9_]*"
                   },
                   {
                     "type": "CHOICE",
@@ -4229,8 +4208,34 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "?"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "!"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1009,8 +1009,8 @@
           "value": "=>"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "PATTERN",
+          "value": "[a-zA-Z0-9_]*"
         }
       ]
     },


### PR DESCRIPTION
Don't produce `(last_exception (identifier))`, instead produce `(last_exception)` and tighten identifier pattern for allowed exception capture variable names.