### PR TITLE
Singleton classes, block arguments, and bug fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -288,7 +288,7 @@ module.exports = grammar({
     complement: $ => prec.right(PREC.COMPLEMENT, seq(choice('!', '~'), expression($))),
 
     _lhs: $ => choice(
-      prec(PREC.PRIMARY, $._variable),
+      $._variable,
       $.scope_resolution_expression,
       $.element_reference,
       $.member_access,

--- a/grammar.js
+++ b/grammar.js
@@ -132,8 +132,7 @@ module.exports = grammar({
       optional($.else_block),
       "end"
     ),
-    when_block: $ => seq("when", $.pattern, $._then_block),
-
+    when_block: $ => seq("when", commaSep1($.pattern), $._then_block),
     pattern: $ => $._statement,
 
     if_modifier: $ => seq($._statement, "if", expression($)),

--- a/grammar.js
+++ b/grammar.js
@@ -47,6 +47,7 @@ module.exports = grammar({
     [$._lhs, $.function_call_with_do_block],
     [$._argument_list],
     [$._argument_list, $._statement],
+    [$.yield]
   ],
 
   rules: {
@@ -253,7 +254,6 @@ module.exports = grammar({
       "}"
     ),
 
-    // TODO argument_list is optional
     yield: $ => seq("yield", optional($.argument_list)),
 
     and: $ => prec.left(PREC.AND, seq(expression($), "and", expression($))),
@@ -288,7 +288,7 @@ module.exports = grammar({
     complement: $ => prec.right(PREC.COMPLEMENT, seq(choice('!', '~'), expression($))),
 
     _lhs: $ => choice(
-      $._variable,
+      prec(PREC.PRIMARY, $._variable),
       $.scope_resolution_expression,
       $.element_reference,
       $.member_access,

--- a/grammar.js
+++ b/grammar.js
@@ -127,7 +127,7 @@ module.exports = grammar({
     return_statement: $ => seq("return", optional(expression($))),
 
     case_expression: $ => seq(
-      "case", $._statement, $._line_break,
+      "case", $._simple_expression, $._terminator,
       repeat($.when_block),
       optional($.else_block),
       "end"

--- a/grammar.js
+++ b/grammar.js
@@ -79,6 +79,7 @@ module.exports = grammar({
     _declaration: $ => choice(
       $.method_declaration,
       $.class_declaration,
+      $.singleton_class_declaration,
       $.module_declaration
     ),
 
@@ -107,6 +108,8 @@ module.exports = grammar({
     optional_parameter: $ => seq($.identifier, "=", $._simple_expression),
 
     class_declaration: $ => seq("class", $.identifier, optional(seq("<", sep1($.identifier, "::"))), $._terminator, optional($._statements), "end"),
+
+    singleton_class_declaration: $ => seq("class", "<<", $.identifier, $._terminator, optional($._statements), "end"),
 
     module_declaration: $ => seq("module", $.identifier, $._terminator, optional($._statements), "end"),
 

--- a/grammar.js
+++ b/grammar.js
@@ -65,7 +65,6 @@ module.exports = grammar({
       $.for_statement,
       $.begin_statement,
       $.return_statement,
-      $.case_statement,
       $.if_modifier,
       $.unless_modifier,
       $.while_modifier,
@@ -127,7 +126,7 @@ module.exports = grammar({
 
     return_statement: $ => seq("return", optional(expression($))),
 
-    case_statement: $ => seq(
+    case_expression: $ => seq(
       "case", $._statement, $._line_break,
       repeat($.when_block),
       optional($.else_block),
@@ -186,6 +185,7 @@ module.exports = grammar({
       $.range,
       $.boolean_or,
       $.boolean_and,
+      $.case_expression,
       $.relational,
       $.comparison,
       $.bitwise_or,

--- a/grammar.js
+++ b/grammar.js
@@ -207,7 +207,7 @@ module.exports = grammar({
     element_reference: $ => prec.left(1, seq($._primary, "[", $._argument_list, "]")),
     member_access: $ => prec.left(1, seq($._primary, ".", $.identifier)),
 
-    function_call_with_do_block: $ => prec.left(0, seq(
+    function_call_with_do_block: $ => prec.left(seq(
       choice($._variable, $.scope_resolution_expression, $.member_access),
       choice(
         seq($.argument_list, $.do_block),
@@ -215,7 +215,7 @@ module.exports = grammar({
       )
     )),
 
-    function_call: $ => prec.left(0, seq(
+    function_call: $ => prec.left(seq(
       choice($._variable, $.scope_resolution_expression, $.member_access),
       choice(
         seq($.argument_list, $.block),

--- a/grammar.js
+++ b/grammar.js
@@ -4,6 +4,7 @@ const PREC = {
   OR: -2,
   NOT: 5,
   DEFINED: 10,
+  ALIAS: 11,
   ASSIGN: 15,
   RESCUE: 16,
   CONDITIONAL: 20,
@@ -55,8 +56,8 @@ module.exports = grammar({
 
     _statement: $ => choice(
       $._declaration,
-      seq("undef", $._function_name),
-      seq("alias", $._function_name, $._function_name),
+      $.undef,
+      $.alias,
       $.while_statement,
       $.until_statement,
       $.if_statement,
@@ -298,6 +299,11 @@ module.exports = grammar({
     _variable: $ => choice($.identifier, 'self'),
 
     identifier: $ => token(seq(repeat(choice('@', '$')), identifierPattern)),
+
+    undef: $ => seq("undef", $._name_symbol_or_operator),
+    alias: $ => seq("alias", $._name_symbol_or_operator, $._name_symbol_or_operator),
+    _name_symbol_or_operator: $ => prec(PREC.ALIAS, choice($.identifier, $.symbol, $.operator)),
+    operator: $ => choice(...operators),
 
     comment: $ => token(prec(PREC.COMMENT, choice(
       seq('#', /.*/),

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -371,7 +371,7 @@ end
 ---
 
 (program
-  (case_statement (identifier)
+  (case_expression (identifier)
   (when_block (pattern (identifier)))))
 
 ==============
@@ -386,7 +386,7 @@ end
 ---
 
 (program
-  (case_statement (identifier)
+  (case_expression (identifier)
     (when_block (pattern (identifier)))
     (else_block)))
 
@@ -406,7 +406,20 @@ end
 ---
 
 (program
-  (case_statement (identifier)
+  (case_expression (identifier)
     (when_block (pattern (identifier)) (identifier))
     (when_block (pattern (identifier)) (identifier))
     (else_block (identifier))))
+
+==============
+case with assignment
+==============
+
+x = case foo
+when bar
+else
+end
+
+---
+
+(program (assignment (identifier) (case_expression (identifier) (when_block (pattern (identifier))) (else_block))))

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -423,3 +423,16 @@ end
 ---
 
 (program (assignment (identifier) (case_expression (identifier) (when_block (pattern (identifier))) (else_block))))
+
+==============
+case with expression
+==============
+
+x = case foo = bar | baz
+when bar
+else
+end
+
+---
+
+(program (assignment (identifier) (case_expression (assignment (identifier) (bitwise_or (identifier) (identifier))) (when_block (pattern (identifier))) (else_block))))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -254,6 +254,23 @@ end
 
 (program (class_declaration (identifier) (method_declaration (identifier))))
 
+===============
+singleton class
+===============
+
+class << self
+end
+
+class << Foo
+end
+
+---
+
+(program
+  (singleton_class_declaration (identifier))
+  (singleton_class_declaration (identifier)))
+
+
 ============
 empty module
 ============

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -6,7 +6,8 @@ Foo::bar
 
 ---
 
-(program (scope_resolution_expression (identifier) (identifier)))
+(program
+  (scope_resolution_expression (identifier) (identifier)))
 
 ============
 element reference

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -583,3 +583,15 @@ lambda { |a, b, c|
 ---
 
 (program (lambda_expression (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
+
+====================
+lambda expression with do end
+====================
+
+lambda do |foo|
+  1
+end
+
+---
+
+(program (lambda_expression (formal_parameters (identifier)) (integer)))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -129,10 +129,19 @@ defined?
 ========
 
 defined? foo
+defined? Foo.bar
+defined?(foo)
+defined?($foo)
+defined?(@foo)
 
 ---
 
-(program (defined (identifier)))
+(program
+  (defined (identifier))
+  (defined (member_access (identifier) (identifier)))
+  (defined (identifier))
+  (defined (identifier))
+  (defined (identifier)))
 
 ==========
 assignment
@@ -433,6 +442,41 @@ foo(&bar)
 (program
   (function_call (identifier) (argument_list (block_argument (symbol))))
   (function_call (identifier) (argument_list (block_argument (identifier)))))
+
+===============================
+method call lambda argument
+===============================
+
+foo :bar, -> (a) { 1 }
+foo :bar, -> (a) { where(:c => b) }
+
+---
+
+(program
+  (function_call (identifier)
+    (argument_list
+      (symbol)
+      (lambda_literal (formal_parameters (identifier)) (integer))))
+  (function_call (identifier)
+    (argument_list
+      (symbol)
+      (lambda_literal
+        (formal_parameters (identifier))
+        (function_call (identifier) (argument_list (argument_pair (symbol) (identifier))))))))
+
+===============================
+method call lambda argument and do block
+===============================
+
+foo :bar, -> (a) { 1 } do
+end
+
+---
+
+(program
+  (function_call_with_do_block (identifier)
+    (argument_list (symbol) (lambda_literal (formal_parameters (identifier)) (integer)))
+    (do_block)))
 
 ============================
 function call without parens

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -3,11 +3,13 @@ scope resolution
 ================
 
 Foo::bar
+::Bar
 
 ---
 
 (program
-  (scope_resolution_expression (identifier) (identifier)))
+  (scope_resolution_expression (identifier) (identifier))
+  (scope_resolution_expression (identifier)))
 
 ============
 element reference
@@ -419,6 +421,19 @@ foo a: true
   (function_call (identifier) (argument_list (argument_pair (identifier) (boolean))))
   (function_call (identifier) (argument_list (argument_pair (identifier) (boolean)))))
 
+===============================
+method call with block argument
+===============================
+
+foo(&:sort)
+foo(&bar)
+
+---
+
+(program
+  (function_call (identifier) (argument_list (block_argument (symbol))))
+  (function_call (identifier) (argument_list (block_argument (identifier)))))
+
 ============================
 function call without parens
 ============================
@@ -430,7 +445,7 @@ include D::E.f
 (program (function_call (identifier) (argument_list (member_access (scope_resolution_expression (identifier) (identifier)) (identifier)))))
 
 ===============================
-method call with block parameter do end
+method call with block argument do end
 ===============================
 
 foo do |i|
@@ -468,7 +483,7 @@ end
     (do_block (formal_parameters (keyword_parameter (identifier) (identifier)) (splat_parameter (identifier))))))
 
 ===============================
-method call with block parameter curly
+method call with block argument curly
 ===============================
 
 foo { |i| foo }

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -631,3 +631,15 @@ lambda literal with multiple args
 ---
 
 (program (lambda_literal (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
+
+====================
+lambda literal with do end
+====================
+
+-> (foo) do
+	1
+end
+
+---
+
+(program (lambda_literal (formal_parameters (identifier)) (integer)))

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -611,10 +611,13 @@ lambda literal with an arg
 ====================
 
 -> foo { 1 }
+-> (foo) { 1 }
 
 ---
 
-(program (lambda_literal (identifier) (integer)))
+(program
+	(lambda_literal (identifier) (integer))
+	(lambda_literal (formal_parameters (identifier)) (integer)))
 
 ===========================
 lambda literal with multiple args

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -37,3 +37,28 @@ foo until bar
 ---
 
 (program (until_modifier (identifier) (identifier)))
+
+========
+alias
+========
+
+alias :foo :bar
+alias foo bar
+alias foo +
+
+---
+
+(program (alias (symbol) (symbol)) (alias (identifier) (identifier)) (alias (identifier) (operator)))
+
+========
+undef
+========
+
+undef :foo
+undef foo
+
+---
+
+(program
+  (undef (symbol))
+  (undef (identifier)))

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./build/Release/ts_language_ruby_binding");
+module.exports = require("./build/Debug/ts_language_ruby_binding");

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require("./build/Debug/ts_language_ruby_binding");
+module.exports = require("./build/Release/ts_language_ruby_binding");

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1296,10 +1296,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "function_call"
-        },
-        {
-          "type": "SYMBOL",
           "name": "yield"
         },
         {
@@ -1428,21 +1424,13 @@
     },
     "scope_resolution_expression": {
       "type": "PREC_LEFT",
-      "value": 0,
+      "value": 101,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_primary"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_primary"
           },
           {
             "type": "STRING",
@@ -1457,7 +1445,7 @@
     },
     "element_reference": {
       "type": "PREC_LEFT",
-      "value": 0,
+      "value": 101,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1482,7 +1470,7 @@
     },
     "member_access": {
       "type": "PREC_LEFT",
-      "value": 0,
+      "value": 101,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2784,8 +2772,12 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_variable"
+          "type": "PREC",
+          "value": 101,
+          "content": {
+            "type": "SYMBOL",
+            "name": "_variable"
+          }
         },
         {
           "type": "SYMBOL",
@@ -2798,6 +2790,10 @@
         {
           "type": "SYMBOL",
           "name": "member_access"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function_call"
         }
       ]
     },
@@ -5089,13 +5085,17 @@
   ],
   "conflicts": [
     [
+      "_lhs",
       "function_call",
-      "function_call_with_do_block",
-      "_lhs"
+      "function_call_with_do_block"
     ],
     [
-      "function_call_with_do_block",
-      "_lhs"
+      "_lhs",
+      "function_call"
+    ],
+    [
+      "_lhs",
+      "function_call_with_do_block"
     ],
     [
       "_argument_list"
@@ -5103,6 +5103,9 @@
     [
       "_argument_list",
       "_statement"
+    ],
+    [
+      "yield"
     ]
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -866,8 +866,29 @@
           "value": "when"
         },
         {
-          "type": "SYMBOL",
-          "name": "pattern"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "pattern"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "pattern"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -85,34 +85,12 @@
           "name": "_declaration"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "undef"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_function_name"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "undef"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "alias"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_function_name"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_function_name"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "alias"
         },
         {
           "type": "SYMBOL",
@@ -2924,6 +2902,162 @@
           }
         ]
       }
+    },
+    "undef": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "undef"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_name_symbol_or_operator"
+        }
+      ]
+    },
+    "alias": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_name_symbol_or_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_name_symbol_or_operator"
+        }
+      ]
+    },
+    "_name_symbol_or_operator": {
+      "type": "PREC",
+      "value": 11,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "symbol"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "operator"
+          }
+        ]
+      }
+    },
+    "operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": ".."
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "STRING",
+          "value": "<=>"
+        },
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": "==="
+        },
+        {
+          "type": "STRING",
+          "value": "=~"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": ">="
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": "<="
+        },
+        {
+          "type": "STRING",
+          "value": "+"
+        },
+        {
+          "type": "STRING",
+          "value": "-"
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        },
+        {
+          "type": "STRING",
+          "value": "%"
+        },
+        {
+          "type": "STRING",
+          "value": "**"
+        },
+        {
+          "type": "STRING",
+          "value": "<<"
+        },
+        {
+          "type": "STRING",
+          "value": ">>"
+        },
+        {
+          "type": "STRING",
+          "value": "~"
+        },
+        {
+          "type": "STRING",
+          "value": "+@"
+        },
+        {
+          "type": "STRING",
+          "value": "-@"
+        },
+        {
+          "type": "STRING",
+          "value": "[]"
+        },
+        {
+          "type": "STRING",
+          "value": "[]="
+        }
+      ]
     },
     "comment": {
       "type": "TOKEN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -194,6 +194,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "singleton_class_declaration"
+        },
+        {
+          "type": "SYMBOL",
           "name": "module_declaration"
         }
       ]
@@ -523,6 +527,43 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_terminator"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "singleton_class_declaration": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "class"
+        },
+        {
+          "type": "STRING",
+          "value": "<<"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -2772,12 +2813,8 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "PREC",
-          "value": 101,
-          "content": {
-            "type": "SYMBOL",
-            "name": "_variable"
-          }
+          "type": "SYMBOL",
+          "name": "_variable"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1465,13 +1465,21 @@
     },
     "scope_resolution_expression": {
       "type": "PREC_LEFT",
-      "value": 101,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_primary"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_primary"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "STRING",
@@ -1486,7 +1494,7 @@
     },
     "element_reference": {
       "type": "PREC_LEFT",
-      "value": 101,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1511,7 +1519,7 @@
     },
     "member_access": {
       "type": "PREC_LEFT",
-      "value": 101,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1532,7 +1540,7 @@
     },
     "function_call_with_do_block": {
       "type": "PREC_LEFT",
-      "value": -2,
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1580,7 +1588,7 @@
     },
     "function_call": {
       "type": "PREC_LEFT",
-      "value": -2,
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1632,7 +1640,7 @@
     },
     "argument_list": {
       "type": "PREC_LEFT",
-      "value": -1,
+      "value": 1,
       "content": {
         "type": "CHOICE",
         "members": [
@@ -1656,21 +1664,50 @@
                 ]
               },
               {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "block_argument"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
                 "type": "STRING",
                 "value": ")"
               }
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "_argument_list"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_argument_list"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "block_argument"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }
     },
     "_argument_list": {
       "type": "PREC_LEFT",
-      "value": 0,
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1716,8 +1753,8 @@
       }
     },
     "argument_pair": {
-      "type": "PREC",
-      "value": -1,
+      "type": "PREC_LEFT",
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1758,6 +1795,19 @@
           }
         ]
       }
+    },
+    "block_argument": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "&"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_simple_expression"
+        }
+      ]
     },
     "do_block": {
       "type": "SEQ",
@@ -5133,13 +5183,6 @@
     [
       "_lhs",
       "function_call_with_do_block"
-    ],
-    [
-      "_argument_list"
-    ],
-    [
-      "_argument_list",
-      "_statement"
     ],
     [
       "yield"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -122,10 +122,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "case_statement"
-        },
-        {
-          "type": "SYMBOL",
           "name": "if_modifier"
         },
         {
@@ -822,7 +818,7 @@
         }
       ]
     },
-    "case_statement": {
+    "case_expression": {
       "type": "SEQ",
       "members": [
         {
@@ -1360,6 +1356,10 @@
         {
           "type": "SYMBOL",
           "name": "boolean_and"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case_expression"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -827,11 +827,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_statement"
+          "name": "_simple_expression"
         },
         {
           "type": "SYMBOL",
-          "name": "_line_break"
+          "name": "_terminator"
         },
         {
           "type": "REPEAT",
@@ -1017,8 +1017,29 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_do_block"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "do"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "end"
+            }
+          ]
         },
         {
           "type": "SEQ",
@@ -1044,31 +1065,6 @@
               "value": "end"
             }
           ]
-        }
-      ]
-    },
-    "_do_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "do"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
         }
       ]
     },
@@ -1788,6 +1784,10 @@
       ]
     },
     "do_block": {
+      "type": "SYMBOL",
+      "name": "_do_block"
+    },
+    "_do_block": {
       "type": "SEQ",
       "members": [
         {
@@ -1846,6 +1846,10 @@
       ]
     },
     "block": {
+      "type": "SYMBOL",
+      "name": "_block"
+    },
+    "_block": {
       "type": "SEQ",
       "members": [
         {
@@ -5079,6 +5083,24 @@
           ]
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_lambda_block"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_lambda_do_block"
+            }
+          ]
+        }
+      ]
+    },
+    "_lambda_block": {
+      "type": "SEQ",
+      "members": [
+        {
           "type": "STRING",
           "value": "{"
         },
@@ -5100,49 +5122,12 @@
         }
       ]
     },
-    "lambda_expression": {
+    "_lambda_do_block": {
       "type": "SEQ",
       "members": [
         {
           "type": "STRING",
-          "value": "lambda"
-        },
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "|"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "formal_parameters"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": "|"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "value": "do"
         },
         {
           "type": "CHOICE",
@@ -5158,7 +5143,29 @@
         },
         {
           "type": "STRING",
-          "value": "}"
+          "value": "end"
+        }
+      ]
+    },
+    "lambda_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "lambda"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_block"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_do_block"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This allows parsing of:

- [x] Singleton class declarations, e.g. `class << self; end`
- [x] Block arguments, e.g. `foo(&:bar)`
- [x] Rework `alias` and `undef`
- [x] Case on expressions and use a case statement for assignment
- [x] Lambda literals can use `do/end` notation 
- [x] When blocks can match multiple patterns, e.g. `when A, B` 

Additionally, scope resolution, element reference, and member access all allow functions on their left hand side now.

This also bumps to latest tree-sitter with new precedence handling.