### PR TITLE
Continue to expand ruby grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -300,11 +300,12 @@ module.exports = grammar({
     _variable: $ => choice($.identifier, 'self'),
 
     identifier: $ => token(seq(repeat(choice('@', '$')), identifierPattern)),
-
-    undef: $ => seq("undef", $._name_symbol_or_operator),
-    alias: $ => seq("alias", $._name_symbol_or_operator, $._name_symbol_or_operator),
-    _name_symbol_or_operator: $ => prec(PREC.ALIAS, choice($.identifier, $.symbol, $.operator)),
     operator: $ => choice(...operators),
+    _item: $ => choice($.identifier, $.symbol, $.operator),
+
+    _undef_list: $ => choice($._item, prec(1, seq($._undef_list, ',', $._item))),
+    undef: $ => seq("undef", $._undef_list),
+    alias: $ => seq("alias", $._item, $._item),
 
     comment: $ => token(prec(PREC.COMMENT, choice(
       seq('#', /.*/),

--- a/grammar.js
+++ b/grammar.js
@@ -446,7 +446,7 @@ module.exports = grammar({
     ),
 
     array: $ => choice(
-      seq('[', $._array_items, ']'),
+      seq('[', optional($._array_items), ']'),
       seq(/%[wi]/, choice(
         $._uninterpolated_paren
       )),
@@ -455,7 +455,7 @@ module.exports = grammar({
       ))
     ),
 
-    _array_items: $ => optional(seq(expression($), optional(seq(',', $._array_items)))),
+    _array_items: $ => sepTrailing($._array_items, $._arg, ','),
 
     hash: $ => prec(1, seq('{', optional($._hash_items), '}')),
     _hash_items: $ => seq($.pair, optional(seq(',', optional($._hash_items)))),

--- a/grammar.js
+++ b/grammar.js
@@ -50,7 +50,10 @@ module.exports = grammar({
     _statements: $ => sepTrailing($._statements, $._statement, $._terminator),
 
     _statement: $ => choice(
-      $._declaration,
+      $.method_declaration,
+      $.class_declaration,
+      $.singleton_class_declaration,
+      $.module_declaration,
       $.undef,
       $.alias,
       $.while_statement,
@@ -66,13 +69,6 @@ module.exports = grammar({
       $.until_modifier,
       $.rescue_modifier,
       expression($)
-    ),
-
-    _declaration: $ => choice(
-      $.method_declaration,
-      $.class_declaration,
-      $.singleton_class_declaration,
-      $.module_declaration
     ),
 
     method_declaration: $ => seq(

--- a/grammar.js
+++ b/grammar.js
@@ -118,18 +118,18 @@ module.exports = grammar({
       'end'
     ),
 
-    super: $ => prec.right(seq('super', optional($.argument_list))),
-    return: $ => prec.right(seq('return', optional($.argument_list))),
-    yield: $ => prec.right(seq('yield', optional($.argument_list))),
-    break: $ => prec.right(seq('break', optional($.argument_list))),
-    next: $ => prec.right(seq('next', optional($.argument_list))),
+    super: $ => prec.left(seq('super', optional($.argument_list))),
+    return: $ => prec.left(seq('return', optional($.argument_list))),
+    yield: $ => prec.left(seq('yield', optional($.argument_list))),
+    break: $ => prec.left(seq('break', optional($.argument_list))),
+    next: $ => prec.left(seq('next', optional($.argument_list))),
     redo: $ => 'redo',
     retry: $ => 'retry',
 
-    if_modifier: $ => seq($._statement, 'if', $._arg),
-    unless_modifier: $ => seq($._statement, 'unless', $._arg),
-    while_modifier: $ => seq($._statement, 'while', $._arg),
-    until_modifier: $ => seq($._statement, 'until', $._arg),
+    if_modifier: $ => prec(PREC.RESCUE, seq($._statement, 'if', $._arg)),
+    unless_modifier: $ => prec(PREC.RESCUE, seq($._statement, 'unless', $._arg)),
+    while_modifier: $ => prec(PREC.RESCUE, seq($._statement, 'while', $._arg)),
+    until_modifier: $ => prec(PREC.RESCUE, seq($._statement, 'until', $._arg)),
     rescue_modifier: $ => prec(PREC.RESCUE, seq($._statement, 'rescue', $._arg)),
 
     while: $ => seq('while', $._arg, $._do, optional($._statements), 'end'),
@@ -293,10 +293,10 @@ module.exports = grammar({
       seq($._argument_list, optional($.block_argument))
     )),
 
-    _argument_list: $ => prec.left(1, commaSep1(choice(
+    _argument_list: $ => prec.left(1, sepTrailing($._argument_list, choice(
       $._arg,
       $.argument_pair
-    ))),
+    ), ',')),
 
     argument_pair: $ => prec.left(1, seq(choice(
       seq($.symbol, '=>'),

--- a/grammar.js
+++ b/grammar.js
@@ -316,12 +316,7 @@ module.exports = grammar({
     do_block: $ => $._do_block,
     _do_block: $ => seq(
       'do',
-      optional(seq(
-        '|',
-        optional($.formal_parameters),
-        optional(seq(';', sep1($._identifier, ','))), // Block shadow args e.g. {|; a, b| ...}
-        '|')
-      ),
+      optional($._block_parameters),
       optional($._statements),
       'end'
     ),
@@ -329,12 +324,7 @@ module.exports = grammar({
     block: $ => $._block,
     _block: $ => seq(
       '{',
-      optional(seq(
-        '|',
-        optional($.formal_parameters),
-        optional(seq(';', sep1($._identifier, ','))), // Block shadow args e.g. {|; a, b| ...}
-        '|')
-      ),
+      optional($._block_parameters),
       optional($._statements),
       '}'
     ),
@@ -346,6 +336,13 @@ module.exports = grammar({
     assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, '=', expression($))),
     math_assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, choice('+=', '-=', '*=', '**=', '/='), expression($))),
     conditional_assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, choice('||=', '&&='), expression($))),
+    _block_parameters: $ => seq(
+      '|',
+      optional($.formal_parameters),
+      optional(seq(';', sep1($._identifier, ','))), // Block shadow args e.g. {|; a, b| ...}
+      '|'
+    ),
+
 
     conditional: $ => prec.right(PREC.CONDITIONAL, seq(expression($), '?', expression($), ':', expression($))),
     range: $ => prec.right(PREC.RANGE, seq(expression($), choice('..', '...'), expression($))),

--- a/grammar.js
+++ b/grammar.js
@@ -44,9 +44,9 @@ module.exports = grammar({
   ],
 
   conflicts: $ => [
-    [$._lhs, $.function_call, $.function_call_with_do_block],
-    [$._lhs, $.function_call],
-    [$._lhs, $.function_call_with_do_block]
+    [$._lhs, $.method_call, $.method_call_with_do_block],
+    [$._lhs, $.method_call],
+    [$._lhs, $.method_call_with_do_block]
   ],
 
   rules: {
@@ -257,21 +257,20 @@ module.exports = grammar({
       $.retry
     ),
 
-    scope_resolution_expression: $ => prec.left(1, seq(optional($._primary), '::', $._identifier)),
     element_reference: $ => prec.left(1, seq($._primary, "[", $._argument_list, "]")),
-    // TODO: Needs a new name
-    member_access: $ => prec.left(PREC.BITWISE_AND + 1, seq($._primary, choice(".", "&."), $._identifier)),
+    scope_resolution: $ => prec.left(1, seq(optional($._primary), '::', $._identifier)),
+    call: $ => prec.left(PREC.BITWISE_AND + 1, seq($._primary, choice(".", "&."), $._identifier)),
 
-    function_call_with_do_block: $ => prec.left(seq(
-      choice($._variable, $.scope_resolution_expression, $.member_access),
+    method_call_with_do_block: $ => prec.left(seq(
+      choice($._variable, $.scope_resolution, $.call),
       choice(
         seq($.argument_list, $.do_block),
         $.do_block
       )
     )),
 
-    function_call: $ => prec.left(seq(
-      choice($._variable, $.scope_resolution_expression, $.member_access),
+    method_call: $ => prec.left(seq(
+      choice($._variable, $.scope_resolution, $.call),
       choice(
         seq($.argument_list, $.block),
         $.argument_list,
@@ -355,10 +354,10 @@ module.exports = grammar({
 
     _lhs: $ => choice(
       $._variable,
-      $.scope_resolution_expression,
+      $.scope_resolution,
       $.element_reference,
-      $.member_access,
-      $.function_call
+      $.call,
+      $.method_call
     ),
     _variable: $ => choice(
       $._identifier,
@@ -591,7 +590,7 @@ function regexBody (open, close, interpolation, self) {
 function expression ($) {
   return choice(
     $._arg,
-    $.function_call_with_do_block
+    $.method_call_with_do_block
   )
 }
 

--- a/grammar.js
+++ b/grammar.js
@@ -72,7 +72,7 @@ module.exports = grammar({
         choice($._variable, seq('(', $._arg, ')')),
         choice('.', '::')
       )),
-      $._function_name,
+      $._method_name,
       choice(
         seq('(', optional($.formal_parameters), ')'),
         seq(optional($.formal_parameters), $._terminator)
@@ -383,10 +383,10 @@ module.exports = grammar({
       $.constant
     ),
 
-    _function_name: $ => choice($._identifier, $.symbol, $.operator),
-    _undef_list: $ => choice($._function_name, prec(1, seq($._undef_list, ',', $._function_name))),
-    undef: $ => seq("undef", $._undef_list),
-    alias: $ => seq("alias", $._function_name, $._function_name),
+    _method_name: $ => choice($._identifier, $.symbol, $.operator),
+    _undef_list: $ => choice($._method_name, prec(1, seq($._undef_list, ',', $._method_name))),
+    undef: $ => seq('undef', $._undef_list),
+    alias: $ => seq('alias', $._method_name, $._method_name),
 
     comment: $ => token(prec(PREC.COMMENT, choice(
       seq('#', /.*/),
@@ -449,7 +449,7 @@ module.exports = grammar({
     ),
 
     array: $ => choice(
-      seq('[', $._array_function_names, ']'),
+      seq('[', $._array_items, ']'),
       seq(/%[wi]/, choice(
         $._uninterpolated_paren
       )),
@@ -458,10 +458,10 @@ module.exports = grammar({
       ))
     ),
 
-    _array_function_names: $ => optional(seq(expression($), optional(seq(',', $._array_function_names)))),
+    _array_items: $ => optional(seq(expression($), optional(seq(',', $._array_items)))),
 
-    hash: $ => prec(1, seq('{', optional($._hash_function_names), '}')),
-    _hash_function_names: $ => seq($.pair, optional(seq(',', optional($._hash_function_names)))),
+    hash: $ => prec(1, seq('{', optional($._hash_items), '}')),
+    _hash_items: $ => seq($.pair, optional(seq(',', optional($._hash_items)))),
 
     pair: $ => prec(-1, seq(choice(
       seq(expression($), '=>'),

--- a/grammar.js
+++ b/grammar.js
@@ -76,7 +76,7 @@ module.exports = grammar({
         seq('(', optional($.formal_parameters), ')'),
         seq(optional($.formal_parameters), $._terminator)
       ),
-      bodyStatement($),
+      optional($._body_statement),
       'end'
     ),
 
@@ -100,7 +100,7 @@ module.exports = grammar({
       'class',
       sep1($._identifier, '::'),
       optional(seq('<', sep1($._identifier, '::'), $._terminator)),
-      bodyStatement($),
+      optional($._body_statement),
       'end'
     ),
 
@@ -109,7 +109,7 @@ module.exports = grammar({
       '<<',
       $._identifier,
       $._terminator,
-      bodyStatement($),
+      optional($._body_statement),
       'end'
     ),
 
@@ -117,7 +117,7 @@ module.exports = grammar({
       'module',
       sep1($._identifier, '::'),
       $._terminator,
-      bodyStatement($),
+      optional($._body_statement),
       'end'
     ),
 
@@ -186,7 +186,7 @@ module.exports = grammar({
       $.elsif
     ),
 
-    begin: $ => seq('begin', bodyStatement($), 'end'),
+    begin: $ => seq('begin', optional($._body_statement), 'end'),
     ensure: $ => seq('ensure', optional($._statements)),
     rescue: $ => seq(
       'rescue',
@@ -198,6 +198,25 @@ module.exports = grammar({
     ),
     rescue_arguments: $ => commaSep1($._arg),
     rescued_exception: $ => (identifierPattern),
+
+    _body_statement: $ => choice(
+      seq(
+        $._statements,
+        optional($.rescue),
+        optional($.else),
+        optional($.ensure)
+      ),
+      seq(
+        $.rescue,
+        optional($.else),
+        optional($.ensure)
+      ),
+      seq(
+        $.else,
+        optional($.ensure)
+      ),
+      $.ensure
+    ),
 
     _arg: $ => choice(
       $._primary,
@@ -588,15 +607,6 @@ function expression ($) {
   return choice(
     $._arg,
     $.method_call_with_do_block
-  )
-}
-
-function bodyStatement($) {
-  return seq(
-    optional($._statements),
-    optional($.rescue),
-    optional($.else),
-    optional($.ensure)
   )
 }
 

--- a/grammar.js
+++ b/grammar.js
@@ -155,7 +155,7 @@ module.exports = grammar({
       optional($._statements),
       choice(optional($.else), $.when)
     ),
-    pattern: $ => $._statement,
+    pattern: $ => $._arg,
 
     if: $ => seq(
       'if',

--- a/grammar.js
+++ b/grammar.js
@@ -259,9 +259,8 @@ module.exports = grammar({
 
     scope_resolution_expression: $ => prec.left(1, seq(optional($._primary), '::', $._identifier)),
     element_reference: $ => prec.left(1, seq($._primary, "[", $._argument_list, "]")),
-
-    // TODO: Needs a new name. send? but then you'd want to include args
-    member_access: $ => prec.left(1, seq($._primary, ".", $._identifier)),
+    // TODO: Needs a new name
+    member_access: $ => prec.left(PREC.BITWISE_AND + 1, seq($._primary, choice(".", "&."), $._identifier)),
 
     function_call_with_do_block: $ => prec.left(seq(
       choice($._variable, $.scope_resolution_expression, $.member_access),
@@ -299,18 +298,28 @@ module.exports = grammar({
 
     do_block: $ => $._do_block,
     _do_block: $ => seq(
-      "do",
-      optional(seq("|", optional($.formal_parameters), "|")),
+      'do',
+      optional(seq(
+        '|',
+        optional($.formal_parameters),
+        optional(seq(';', sep1($._identifier, ','))), // Block shadow args e.g. {|; a, b| ...}
+        '|')
+      ),
       optional($._statements),
-      "end"
+      'end'
     ),
 
     block: $ => $._block,
     _block: $ => seq(
-      "{",
-      optional(seq("|", optional($.formal_parameters), "|")),
+      '{',
+      optional(seq(
+        '|',
+        optional($.formal_parameters),
+        optional(seq(';', sep1($._identifier, ','))), // Block shadow args e.g. {|; a, b| ...}
+        '|')
+      ),
       optional($._statements),
-      "}"
+      '}'
     ),
 
     and: $ => prec.left(PREC.AND, seq(expression($), "and", expression($))),

--- a/grammar.js
+++ b/grammar.js
@@ -25,7 +25,6 @@ const PREC = {
 };
 
 const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*(\?|\!)?/;
-const constantPattern = /[A-Z_][a-zA-Z0-9_]*/; // (e.g. FOO)
 // Global variables start with $ and can be:
 // - Regex back references (e.g. $&, $', $', and $+)
 // - Number global references (e.g. $1)
@@ -372,15 +371,13 @@ module.exports = grammar({
     instance_variable: $ => (instanceVariablePattern),
     class_variable: $ => (classVariablePattern),
     global_variable: $ => (globalVariablePattern),
-    constant: $ => (constantPattern),
     identifier: $ => (identifierPattern),
     operator: $ => choice(...operators),
     _identifier: $ => choice(
       $.instance_variable,
       $.class_variable,
       $.global_variable,
-      $.identifier,
-      $.constant
+      $.identifier
     ),
 
     _method_name: $ => choice($._identifier, $.symbol, $.operator),

--- a/grammar.js
+++ b/grammar.js
@@ -130,11 +130,11 @@ module.exports = grammar({
     redo: $ => 'redo',
     retry: $ => 'retry',
 
-    if_modifier: $ => seq($._statement, "if", expression($)),
-    unless_modifier: $ => seq($._statement, "unless", expression($)),
-    while_modifier: $ => seq($._statement, "while", expression($)),
-    until_modifier: $ => seq($._statement, "until", expression($)),
-    rescue_modifier: $ => prec(PREC.RESCUE, seq($._statement, "rescue", expression($))),
+    if_modifier: $ => seq($._statement, 'if', expression($)),
+    unless_modifier: $ => seq($._statement, 'unless', expression($)),
+    while_modifier: $ => seq($._statement, 'while', expression($)),
+    until_modifier: $ => seq($._statement, 'until', expression($)),
+    rescue_modifier: $ => prec(PREC.RESCUE, seq($._statement, 'rescue', expression($))),
 
     while: $ => seq('while', expression($), $._do, optional($._statements), 'end'),
     until: $ => seq('until', expression($), $._do, optional($._statements), 'end'),
@@ -227,7 +227,7 @@ module.exports = grammar({
     ),
 
     _primary: $ => choice(
-      seq("(", optional($._statements), ")"),
+      seq('(', optional($._statements), ')'),
       $._lhs,
       $.array,
       $.hash,
@@ -257,9 +257,9 @@ module.exports = grammar({
       $.retry
     ),
 
-    element_reference: $ => prec.left(1, seq($._primary, "[", $._argument_list, "]")),
+    element_reference: $ => prec.left(1, seq($._primary, '[', $._argument_list, ']')),
     scope_resolution: $ => prec.left(1, seq(optional($._primary), '::', $._identifier)),
-    call: $ => prec.left(PREC.BITWISE_AND + 1, seq($._primary, choice(".", "&."), $._identifier)),
+    call: $ => prec.left(PREC.BITWISE_AND + 1, seq($._primary, choice('.', '&.'), $._identifier)),
 
     method_call_with_do_block: $ => prec.left(seq(
       choice($._variable, $.scope_resolution, $.call),
@@ -279,7 +279,7 @@ module.exports = grammar({
     )),
 
     argument_list: $ => prec.left(1, choice(
-      seq("(", optional($._argument_list), optional($.block_argument), ")"),
+      seq('(', optional($._argument_list), optional($.block_argument), ')'),
       seq($._argument_list, optional($.block_argument))
     )),
 
@@ -293,7 +293,7 @@ module.exports = grammar({
       seq($._identifier, ':')
     ), $._arg)),
 
-    block_argument: $ => seq("&", $._arg),
+    block_argument: $ => seq('&', $._arg),
 
     do_block: $ => $._do_block,
     _do_block: $ => seq(
@@ -321,10 +321,10 @@ module.exports = grammar({
       '}'
     ),
 
-    and: $ => prec.left(PREC.AND, seq(expression($), "and", expression($))),
-    or: $ => prec.left(PREC.OR, seq(expression($), "or", expression($))),
-    not: $ => prec.right(PREC.NOT, seq("not", expression($))),
-    defined: $ => prec(PREC.DEFINED, seq("defined?", expression($))),
+    and: $ => prec.left(PREC.AND, seq(expression($), 'and', expression($))),
+    or: $ => prec.left(PREC.OR, seq(expression($), 'or', expression($))),
+    not: $ => prec.right(PREC.NOT, seq('not', expression($))),
+    defined: $ => prec(PREC.DEFINED, seq('defined?', expression($))),
     assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, '=', expression($))),
     math_assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, choice('+=', '-=', '*=', '**=', '/='), expression($))),
     conditional_assignment: $ => prec.right(PREC.ASSIGN, seq($._lhs, choice('||=', '&&='), expression($))),
@@ -487,8 +487,8 @@ module.exports = grammar({
           // $._formal_parameter
         )),
         choice(
-          seq("{", optional($._statements), "}"),
-          seq("do", optional($._statements), "end")
+          seq('{', optional($._statements), '}'),
+          seq('do', optional($._statements), 'end')
         )
       ),
       seq('lambda', choice($._block, $._do_block))

--- a/grammar.js
+++ b/grammar.js
@@ -22,7 +22,6 @@ const PREC = {
   EXPONENTIAL: 80,
   COMPLEMENT: 85,
   UNARY_PLUS: 85,
-  REGEX: 100
 };
 
 const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*(\?|\!)?/;
@@ -383,7 +382,7 @@ module.exports = grammar({
       seq($.identifier, ':')
     ), expression($))),
 
-    regex: $ => prec(PREC.REGEX, choice(
+    regex: $ => choice(
       regexBody('/', '/', $.interpolation),
       seq('%r', choice(
         $._regex_interpolated_paren

--- a/grammar.js
+++ b/grammar.js
@@ -412,7 +412,13 @@ module.exports = grammar({
     ))),
 
     symbol: $ => choice(
-      token(seq(':', choice(identifierPattern, choice.apply(null, operators)))),
+      token(seq(':', choice(
+        identifierPattern,
+        instanceVariablePattern,
+        classVariablePattern,
+        globalVariablePattern,
+        ...operators
+      ))),
       seq(":'", $._single_quoted_continuation),
       seq(':"', $._double_quoted_continuation),
       seq('%s', choice(

--- a/grammar.js
+++ b/grammar.js
@@ -194,12 +194,23 @@ module.exports = grammar({
       $.unary_minus,
       $.exponential,
       $.complement,
-      $._literal
+      $.symbol,
+      $.integer,
+      $.float,
+      $.boolean,
+      $.nil,
+      $.string,
+      $.subshell,
+      $.hash,
+      $.regex,
+      $.lambda_literal,
+      $.lambda_expression
     ),
 
     _primary: $ => choice(
       seq("(", optional($._statements), ")"),
-      $._lhs
+      $._lhs,
+      $.array
     ),
 
     scope_resolution_expression: $ => prec.left(1, seq(optional($._primary), '::', $.identifier)),
@@ -318,21 +329,6 @@ module.exports = grammar({
         '=end\n'
       )
     ))),
-
-    _literal: $ => choice(
-      $.symbol,
-      $.integer,
-      $.float,
-      $.boolean,
-      $.nil,
-      $.string,
-      $.subshell,
-      $.array,
-      $.hash,
-      $.regex,
-      $.lambda_literal,
-      $.lambda_expression
-    ),
 
     symbol: $ => choice(
       token(seq(':', choice(identifierPattern, choice.apply(null, operators)))),

--- a/grammar.js
+++ b/grammar.js
@@ -56,9 +56,6 @@ module.exports = grammar({
     _statements: $ => sepTrailing($._statements, $._statement, $._terminator),
 
     _statement: $ => choice(
-      $.class_declaration,
-      $.singleton_class_declaration,
-      $.module_declaration,
       $.undef,
       $.alias,
       $.if_modifier,
@@ -94,17 +91,36 @@ module.exports = grammar({
       $.optional_parameter
     ),
 
-    splat_parameter: $ => seq("*", optional($._identifier)),
-    hash_splat_parameter: $ => seq("**", optional($._identifier)),
-    block_parameter: $ => seq("&", $._identifier),
-    keyword_parameter: $ => seq($._identifier, ":", optional($._simple_expression)),
-    optional_parameter: $ => seq($._identifier, "=", $._simple_expression),
+    splat_parameter: $ => seq('*', optional($._identifier)),
+    hash_splat_parameter: $ => seq('**', optional($._identifier)),
+    block_parameter: $ => seq('&', $._identifier),
+    keyword_parameter: $ => seq($._identifier, ':', optional($._simple_expression)),
+    optional_parameter: $ => seq($._identifier, '=', $._simple_expression),
 
-    class_declaration: $ => seq("class", $._identifier, optional(seq("<", sep1($._identifier, "::"))), $._terminator, optional($._statements), "end"),
+    class: $ => seq(
+      'class',
+      sep1($._identifier, '::'),
+      optional(seq('<', sep1($._identifier, '::'), $._terminator)),
+      bodyStatement($),
+      'end'
+    ),
 
-    singleton_class_declaration: $ => seq("class", "<<", $._identifier, $._terminator, optional($._statements), "end"),
+    singleton_class: $ => seq(
+      'class',
+      '<<',
+      $._identifier,
+      $._terminator,
+      bodyStatement($),
+      'end'
+    ),
 
-    module_declaration: $ => seq("module", $._identifier, $._terminator, optional($._statements), "end"),
+    module: $ => seq(
+      'module',
+      sep1($._identifier, '::'),
+      $._terminator,
+      bodyStatement($),
+      'end'
+    ),
 
     return: $ => prec.right(seq('return', optional($.argument_list))),
     yield: $ => prec.right(seq('yield', optional($.argument_list))),
@@ -219,6 +235,9 @@ module.exports = grammar({
       $.lambda,
       $.array,
       $.method,
+      $.class,
+      $.singleton_class,
+      $.module,
       $.begin,
       $.while,
       $.until,

--- a/grammar.js
+++ b/grammar.js
@@ -79,14 +79,15 @@ module.exports = grammar({
       "end"
     ),
 
-    formal_parameters: $ => commaSep1(choice(
+    formal_parameters: $ => commaSep1($._formal_parameter),
+    _formal_parameter: $ => choice(
       $.identifier,
       $.splat_parameter,
       $.hash_splat_parameter,
       $.block_parameter,
       $.keyword_parameter,
       $.optional_parameter
-    )),
+    ),
 
     splat_parameter: $ => seq("*", optional($.identifier)),
     hash_splat_parameter: $ => seq("**", optional($.identifier)),
@@ -192,14 +193,13 @@ module.exports = grammar({
       $.string,
       $.subshell,
       $.hash,
-      $.regex,
-      $.lambda_literal,
-      $.lambda_expression
+      $.regex
     ),
 
     _primary: $ => choice(
       seq("(", optional($._statements), ")"),
       $._lhs,
+      $.lambda,
       $.array
     ),
 
@@ -387,25 +387,25 @@ module.exports = grammar({
       seq('%r', choice(
         $._regex_interpolated_paren
       ))
-    )),
+    ),
 
     _regex_interpolated_paren: $ => regexBody('(', ')', $.interpolation, $._regex_interpolated_paren),
 
-    lambda_literal: $ => seq(
-      '->',
-      optional(choice(
-        seq('(', optional($.formal_parameters), ')'),
-        $.identifier
-      )),
-      choice($._lambda_block, $._lambda_do_block)
-    ),
-
-    _lambda_block: $ => seq("{", optional($._statements), "}"),
-    _lambda_do_block: $ => seq("do", optional($._statements), "end"),
-
-    lambda_expression: $ => seq(
-      'lambda',
-      choice($._block, $._do_block)
+    lambda: $ => choice(
+      seq(
+        '->',
+        optional(choice(
+          seq('(', optional($.formal_parameters), ')'),
+          $.identifier
+          // TODO: can be any single formal_parameter
+          // $._formal_parameter
+        )),
+        choice(
+          seq("{", optional($._statements), "}"),
+          seq("do", optional($._statements), "end")
+        )
+      ),
+      seq('lambda', choice($._block, $._do_block))
     ),
 
     _function_name: $ => choice($.identifier, choice(...operators)),

--- a/grammar.js
+++ b/grammar.js
@@ -56,7 +56,6 @@ module.exports = grammar({
     _statements: $ => sepTrailing($._statements, $._statement, $._terminator),
 
     _statement: $ => choice(
-      $.method_declaration,
       $.class_declaration,
       $.singleton_class_declaration,
       $.module_declaration,
@@ -70,13 +69,19 @@ module.exports = grammar({
       expression($)
     ),
 
-    method_declaration: $ => seq(
-      "def",
-      optional(seq($._identifier,'.')),
+    method: $ => seq(
+      'def',
+      optional(seq(
+        choice($._variable, seq('(', $._simple_expression, ')')),
+        choice('.', '::')
+      )),
       $._function_name,
-      choice(seq("(", optional($.formal_parameters), ")"), seq(optional($.formal_parameters), $._terminator)),
-      optional($._statements),
-      "end"
+      choice(
+        seq('(', optional($.formal_parameters), ')'),
+        seq(optional($.formal_parameters), $._terminator)
+      ),
+      bodyStatement($),
+      'end'
     ),
 
     formal_parameters: $ => commaSep1($._formal_parameter),
@@ -213,6 +218,7 @@ module.exports = grammar({
       $._lhs,
       $.lambda,
       $.array,
+      $.method,
       $.begin,
       $.while,
       $.until,

--- a/grammar.js
+++ b/grammar.js
@@ -491,9 +491,7 @@ module.exports = grammar({
         '->',
         optional(choice(
           seq('(', optional($.formal_parameters), ')'),
-          $._identifier
-          // TODO: can be any single formal_parameter
-          // $._formal_parameter
+          $._formal_parameter
         )),
         choice(
           seq('{', optional($._statements), '}'),

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -7,7 +7,7 @@ end
 
 ---
 
-(program (while_statement (identifier)))
+(program (while (identifier)))
 
 ================
 while without do
@@ -18,7 +18,7 @@ end
 
 ---
 
-(program (while_statement (identifier)))
+(program (while (identifier)))
 
 =========================
 while statement with body
@@ -30,7 +30,7 @@ end
 
 ---
 
-(program (while_statement (identifier) (identifier)))
+(program (while (identifier) (identifier)))
 
 =====================
 empty until statement
@@ -41,7 +41,7 @@ end
 
 ---
 
-(program (until_statement (identifier)))
+(program (until (identifier)))
 
 =========================
 until statement with body
@@ -53,7 +53,7 @@ end
 
 ---
 
-(program (until_statement (identifier) (identifier)))
+(program (until (identifier) (identifier)))
 
 ==================
 empty if statement
@@ -64,7 +64,7 @@ end
 
 ---
 
-(program (if_statement (identifier)))
+(program (if (identifier)))
 
 =======================
 empty if/else statement
@@ -76,7 +76,7 @@ end
 
 ---
 
-(program (if_statement (identifier) (else_block)))
+(program (if (identifier) (else)))
 
 ==================================
 single-line if then else statement
@@ -86,7 +86,7 @@ if foo then bar else quux end
 
 ---
 
-(program (if_statement (identifier) (identifier) (else_block (identifier))))
+(program (if (identifier) (identifier) (else (identifier))))
 
 ========
 if elsif
@@ -101,8 +101,8 @@ end
 ---
 
 (program
-  (if_statement (identifier) (identifier)
-  (elsif_block (identifier) (identifier))))
+  (if (identifier) (identifier)
+  (elsif (identifier) (identifier))))
 
 =============
 if elsif else
@@ -119,9 +119,9 @@ end
 ---
 
 (program
-  (if_statement (identifier) (identifier)
-  (elsif_block (identifier) (identifier))
-  (else_block (identifier))))
+  (if (identifier) (identifier)
+    (elsif (identifier) (identifier)
+      (else (identifier)))))
 
 ======================
 empty unless statement
@@ -132,7 +132,7 @@ end
 
 ---
 
-(program (unless_statement (identifier)))
+(program (unless (identifier)))
 
 ================================
 empty unless statement with then
@@ -143,7 +143,7 @@ end
 
 ---
 
-(program (unless_statement (identifier)))
+(program (unless (identifier)))
 
 ================================
 empty unless statement with else
@@ -155,7 +155,7 @@ end
 
 ---
 
-(program (unless_statement (identifier) (else_block)))
+(program (unless (identifier) (else)))
 
 ===
 for
@@ -167,7 +167,7 @@ end
 
 ---
 
-(program (for_statement (identifier) (identifier) (identifier)))
+(program (for (identifier) (identifier) (identifier)))
 
 ==============
 for without do
@@ -179,7 +179,7 @@ end
 
 ---
 
-(program (for_statement (identifier) (identifier) (identifier)))
+(program (for (identifier) (identifier) (identifier)))
 
 ===========
 empty begin
@@ -190,7 +190,7 @@ end
 
 ---
 
-(program (begin_statement))
+(program (begin))
 
 ===============
 begin with body
@@ -202,7 +202,7 @@ end
 
 ---
 
-(program (begin_statement (identifier)))
+(program (begin (identifier)))
 
 ===============
 begin with else
@@ -217,8 +217,8 @@ end
 ---
 
 (program
-  (begin_statement (identifier)
-    (else_block (identifier))))
+  (begin (identifier)
+    (else (identifier))))
 
 ===============
 begin with ensure
@@ -233,8 +233,8 @@ end
 ---
 
 (program
-  (begin_statement (identifier)
-    (ensure_block (identifier))))
+  (begin (identifier)
+    (ensure (identifier))))
 
 =======================
 begin with empty rescue
@@ -257,9 +257,9 @@ end
 ---
 
 (program
-  (begin_statement (rescue_block))
-  (begin_statement (rescue_block))
-  (begin_statement (rescue_block (identifier))))
+  (begin (rescue))
+  (begin (rescue))
+  (begin (rescue (identifier))))
 
 ===========================
 begin with rescue with args
@@ -300,13 +300,13 @@ end
 ---
 
 (program
-  (begin_statement (rescue_block (rescue_arguments (identifier))))
-  (begin_statement (rescue_block (rescue_arguments (identifier))))
-  (begin_statement (rescue_block (rescue_arguments (identifier)) (identifier)))
-  (begin_statement (rescue_block (rescued_exception) (identifier)))
-  (begin_statement (rescue_block (rescue_arguments (identifier) (identifier)) (identifier)))
-  (begin_statement (rescue_block (rescue_arguments (identifier)) (rescued_exception)))
-  (begin_statement (rescue_block (rescue_arguments (identifier)) (rescued_exception) (identifier))))
+  (begin (rescue (rescue_arguments (identifier))))
+  (begin (rescue (rescue_arguments (identifier))))
+  (begin (rescue (rescue_arguments (identifier)) (identifier)))
+  (begin (rescue (rescued_exception) (identifier)))
+  (begin (rescue (rescue_arguments (identifier) (identifier)) (identifier)))
+  (begin (rescue (rescue_arguments (identifier)) (rescued_exception)))
+  (begin (rescue (rescue_arguments (identifier)) (rescued_exception) (identifier))))
 
 =================
 rescue modifier
@@ -335,10 +335,10 @@ end
 ---
 
 (program
-  (begin_statement (identifier)
-    (rescue_block (rescue_arguments (identifier)) (identifier))
-    (else_block (identifier))
-    (ensure_block (identifier))))
+  (begin (identifier)
+    (rescue (rescue_arguments (identifier)) (identifier))
+    (else (identifier))
+    (ensure (identifier))))
 
 ======
 return
@@ -371,8 +371,8 @@ end
 ---
 
 (program
-  (case_expression (identifier)
-  (when_block (pattern (identifier)))))
+  (case (identifier)
+  (when (pattern (identifier)))))
 
 ==============
 case with else
@@ -386,9 +386,9 @@ end
 ---
 
 (program
-  (case_expression (identifier)
-    (when_block (pattern (identifier)))
-    (else_block)))
+  (case (identifier)
+    (when (pattern (identifier))
+      (else))))
 
 ==============================
 case with multiple when blocks
@@ -406,10 +406,10 @@ end
 ---
 
 (program
-  (case_expression (identifier)
-    (when_block (pattern (identifier)) (identifier))
-    (when_block (pattern (identifier)) (identifier))
-    (else_block (identifier))))
+  (case (identifier)
+    (when (pattern (identifier)) (identifier)
+      (when (pattern (identifier)) (identifier)
+        (else (identifier))))))
 
 ==============
 case with assignment
@@ -422,7 +422,10 @@ end
 
 ---
 
-(program (assignment (identifier) (case_expression (identifier) (when_block (pattern (identifier))) (else_block))))
+(program (assignment (identifier)
+  (case (identifier)
+    (when (pattern (identifier))
+      (else)))))
 
 ==============
 case with expression
@@ -435,4 +438,7 @@ end
 
 ---
 
-(program (assignment (identifier) (case_expression (assignment (identifier) (bitwise_or (identifier) (identifier))) (when_block (pattern (identifier))) (else_block))))
+(program (assignment (identifier)
+  (case (assignment (identifier) (bitwise_or (identifier) (identifier)))
+    (when (pattern (identifier))
+      (else)))))

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -181,6 +181,54 @@ end
 
 (program (for (identifier) (identifier) (identifier)))
 
+==============
+next
+==============
+
+for x in y
+  next
+end
+
+---
+
+(program (for (identifier) (identifier) (next)))
+
+==============
+retry
+==============
+
+for x in y
+  retry
+end
+
+---
+
+(program (for (identifier) (identifier) (retry)))
+
+==============
+break
+==============
+
+while b
+  break
+end
+
+---
+
+(program (while (identifier) (break)))
+
+==============
+redo
+==============
+
+while b
+  redo
+end
+
+---
+
+(program (while (identifier) (redo)))
+
 ===========
 empty begin
 ===========
@@ -325,7 +373,7 @@ begin with all the trimmings
 begin
 	foo
 rescue x
-  bar
+  retry
 else
 	quux
 ensure
@@ -336,7 +384,7 @@ end
 
 (program
   (begin (identifier)
-    (rescue (rescue_arguments (identifier)) (identifier))
+    (rescue (rescue_arguments (identifier)) (retry))
     (else (identifier))
     (ensure (identifier))))
 

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -348,7 +348,7 @@ return foo
 
 ---
 
-(program (return_statement (identifier)))
+(program (return (argument_list (identifier))))
 
 ====================
 return without value
@@ -358,7 +358,7 @@ return
 
 ---
 
-(program (return_statement))
+(program (return))
 
 ====
 case

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -217,7 +217,7 @@ end
 
 ---
 
-(program (class_declaration (identifier)))
+(program (class (identifier)))
 
 ==============
 empty subclass
@@ -228,7 +228,7 @@ end
 
 ---
 
-(program (class_declaration (identifier) (identifier)))
+(program (class (identifier) (identifier)))
 
 ==================================
 empty subclass of namespaced class
@@ -239,7 +239,7 @@ end
 
 ---
 
-(program (class_declaration (identifier) (identifier) (identifier)))
+(program (class (identifier) (identifier) (identifier)))
 
 ===============
 class with body
@@ -252,7 +252,7 @@ end
 
 ---
 
-(program (class_declaration (identifier) (method (identifier))))
+(program (class (identifier) (method (identifier))))
 
 ===============
 singleton class
@@ -267,8 +267,8 @@ end
 ---
 
 (program
-  (singleton_class_declaration (identifier))
-  (singleton_class_declaration (identifier)))
+  (singleton_class (identifier))
+  (singleton_class (identifier)))
 
 
 ============
@@ -280,7 +280,7 @@ end
 
 ---
 
-(program (module_declaration (identifier)))
+(program (module (identifier)))
 
 ================
 module with body
@@ -293,7 +293,7 @@ end
 
 ---
 
-(program (module_declaration (identifier) (method (identifier))))
+(program (module (identifier) (method (identifier))))
 
 =======
 __END__
@@ -329,8 +329,8 @@ end
 
 ---
 
-(program (module_declaration (identifier)
-  (class_declaration (identifier) (identifier)
+(program (module (identifier)
+  (class (identifier) (identifier)
     (function_call (identifier) (argument_list
       (member_access
         (member_access

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -343,14 +343,14 @@ end
 
 (program (module (identifier)
   (class (identifier) (identifier)
-    (function_call (identifier) (argument_list
-      (member_access
-        (member_access
-          (scope_resolution_expression (identifier) (identifier))
+    (method_call (identifier) (argument_list
+      (call
+        (call
+          (scope_resolution (identifier) (identifier))
           (identifier))
         (identifier))))
 
-    (function_call (identifier) (argument_list (symbol)))
+    (method_call (identifier) (argument_list (symbol)))
 
     (comment)
     (method (identifier) (identifier))

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -31,6 +31,18 @@ end
 (program (method (identifier) (identifier)))
 
 ================
+method with call to super
+================
+
+def foo
+  super
+end
+
+---
+
+(program (method (identifier) (super)))
+
+================
 method with args
 ================
 

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -14,9 +14,9 @@ end
 ---
 
 (program
-  (method_declaration (identifier))
-  (method_declaration (identifier))
-  (method_declaration (identifier)))
+  (method (identifier))
+  (method (identifier))
+  (method (identifier)))
 
 ================
 method with body
@@ -28,7 +28,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier)))
+(program (method (identifier) (identifier)))
 
 ================
 method with args
@@ -39,7 +39,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (formal_parameters (identifier))))
+(program (method (identifier) (formal_parameters (identifier))))
 
 ================================
 method with unparenthesized args
@@ -50,7 +50,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (formal_parameters (identifier))))
+(program (method (identifier) (formal_parameters (identifier))))
 
 =========================
 method with multiple args
@@ -61,7 +61,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (formal_parameters (identifier) (identifier))))
+(program (method (identifier) (formal_parameters (identifier) (identifier))))
 
 =========================================
 method with multiple unparenthesized args
@@ -72,7 +72,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (formal_parameters (identifier) (identifier))))
+(program (method (identifier) (formal_parameters (identifier) (identifier))))
 
 =========================================
 method with keyword parameters
@@ -84,7 +84,7 @@ end
 ---
 
 (program
-  (method_declaration (identifier)
+  (method (identifier)
     (formal_parameters
       (keyword_parameter (identifier) (nil))
       (keyword_parameter (identifier)))))
@@ -102,9 +102,9 @@ end
 ---
 
 (program
-  (method_declaration (identifier)
+  (method (identifier)
     (formal_parameters (optional_parameter (identifier) (nil))))
-  (method_declaration (identifier)
+  (method (identifier)
     (formal_parameters (optional_parameter (identifier) (nil)))))
 
 =========================================
@@ -132,12 +132,12 @@ end
 ---
 
 (program
-  (method_declaration (identifier) (formal_parameters (splat_parameter (identifier))))
-  (method_declaration (identifier) (formal_parameters (identifier) (splat_parameter (identifier))))
-  (method_declaration (identifier) (formal_parameters (identifier) (splat_parameter (identifier)) (identifier)))
-  (method_declaration (identifier) (formal_parameters (hash_splat_parameter (identifier))))
-  (method_declaration (identifier) (formal_parameters (keyword_parameter (identifier)) (hash_splat_parameter)))
-  (method_declaration (identifier) (formal_parameters (block_parameter (identifier)))))
+  (method (identifier) (formal_parameters (splat_parameter (identifier))))
+  (method (identifier) (formal_parameters (identifier) (splat_parameter (identifier))))
+  (method (identifier) (formal_parameters (identifier) (splat_parameter (identifier)) (identifier)))
+  (method (identifier) (formal_parameters (hash_splat_parameter (identifier))))
+  (method (identifier) (formal_parameters (keyword_parameter (identifier)) (hash_splat_parameter)))
+  (method (identifier) (formal_parameters (block_parameter (identifier)))))
 
 =========================================
 singleton method
@@ -148,7 +148,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier)))
+(program (method (self) (identifier)))
 
 =========================================
 singleton method with body
@@ -160,7 +160,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier) (identifier)))
+(program (method (self) (identifier) (identifier)))
 
 
 =========================================
@@ -172,7 +172,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier) (formal_parameters (identifier))))
+(program (method (self) (identifier) (formal_parameters (identifier))))
 
 =========================================
 singleton method with un-parenthesized arg
@@ -183,7 +183,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier) (formal_parameters (identifier))))
+(program (method (self) (identifier) (formal_parameters (identifier))))
 
 =========================================
 singleton method with args
@@ -194,7 +194,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier) (formal_parameters (identifier) (identifier))))
+(program (method (self) (identifier) (formal_parameters (identifier) (identifier))))
 
 
 =========================================
@@ -206,7 +206,7 @@ end
 
 ---
 
-(program (method_declaration (identifier) (identifier) (formal_parameters (identifier) (identifier))))
+(program (method (self) (identifier) (formal_parameters (identifier) (identifier))))
 
 ===========
 empty class
@@ -252,7 +252,7 @@ end
 
 ---
 
-(program (class_declaration (identifier) (method_declaration (identifier))))
+(program (class_declaration (identifier) (method (identifier))))
 
 ===============
 singleton class
@@ -293,7 +293,7 @@ end
 
 ---
 
-(program (module_declaration (identifier) (method_declaration (identifier))))
+(program (module_declaration (identifier) (method (identifier))))
 
 =======
 __END__
@@ -341,5 +341,5 @@ end
     (function_call (identifier) (argument_list (symbol)))
 
     (comment)
-    (method_declaration (identifier) (identifier))
-    (method_declaration (identifier) (identifier)))))
+    (method (identifier) (identifier))
+    (method (self) (identifier)))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -410,6 +410,16 @@ foo.bar("hi", 2)
   (function_call (member_access (identifier) (identifier)) (argument_list (string) (integer))))
 
 ===============================
+method call with safe navigation operator
+===============================
+
+foo&.bar
+
+---
+
+(program (member_access (identifier) (identifier)))
+
+===============================
 method call with hash args
 ===============================
 
@@ -545,6 +555,16 @@ foo items.any? { |i| i > 0 }
   (function_call (identifier) (argument_list (function_call
     (member_access (identifier) (identifier))
     (block (formal_parameters (identifier)) (comparison (identifier) (integer)))))))
+
+===============================
+method call with block shadow arguments
+===============================
+
+foo { |; i, j| }
+
+---
+
+(program (function_call (identifier) (block (identifier) (identifier))))
 
 ==============
 empty lambda expression

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -8,8 +8,8 @@ Foo::bar
 ---
 
 (program
-  (scope_resolution_expression (identifier) (identifier))
-  (scope_resolution_expression (identifier)))
+  (scope_resolution (identifier) (identifier))
+  (scope_resolution (identifier)))
 
 ============
 element reference
@@ -138,7 +138,7 @@ defined?(@foo)
 
 (program
   (defined (identifier))
-  (defined (member_access (identifier) (identifier)))
+  (defined (call (identifier) (identifier)))
   (defined (identifier))
   (defined (global_variable))
   (defined (instance_variable)))
@@ -372,7 +372,7 @@ complement
 (program (complement (identifier)))
 
 ===============================
-function call
+method call
 ===============================
 
 foo
@@ -384,9 +384,9 @@ print("hello")
 
 (program
   (identifier)
-  (function_call (identifier) (argument_list))
-  (function_call (identifier) (argument_list (string)))
-  (function_call (identifier) (argument_list (string))))
+  (method_call (identifier) (argument_list))
+  (method_call (identifier) (argument_list (string)))
+  (method_call (identifier) (argument_list (string))))
 
 ===============================
 method call with receiver
@@ -402,12 +402,12 @@ foo.bar("hi", 2)
 ---
 
 (program
-  (member_access (identifier) (identifier))
-  (function_call (member_access (identifier) (identifier)) (argument_list))
-  (function_call (member_access (identifier) (identifier)) (argument_list (string)))
-  (function_call (member_access (identifier) (identifier)) (argument_list (string) (integer)))
-  (function_call (member_access (identifier) (identifier)) (argument_list (string)))
-  (function_call (member_access (identifier) (identifier)) (argument_list (string) (integer))))
+  (call (identifier) (identifier))
+  (method_call (call (identifier) (identifier)) (argument_list))
+  (method_call (call (identifier) (identifier)) (argument_list (string)))
+  (method_call (call (identifier) (identifier)) (argument_list (string) (integer)))
+  (method_call (call (identifier) (identifier)) (argument_list (string)))
+  (method_call (call (identifier) (identifier)) (argument_list (string) (integer))))
 
 ===============================
 method call with safe navigation operator
@@ -417,7 +417,7 @@ foo&.bar
 
 ---
 
-(program (member_access (identifier) (identifier)))
+(program (call (identifier) (identifier)))
 
 ===============================
 method call with hash args
@@ -429,8 +429,8 @@ foo :a => true, :c => 1
 ---
 
 (program
-  (function_call (identifier) (argument_list (argument_pair (symbol) (boolean))))
-  (function_call (identifier) (argument_list (argument_pair (symbol) (boolean)) (argument_pair (symbol) (integer)))))
+  (method_call (identifier) (argument_list (argument_pair (symbol) (boolean))))
+  (method_call (identifier) (argument_list (argument_pair (symbol) (boolean)) (argument_pair (symbol) (integer)))))
 
 ===============================
 method call with keyword args
@@ -442,8 +442,8 @@ foo a: true
 ---
 
 (program
-  (function_call (identifier) (argument_list (argument_pair (identifier) (boolean))))
-  (function_call (identifier) (argument_list (argument_pair (identifier) (boolean)))))
+  (method_call (identifier) (argument_list (argument_pair (identifier) (boolean))))
+  (method_call (identifier) (argument_list (argument_pair (identifier) (boolean)))))
 
 ===============================
 method call with block argument
@@ -455,8 +455,8 @@ foo(&bar)
 ---
 
 (program
-  (function_call (identifier) (argument_list (block_argument (symbol))))
-  (function_call (identifier) (argument_list (block_argument (identifier)))))
+  (method_call (identifier) (argument_list (block_argument (symbol))))
+  (method_call (identifier) (argument_list (block_argument (identifier)))))
 
 ===============================
 method call lambda argument
@@ -468,16 +468,16 @@ foo :bar, -> (a) { where(:c => b) }
 ---
 
 (program
-  (function_call (identifier)
+  (method_call (identifier)
     (argument_list
       (symbol)
       (lambda (formal_parameters (identifier)) (integer))))
-  (function_call (identifier)
+  (method_call (identifier)
     (argument_list
       (symbol)
       (lambda
         (formal_parameters (identifier))
-        (function_call (identifier) (argument_list (argument_pair (symbol) (identifier))))))))
+        (method_call (identifier) (argument_list (argument_pair (symbol) (identifier))))))))
 
 ===============================
 method call lambda argument and do block
@@ -489,19 +489,19 @@ end
 ---
 
 (program
-  (function_call_with_do_block (identifier)
+  (method_call_with_do_block (identifier)
     (argument_list (symbol) (lambda (formal_parameters (identifier)) (integer)))
     (do_block)))
 
 ============================
-function call without parens
+method call without parens
 ============================
 
 include D::E.f
 
 ---
 
-(program (function_call (identifier) (argument_list (member_access (scope_resolution_expression (identifier) (identifier)) (identifier)))))
+(program (method_call (identifier) (argument_list (call (scope_resolution (identifier) (identifier)) (identifier)))))
 
 ===============================
 method call with block argument do end
@@ -525,18 +525,18 @@ end
 ---
 
 (program
-  (function_call_with_do_block
+  (method_call_with_do_block
     (identifier)
     (do_block (formal_parameters (identifier)) (identifier)))
-  (function_call_with_do_block
+  (method_call_with_do_block
     (identifier)
     (argument_list (identifier))
     (do_block (formal_parameters (identifier)) (identifier)))
-  (function_call_with_do_block
-    (member_access (identifier) (identifier))
+  (method_call_with_do_block
+    (call (identifier) (identifier))
     (argument_list (identifier))
     (do_block (formal_parameters (identifier)) (identifier)))
-  (function_call_with_do_block
+  (method_call_with_do_block
     (identifier)
     (argument_list (identifier))
     (do_block (formal_parameters (keyword_parameter (identifier) (identifier)) (splat_parameter (identifier))))))
@@ -551,9 +551,9 @@ foo items.any? { |i| i > 0 }
 ---
 
 (program
-  (function_call (identifier) (block (formal_parameters (identifier)) (identifier)))
-  (function_call (identifier) (argument_list (function_call
-    (member_access (identifier) (identifier))
+  (method_call (identifier) (block (formal_parameters (identifier)) (identifier)))
+  (method_call (identifier) (argument_list (method_call
+    (call (identifier) (identifier))
     (block (formal_parameters (identifier)) (comparison (identifier) (integer)))))))
 
 ===============================
@@ -564,7 +564,7 @@ foo { |; i, j| }
 
 ---
 
-(program (function_call (identifier) (block (identifier) (identifier))))
+(program (method_call (identifier) (block (identifier) (identifier))))
 
 ==============
 empty lambda expression

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -456,11 +456,11 @@ foo :bar, -> (a) { where(:c => b) }
   (function_call (identifier)
     (argument_list
       (symbol)
-      (lambda_literal (formal_parameters (identifier)) (integer))))
+      (lambda (formal_parameters (identifier)) (integer))))
   (function_call (identifier)
     (argument_list
       (symbol)
-      (lambda_literal
+      (lambda
         (formal_parameters (identifier))
         (function_call (identifier) (argument_list (argument_pair (symbol) (identifier))))))))
 
@@ -475,7 +475,7 @@ end
 
 (program
   (function_call_with_do_block (identifier)
-    (argument_list (symbol) (lambda_literal (formal_parameters (identifier)) (integer)))
+    (argument_list (symbol) (lambda (formal_parameters (identifier)) (integer)))
     (do_block)))
 
 ============================
@@ -549,7 +549,7 @@ lambda {}
 
 ---
 
-(program (lambda_expression))
+(program (lambda))
 
 ==================
 lambda expression with body
@@ -559,7 +559,7 @@ lambda { foo }
 
 ---
 
-(program (lambda_expression (identifier)))
+(program (lambda (identifier)))
 
 ====================
 lambda expression with an arg
@@ -569,7 +569,7 @@ lambda { |foo| 1 }
 
 ---
 
-(program (lambda_expression (formal_parameters (identifier)) (integer)))
+(program (lambda (formal_parameters (identifier)) (integer)))
 
 ===========================
 lambda expression with multiple args
@@ -582,7 +582,7 @@ lambda { |a, b, c|
 
 ---
 
-(program (lambda_expression (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
+(program (lambda (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
 
 ====================
 lambda expression with do end
@@ -594,4 +594,4 @@ end
 
 ---
 
-(program (lambda_expression (formal_parameters (identifier)) (integer)))
+(program (lambda (formal_parameters (identifier)) (integer)))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -489,7 +489,7 @@ end
 ---
 
 (program
-  (method_call_with_do_block (identifier)
+  (method_call (identifier)
     (argument_list (symbol) (lambda (formal_parameters (identifier)) (integer)))
     (do_block)))
 
@@ -525,18 +525,18 @@ end
 ---
 
 (program
-  (method_call_with_do_block
+  (method_call
     (identifier)
     (do_block (formal_parameters (identifier)) (identifier)))
-  (method_call_with_do_block
+  (method_call
     (identifier)
     (argument_list (identifier))
     (do_block (formal_parameters (identifier)) (identifier)))
-  (method_call_with_do_block
+  (method_call
     (call (identifier) (identifier))
     (argument_list (identifier))
     (do_block (formal_parameters (identifier)) (identifier)))
-  (method_call_with_do_block
+  (method_call
     (identifier)
     (argument_list (identifier))
     (do_block (formal_parameters (keyword_parameter (identifier) (identifier)) (splat_parameter (identifier))))))
@@ -547,6 +547,7 @@ method call with block argument curly
 
 foo { |i| foo }
 foo items.any? { |i| i > 0 }
+foo(bar, baz) { quux }
 
 ---
 
@@ -554,7 +555,12 @@ foo items.any? { |i| i > 0 }
   (method_call (identifier) (block (formal_parameters (identifier)) (identifier)))
   (method_call (identifier) (argument_list (method_call
     (call (identifier) (identifier))
-    (block (formal_parameters (identifier)) (comparison (identifier) (integer)))))))
+    (block (formal_parameters (identifier)) (comparison (identifier) (integer))))))
+
+  (method_call
+    (identifier)
+    (argument_list (identifier) (identifier))
+    (block (identifier))))
 
 ===============================
 method call with block shadow arguments

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -140,8 +140,8 @@ defined?(@foo)
   (defined (identifier))
   (defined (member_access (identifier) (identifier)))
   (defined (identifier))
-  (defined (identifier))
-  (defined (identifier)))
+  (defined (global_variable))
+  (defined (instance_variable)))
 
 ==========
 assignment

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -191,9 +191,14 @@ conditional
 
 a ? b : c
 
+a ? b
+  : c
+
 ---
 
-(program (conditional (identifier) (identifier) (identifier)))
+(program
+  (conditional (identifier) (identifier) (identifier))
+  (conditional (identifier) (identifier) (identifier)))
 
 ===============
 inclusive range

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -43,30 +43,15 @@ double quoted symbol with interpolation
 
 (program (symbol (interpolation (identifier))))
 
-=========================================
-percent symbol with unbalanced delimiters
-=========================================
-
-%s/a/
-%s\a\
-%s#a#
-
----
-
-(program (symbol) (symbol) (symbol))
-
 =======================================
 percent symbol with balanced delimiters
 =======================================
 
-%s{a{b}c}
-%s<a<b>c>
 %s(a(b)c)
-%s[a[b]c]
 
 ---
 
-(program (symbol) (symbol) (symbol) (symbol))
+(program (symbol))
 
 =======
 integer
@@ -263,86 +248,41 @@ escaped interpolation
 
 (program (string))
 
-===========================================
-percent q string with unbalanced delimiters
-===========================================
-
-%q/a/
-%q\a\
-%q#a#
-
----
-
-(program (string) (string) (string))
-
 =========================================
 percent q string with balanced delimiters
 =========================================
 
-%q<a<b>c>
-%q{a{b}c}
-%q[a[b]c]
 %q(a(b)c)
 
 ---
 
-(program (string) (string) (string) (string))
-
-=========================================
-percent string with unbalanced delimiters
-=========================================
-
-%/a/
-%\a\
-%#a#
-
----
-
-(program (string) (string) (string))
-
-===========================================
-percent Q string with unbalanced delimiters
-===========================================
-
-%Q#a#
-%Q/a/
-%Q\a\
-
----
-
-(program (string) (string) (string))
+(program (string))
 
 =========================================
 percent string with balanced delimiters
 =========================================
 
-%<a<b>c>
-%{a{b}c}
-%[a[b]c]
 %(a(b)c)
 
 ---
 
-(program (string) (string) (string) (string))
+(program (string))
 
 =========================================
 percent Q string with balanced delimiters
 =========================================
 
-%Q<a<b>c>
-%Q{a{b}c}
-%Q[a[b]c]
 %Q(a(b)c)
 
 ---
 
-(program (string) (string) (string) (string))
+(program (string))
 
 ===============
 string chaining
 ===============
 
-%q{a} "b" "c"
+%q(a) "b" "c"
 
 ---
 
@@ -429,16 +369,6 @@ percent w array
 
 (program (array))
 
-==========================
-unbalanced percent w array
-==========================
-
-%w/one two/
-
----
-
-(program (array))
-
 ===================================
 percent W array with interpolations
 ===================================
@@ -464,16 +394,6 @@ percent i array
 ===============
 
 %i(word word)
-
----
-
-(program (array))
-
-==========================
-unbalanced percent i array
-==========================
-
-%i/one two/
 
 ---
 
@@ -552,46 +472,21 @@ regular expression with interpolation
 	(regex (interpolation (identifier)))
 	(regex))
 
-=======================================================
-percent r regular expression with unbalanced delimiters
-=======================================================
-
-%r/a/
-%r\a\
-%r#a#
-
----
-
-(program (regex) (regex) (regex))
-
 =====================================================
 percent r regular expression with balanced delimiters
 =====================================================
 
-%r<a<b>c>
-%r{a{b}c}
-%r[a[b]c]
 %r(a(b)c)
 
 ---
 
-(program (regex) (regex) (regex) (regex))
-
-=========================================================================
-percent r regular expression with unbalanced delimiters and interpolation
-=========================================================================
-
-%r/a#{b}c/
-
----
-
-(program (regex (interpolation (identifier))))
+(program (regex))
 
 =======================================================================
 percent r regular expression with balanced delimiters and interpolation
 =======================================================================
 
-%r[a#{b}c]
+%r(a#{b}c)
 
 ---
 

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -388,6 +388,17 @@ array
 
 (program (array (identifier) (identifier)))
 
+=====
+array
+=====
+
+[1, 2].any? { |i| i > 1 }
+
+---
+(program
+	(function_call (member_access (array (integer) (integer)) (identifier))
+		(block (formal_parameters (identifier)) (comparison (identifier) (integer)))))
+
 =========================
 array with trailing comma
 =========================

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -500,7 +500,7 @@ empty function
 
 ---
 
-(program (lambda_literal))
+(program (lambda))
 
 ==================
 lambda literal with body
@@ -510,7 +510,7 @@ lambda literal with body
 
 ---
 
-(program (lambda_literal (identifier)))
+(program (lambda (identifier)))
 
 ====================
 lambda literal with an arg
@@ -522,8 +522,8 @@ lambda literal with an arg
 ---
 
 (program
-	(lambda_literal (identifier) (integer))
-	(lambda_literal (formal_parameters (identifier)) (integer)))
+	(lambda (identifier) (integer))
+	(lambda (formal_parameters (identifier)) (integer)))
 
 ===========================
 lambda literal with multiple args
@@ -536,7 +536,7 @@ lambda literal with multiple args
 
 ---
 
-(program (lambda_literal (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
+(program (lambda (formal_parameters (identifier) (identifier) (identifier)) (integer) (integer)))
 
 ====================
 lambda literal with do end
@@ -548,4 +548,4 @@ end
 
 ---
 
-(program (lambda_literal (formal_parameters (identifier)) (integer)))
+(program (lambda (formal_parameters (identifier)) (integer)))

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -336,7 +336,7 @@ array as object
 
 ---
 (program
-	(function_call (member_access (array (integer) (integer)) (identifier))
+	(method_call (call (array (integer) (integer)) (identifier))
 		(block (formal_parameters (identifier)) (comparison (identifier) (integer)))))
 
 =========================

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -329,7 +329,7 @@ array
 (program (array (identifier) (identifier)))
 
 =====
-array
+array as object
 =====
 
 [1, 2].any? { |i| i > 1 }

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -518,12 +518,16 @@ lambda literal with an arg
 
 -> foo { 1 }
 -> (foo) { 1 }
+-> *foo { 1 }
+-> foo: 1 { 2 }
 
 ---
 
 (program
 	(lambda (identifier) (integer))
-	(lambda (formal_parameters (identifier)) (integer)))
+	(lambda (formal_parameters (identifier)) (integer))
+	(lambda (splat_parameter (identifier)) (integer))
+	(lambda (keyword_parameter (identifier) (integer)) (integer)))
 
 ===========================
 lambda literal with multiple args

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -5,10 +5,16 @@ symbol
 :foo
 :foo!
 :foo?
+:@foo
+:@@foo
+:$foo
 
 ---
 
 (program
+	(symbol)
+	(symbol)
+	(symbol)
 	(symbol)
 	(symbol)
 	(symbol))

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -56,9 +56,13 @@ undef
 
 undef :foo
 undef foo
+undef +
+undef :foo, :bar
 
 ---
 
 (program
   (undef (symbol))
-  (undef (identifier)))
+  (undef (identifier))
+  (undef (operator))
+  (undef (symbol) (symbol)))

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -3,10 +3,13 @@ conditional modifier
 ====================
 
 foo if bar
+return if false
 
 ---
 
-(program (if_modifier (identifier) (identifier)))
+(program
+  (if_modifier (identifier) (identifier))
+  (if_modifier (return) (boolean)))
 
 ==============
 while modifier

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -44,11 +44,16 @@ alias
 
 alias :foo :bar
 alias foo bar
+alias $FOO $&
 alias foo +
 
 ---
 
-(program (alias (symbol) (symbol)) (alias (identifier) (identifier)) (alias (identifier) (operator)))
+(program
+  (alias (symbol) (symbol))
+  (alias (identifier) (identifier))
+  (alias (global_variable) (global_variable))
+  (alias (identifier) (operator)))
 
 ========
 undef

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -82,43 +82,11 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_declaration"
-        },
-        {
-          "type": "SYMBOL",
           "name": "undef"
         },
         {
           "type": "SYMBOL",
           "name": "alias"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "while_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "until_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "if_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "unless_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "for_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "begin_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "return_statement"
         },
         {
           "type": "SYMBOL",
@@ -155,28 +123,7 @@
         }
       ]
     },
-    "_declaration": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "method_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "class_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "singleton_class_declaration"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "module_declaration"
-        }
-      ]
-    },
-    "method_declaration": {
+    "method": {
       "type": "SEQ",
       "members": [
         {
@@ -190,12 +137,43 @@
               "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_variable"
+                    },
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "_simple_expression"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    }
+                  ]
                 },
                 {
-                  "type": "STRING",
-                  "value": "."
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "."
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "::"
+                    }
+                  ]
                 }
               ]
             },
@@ -260,14 +238,55 @@
           ]
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_statements"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rescue"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
@@ -281,33 +300,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "splat_parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "hash_splat_parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "block_parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "keyword_parameter"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "optional_parameter"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_formal_parameter"
         },
         {
           "type": "REPEAT",
@@ -319,36 +313,40 @@
                 "value": ","
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "splat_parameter"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "hash_splat_parameter"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "block_parameter"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "keyword_parameter"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "optional_parameter"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "_formal_parameter"
               }
             ]
           }
+        }
+      ]
+    },
+    "_formal_parameter": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "splat_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hash_splat_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword_parameter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "optional_parameter"
         }
       ]
     },
@@ -364,7 +362,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             {
               "type": "BLANK"
@@ -385,7 +383,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "identifier"
+              "name": "_identifier"
             },
             {
               "type": "BLANK"
@@ -403,7 +401,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         }
       ]
     },
@@ -412,7 +410,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -437,7 +435,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "STRING",
@@ -449,7 +447,7 @@
         }
       ]
     },
-    "class_declaration": {
+    "class": {
       "type": "SEQ",
       "members": [
         {
@@ -457,8 +455,29 @@
           "value": "class"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_identifier"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "::"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_identifier"
+                  }
+                ]
+              }
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -475,7 +494,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "identifier"
+                      "name": "_identifier"
                     },
                     {
                       "type": "REPEAT",
@@ -488,12 +507,16 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "identifier"
+                            "name": "_identifier"
                           }
                         ]
                       }
                     }
                   ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_terminator"
                 }
               ]
             },
@@ -503,18 +526,55 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_terminator"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_statements"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rescue"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
@@ -524,7 +584,7 @@
         }
       ]
     },
-    "singleton_class_declaration": {
+    "singleton_class": {
       "type": "SEQ",
       "members": [
         {
@@ -537,21 +597,62 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
           "type": "SYMBOL",
           "name": "_terminator"
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_statements"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rescue"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
@@ -561,7 +662,7 @@
         }
       ]
     },
-    "module_declaration": {
+    "module": {
       "type": "SEQ",
       "members": [
         {
@@ -569,308 +670,11 @@
           "value": "module"
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_terminator"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "while_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "while"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_simple_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "function_call_with_do_block"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_statement_block"
-        }
-      ]
-    },
-    "until_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "until"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_simple_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "function_call_with_do_block"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_statement_block"
-        }
-      ]
-    },
-    "if_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "if"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_simple_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "function_call_with_do_block"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_then_elsif_else_block"
-        }
-      ]
-    },
-    "unless_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "unless"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_simple_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "function_call_with_do_block"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_then_else_block"
-        }
-      ]
-    },
-    "for_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_lhs"
-        },
-        {
-          "type": "STRING",
-          "value": "in"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_simple_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "function_call_with_do_block"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_statement_block"
-        }
-      ]
-    },
-    "begin_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "begin"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "rescue_block"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "else_block"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "ensure_block"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "return_statement": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "return"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_simple_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "function_call_with_do_block"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "case_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "case"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_simple_expression"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_terminator"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "when_block"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "else_block"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "when_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "when"
-        },
-        {
           "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "pattern"
+              "name": "_identifier"
             },
             {
               "type": "REPEAT",
@@ -879,11 +683,11 @@
                 "members": [
                   {
                     "type": "STRING",
-                    "value": ","
+                    "value": "::"
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "pattern"
+                    "name": "_identifier"
                   }
                 ]
               }
@@ -892,13 +696,116 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_then_block"
+          "name": "_terminator"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rescue"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
         }
       ]
     },
-    "pattern": {
-      "type": "SYMBOL",
-      "name": "_statement"
+    "return": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "return"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "yield": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "yield"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "if_modifier": {
       "type": "SEQ",
@@ -1034,76 +941,29 @@
         ]
       }
     },
-    "_statement_block": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "do"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "end"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_terminator"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "end"
-            }
-          ]
-        }
-      ]
-    },
-    "_then_block": {
+    "while": {
       "type": "SEQ",
       "members": [
+        {
+          "type": "STRING",
+          "value": "while"
+        },
         {
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "then"
+              "type": "SYMBOL",
+              "name": "_simple_expression"
             },
             {
               "type": "SYMBOL",
-              "name": "_terminator"
+              "name": "function_call_with_do_block"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_do"
         },
         {
           "type": "CHOICE",
@@ -1116,10 +976,338 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
         }
       ]
     },
-    "elsif_block": {
+    "until": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "until"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_simple_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_call_with_do_block"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_do"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "for": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "for"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lhs"
+        },
+        {
+          "type": "STRING",
+          "value": "in"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_simple_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_call_with_do_block"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_do"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "_do": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "do"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_terminator"
+        }
+      ]
+    },
+    "case": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "case"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_simple_expression"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_terminator"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "when"
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "when": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "when"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "pattern"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "pattern"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_then"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "when"
+            }
+          ]
+        }
+      ]
+    },
+    "pattern": {
+      "type": "SYMBOL",
+      "name": "_statement"
+    },
+    "if": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "if"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_simple_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_call_with_do_block"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_then"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_if_tail"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "unless": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "unless"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_simple_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "function_call_with_do_block"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_then"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "else"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "elsif": {
       "type": "SEQ",
       "members": [
         {
@@ -1141,11 +1329,35 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_then_block"
+          "name": "_then"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_if_tail"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
-    "else_block": {
+    "else": {
       "type": "SEQ",
       "members": [
         {
@@ -1166,7 +1378,112 @@
         }
       ]
     },
-    "ensure_block": {
+    "_then": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_terminator"
+        },
+        {
+          "type": "STRING",
+          "value": "then"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_terminator"
+            },
+            {
+              "type": "STRING",
+              "value": "then"
+            }
+          ]
+        }
+      ]
+    },
+    "_if_tail": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "else"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "elsif"
+        }
+      ]
+    },
+    "begin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "begin"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rescue"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "ensure": {
       "type": "SEQ",
       "members": [
         {
@@ -1187,7 +1504,7 @@
         }
       ]
     },
-    "rescue_block": {
+    "rescue": {
       "type": "SEQ",
       "members": [
         {
@@ -1229,7 +1546,31 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_then_block"
+          "name": "_then"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "rescue"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1262,73 +1603,12 @@
       "type": "PATTERN",
       "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
     },
-    "_then_else_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_then_block"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "else_block"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "_then_elsif_else_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_then_block"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "elsif_block"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "else_block"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
     "_simple_expression": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
           "name": "_primary"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "yield"
         },
         {
           "type": "SYMBOL",
@@ -1376,10 +1656,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "case_expression"
-        },
-        {
-          "type": "SYMBOL",
           "name": "relational"
         },
         {
@@ -1420,7 +1696,31 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_literal"
+          "name": "symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "subshell"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "hash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "regex"
         }
       ]
     },
@@ -1455,6 +1755,66 @@
         {
           "type": "SYMBOL",
           "name": "_lhs"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "array"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "method"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "singleton_class"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "module"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "begin"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "while"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "until"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "if"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "unless"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "for"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "case"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "return"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "yield"
         }
       ]
     },
@@ -1482,7 +1842,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           }
         ]
       }
@@ -1528,7 +1888,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "identifier"
+            "name": "_identifier"
           }
         ]
       }
@@ -1774,7 +2134,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   },
                   {
                     "type": "STRING",
@@ -1925,27 +2285,6 @@
         {
           "type": "STRING",
           "value": "}"
-        }
-      ]
-    },
-    "yield": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "yield"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "argument_list"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
         }
       ]
     },
@@ -2892,92 +3231,53 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_identifier"
         },
         {
-          "type": "STRING",
-          "value": "self"
+          "type": "SYMBOL",
+          "name": "nil"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "self"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "boolean"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword__FILE__"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword__LINE__"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "keyword__ENCODING__"
         }
       ]
+    },
+    "instance_variable": {
+      "type": "PATTERN",
+      "value": "@[a-zA-Z_][a-zA-Z0-9_]*"
+    },
+    "class_variable": {
+      "type": "PATTERN",
+      "value": "@@[a-zA-Z_][a-zA-Z0-9_]*"
+    },
+    "global_variable": {
+      "type": "PATTERN",
+      "value": "\\$(([&`'+])|([1-9][0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))"
+    },
+    "constant": {
+      "type": "PATTERN",
+      "value": "[A-Z_][a-zA-Z0-9_]*"
     },
     "identifier": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "REPEAT",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "@"
-                },
-                {
-                  "type": "STRING",
-                  "value": "$"
-                }
-              ]
-            }
-          },
-          {
-            "type": "PATTERN",
-            "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
-          }
-        ]
-      }
-    },
-    "undef": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "undef"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_name_symbol_or_operator"
-        }
-      ]
-    },
-    "alias": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "alias"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_name_symbol_or_operator"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_name_symbol_or_operator"
-        }
-      ]
-    },
-    "_name_symbol_or_operator": {
-      "type": "PREC",
-      "value": 11,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "identifier"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "symbol"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "operator"
-          }
-        ]
-      }
+      "type": "PATTERN",
+      "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
     },
     "operator": {
       "type": "CHOICE",
@@ -3084,6 +3384,108 @@
         }
       ]
     },
+    "_identifier": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "instance_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "constant"
+        }
+      ]
+    },
+    "_function_name": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator"
+        }
+      ]
+    },
+    "_undef_list": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_function_name"
+        },
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_undef_list"
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_function_name"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "undef": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "undef"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_undef_list"
+        }
+      ]
+    },
+    "alias": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "alias"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_name"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_function_name"
+        }
+      ]
+    },
     "comment": {
       "type": "TOKEN",
       "content": {
@@ -3145,59 +3547,6 @@
           ]
         }
       }
-    },
-    "_literal": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "symbol"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "integer"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "float"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "boolean"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "nil"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "subshell"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "array"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "hash"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "regex"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "lambda_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "lambda_expression"
-        }
-      ]
     },
     "symbol": {
       "type": "CHOICE",
@@ -3365,100 +3714,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\#\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\/\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_angle"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_bracket"
-                },
-                {
                   "type": "SYMBOL",
                   "name": "_uninterpolated_paren"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_brace"
                 }
               ]
             }
@@ -3498,6 +3755,10 @@
         ]
       }
     },
+    "self": {
+      "type": "STRING",
+      "value": "self"
+    },
     "nil": {
       "type": "TOKEN",
       "content": {
@@ -3513,6 +3774,18 @@
           }
         ]
       }
+    },
+    "keyword__FILE__": {
+      "type": "STRING",
+      "value": "__FILE__"
+    },
+    "keyword__LINE__": {
+      "type": "STRING",
+      "value": "__LINE__"
+    },
+    "keyword__ENCODING__": {
+      "type": "STRING",
+      "value": "__ENCODING__"
     },
     "string": {
       "type": "SEQ",
@@ -3535,116 +3808,8 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "#"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "\\\\.|[^\\#\\\\\\\n]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "/"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{}]"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "\\\\.|[^\\/\\\\\\\n\\#]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "interpolation"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "#[^{}]"
-                                  },
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\\\\\\n\\#]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_interpolated_angle"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_interpolated_bracket"
-                    },
-                    {
                       "type": "SYMBOL",
                       "name": "_interpolated_paren"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_interpolated_brace"
                     }
                   ]
                 }
@@ -3661,100 +3826,8 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "#"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "\\\\.|[^\\#\\\\\\\n]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "#"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "/"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "\\\\.|[^\\/\\\\\\\n]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "/"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "PATTERN",
-                                    "value": "[^\\\\\\\\\\\n]"
-                                  }
-                                ]
-                              }
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "\\"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_uninterpolated_angle"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_uninterpolated_bracket"
-                    },
-                    {
                       "type": "SYMBOL",
                       "name": "_uninterpolated_paren"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_uninterpolated_brace"
                     }
                   ]
                 }
@@ -3858,80 +3931,6 @@
         }
       ]
     },
-    "_interpolated_angle": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "<"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^{}]"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_interpolated_angle"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\.|[^\\>\\\\\\\n\\#\\<]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": ">"
-        }
-      ]
-    },
-    "_interpolated_bracket": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^{}]"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_interpolated_bracket"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\.|[^\\]\\\\\\\n\\#\\[]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        }
-      ]
-    },
     "_interpolated_paren": {
       "type": "SEQ",
       "members": [
@@ -3969,101 +3968,6 @@
         }
       ]
     },
-    "_interpolated_brace": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^{}]"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_interpolated_brace"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\.|[^\\}\\\\\\\n\\#\\{]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        }
-      ]
-    },
-    "_uninterpolated_angle": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "<"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_uninterpolated_angle"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\.|[^\\>\\\\\\\n\\<]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": ">"
-        }
-      ]
-    },
-    "_uninterpolated_bracket": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_uninterpolated_bracket"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\.|[^\\]\\\\\\\n\\[]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        }
-      ]
-    },
     "_uninterpolated_paren": {
       "type": "SEQ",
       "members": [
@@ -4090,35 +3994,6 @@
         {
           "type": "STRING",
           "value": ")"
-        }
-      ]
-    },
-    "_uninterpolated_brace": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_uninterpolated_brace"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\\\.|[^\\}\\\\\\\n\\{]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
         }
       ]
     },
@@ -4187,116 +4062,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\#\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{}]"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\/\\\\\\\n\\#]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{}]"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\\\\n\\#]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_angle"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_bracket"
-                },
-                {
                   "type": "SYMBOL",
                   "name": "_interpolated_paren"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_brace"
                 }
               ]
             }
@@ -4316,7 +4083,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_array_items"
+              "name": "_array_function_names"
             },
             {
               "type": "STRING",
@@ -4335,100 +4102,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\#\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\/\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_angle"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_bracket"
-                },
-                {
                   "type": "SYMBOL",
                   "name": "_uninterpolated_paren"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_uninterpolated_brace"
                 }
               ]
             }
@@ -4445,116 +4120,8 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\#\\\\\\\n]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "#"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{}]"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "\\\\.|[^\\/\\\\\\\n\\#]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "/"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        },
-                        {
-                          "type": "REPEAT",
-                          "content": {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SYMBOL",
-                                "name": "interpolation"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "#[^{}]"
-                              },
-                              {
-                                "type": "PATTERN",
-                                "value": "[^\\\\\\\\\\\n\\#]"
-                              }
-                            ]
-                          }
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "\\"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_angle"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_bracket"
-                },
-                {
                   "type": "SYMBOL",
                   "name": "_interpolated_paren"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_interpolated_brace"
                 }
               ]
             }
@@ -4562,7 +4129,7 @@
         }
       ]
     },
-    "_array_items": {
+    "_array_function_names": {
       "type": "CHOICE",
       "members": [
         {
@@ -4593,7 +4160,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "_array_items"
+                      "name": "_array_function_names"
                     }
                   ]
                 },
@@ -4624,7 +4191,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_hash_items"
+                "name": "_hash_function_names"
               },
               {
                 "type": "BLANK"
@@ -4638,7 +4205,7 @@
         ]
       }
     },
-    "_hash_items": {
+    "_hash_function_names": {
       "type": "SEQ",
       "members": [
         {
@@ -4660,7 +4227,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_hash_items"
+                      "name": "_hash_function_names"
                     },
                     {
                       "type": "BLANK"
@@ -4712,7 +4279,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier"
+                    "name": "_identifier"
                   },
                   {
                     "type": "STRING",
@@ -4739,244 +4306,58 @@
       }
     },
     "regex": {
-      "type": "PREC",
-      "value": 100,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "/"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "interpolation"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "#[^{}]"
-                    },
-                    {
-                      "type": "PATTERN",
-                      "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\/\\[\\\\\\\n\\#]"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\/[a-z]*"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "%r"
-              },
-              {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "/"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "#"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\#\\#\\[\\\\\\\n]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "\\#[a-z]*"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "/"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{}]"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\/\\[\\\\\\\n\\#]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "\\/[a-z]*"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": "\\"
-                          },
-                          {
-                            "type": "REPEAT",
-                            "content": {
-                              "type": "CHOICE",
-                              "members": [
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "interpolation"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "#[^{}]"
-                                },
-                                {
-                                  "type": "PATTERN",
-                                  "value": "\\[[^\\]\\n]*\\]|[^\\\\\\\\\\[\\\\\\\n\\#]"
-                                }
-                              ]
-                            }
-                          },
-                          {
-                            "type": "PATTERN",
-                            "value": "\\\\[a-z]*"
-                          }
-                        ]
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "interpolation"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_regex_interpolated_angle"
+                    "type": "PATTERN",
+                    "value": "#[^{}]"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_regex_interpolated_bracket"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_regex_interpolated_paren"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_regex_interpolated_brace"
+                    "type": "PATTERN",
+                    "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\/\\/\\[\\\\\\\n\\#]"
                   }
                 ]
               }
-            ]
-          }
-        ]
-      }
-    },
-    "_regex_interpolated_angle": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "<"
+            },
+            {
+              "type": "PATTERN",
+              "value": "\\/[a-z]*"
+            }
+          ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^{}]"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_angle"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\<\\>\\[\\\\\\\n\\#]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PATTERN",
-          "value": "\\>[a-z]*"
-        }
-      ]
-    },
-    "_regex_interpolated_bracket": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^{}]"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_bracket"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\[\\]\\[\\\\\\\n\\#]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PATTERN",
-          "value": "\\][a-z]*"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "%r"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_regex_interpolated_paren"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -5017,53 +4398,58 @@
         }
       ]
     },
-    "_regex_interpolated_brace": {
-      "type": "SEQ",
+    "lambda": {
+      "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              },
-              {
-                "type": "PATTERN",
-                "value": "#[^{}]"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_regex_interpolated_brace"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\{\\}\\[\\\\\\\n\\#]"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PATTERN",
-          "value": "\\}[a-z]*"
-        }
-      ]
-    },
-    "lambda_literal": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "->"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
+            {
+              "type": "STRING",
+              "value": "->"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "("
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "formal_parameters"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ")"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_identifier"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
             {
               "type": "CHOICE",
               "members": [
@@ -5072,14 +4458,14 @@
                   "members": [
                     {
                       "type": "STRING",
-                      "value": "("
+                      "value": "{"
                     },
                     {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "formal_parameters"
+                          "name": "_statements"
                         },
                         {
                           "type": "BLANK"
@@ -5088,217 +4474,58 @@
                     },
                     {
                       "type": "STRING",
-                      "value": ")"
+                      "value": "}"
                     }
                   ]
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "identifier"
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "do"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_statements"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "end"
+                    }
+                  ]
                 }
               ]
-            },
-            {
-              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_lambda_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_lambda_do_block"
-            }
-          ]
-        }
-      ]
-    },
-    "_lambda_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        }
-      ]
-    },
-    "_lambda_do_block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "do"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        }
-      ]
-    },
-    "lambda_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "lambda"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_block"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_do_block"
-            }
-          ]
-        }
-      ]
-    },
-    "_function_name": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
               "type": "STRING",
-              "value": ".."
+              "value": "lambda"
             },
             {
-              "type": "STRING",
-              "value": "|"
-            },
-            {
-              "type": "STRING",
-              "value": "^"
-            },
-            {
-              "type": "STRING",
-              "value": "&"
-            },
-            {
-              "type": "STRING",
-              "value": "<=>"
-            },
-            {
-              "type": "STRING",
-              "value": "=="
-            },
-            {
-              "type": "STRING",
-              "value": "==="
-            },
-            {
-              "type": "STRING",
-              "value": "=~"
-            },
-            {
-              "type": "STRING",
-              "value": ">"
-            },
-            {
-              "type": "STRING",
-              "value": ">="
-            },
-            {
-              "type": "STRING",
-              "value": "<"
-            },
-            {
-              "type": "STRING",
-              "value": "<="
-            },
-            {
-              "type": "STRING",
-              "value": "+"
-            },
-            {
-              "type": "STRING",
-              "value": "-"
-            },
-            {
-              "type": "STRING",
-              "value": "*"
-            },
-            {
-              "type": "STRING",
-              "value": "/"
-            },
-            {
-              "type": "STRING",
-              "value": "%"
-            },
-            {
-              "type": "STRING",
-              "value": "**"
-            },
-            {
-              "type": "STRING",
-              "value": "<<"
-            },
-            {
-              "type": "STRING",
-              "value": ">>"
-            },
-            {
-              "type": "STRING",
-              "value": "~"
-            },
-            {
-              "type": "STRING",
-              "value": "+@"
-            },
-            {
-              "type": "STRING",
-              "value": "-@"
-            },
-            {
-              "type": "STRING",
-              "value": "[]"
-            },
-            {
-              "type": "STRING",
-              "value": "[]="
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_block"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_do_block"
+                }
+              ]
             }
           ]
         }
@@ -5345,9 +4572,6 @@
     [
       "_lhs",
       "function_call_with_do_block"
-    ],
-    [
-      "yield"
     ]
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -117,7 +117,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         }
@@ -910,7 +910,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         }
@@ -936,7 +936,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         }
@@ -962,7 +962,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         }
@@ -988,7 +988,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         }
@@ -1017,7 +1017,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -1040,7 +1040,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -1082,7 +1082,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -1132,7 +1132,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -1298,7 +1298,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -1352,7 +1352,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -1406,7 +1406,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -1921,7 +1921,32 @@
         }
       ]
     },
-    "scope_resolution_expression": {
+    "element_reference": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_primary"
+          },
+          {
+            "type": "STRING",
+            "value": "["
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_argument_list"
+          },
+          {
+            "type": "STRING",
+            "value": "]"
+          }
+        ]
+      }
+    },
+    "scope_resolution": {
       "type": "PREC_LEFT",
       "value": 1,
       "content": {
@@ -1950,32 +1975,7 @@
         ]
       }
     },
-    "element_reference": {
-      "type": "PREC_LEFT",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_primary"
-          },
-          {
-            "type": "STRING",
-            "value": "["
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_argument_list"
-          },
-          {
-            "type": "STRING",
-            "value": "]"
-          }
-        ]
-      }
-    },
-    "member_access": {
+    "call": {
       "type": "PREC_LEFT",
       "value": 56,
       "content": {
@@ -2005,7 +2005,7 @@
         ]
       }
     },
-    "function_call_with_do_block": {
+    "method_call_with_do_block": {
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
@@ -2020,11 +2020,11 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "scope_resolution_expression"
+                "name": "scope_resolution"
               },
               {
                 "type": "SYMBOL",
-                "name": "member_access"
+                "name": "call"
               }
             ]
           },
@@ -2053,7 +2053,7 @@
         ]
       }
     },
-    "function_call": {
+    "method_call": {
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
@@ -2068,11 +2068,11 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "scope_resolution_expression"
+                "name": "scope_resolution"
               },
               {
                 "type": "SYMBOL",
-                "name": "member_access"
+                "name": "call"
               }
             ]
           },
@@ -2499,7 +2499,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2516,7 +2516,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2538,7 +2538,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2555,7 +2555,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2581,7 +2581,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2607,7 +2607,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2637,7 +2637,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2688,7 +2688,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2727,7 +2727,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2749,7 +2749,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2766,7 +2766,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2783,7 +2783,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2805,7 +2805,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2831,7 +2831,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2853,7 +2853,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2870,7 +2870,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2892,7 +2892,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2909,7 +2909,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2931,7 +2931,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -2973,7 +2973,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -2995,7 +2995,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3029,7 +3029,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3051,7 +3051,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3077,7 +3077,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3099,7 +3099,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3116,7 +3116,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3138,7 +3138,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3164,7 +3164,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3186,7 +3186,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3212,7 +3212,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3234,7 +3234,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3264,7 +3264,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3290,7 +3290,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3312,7 +3312,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           },
@@ -3329,7 +3329,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3355,7 +3355,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3390,7 +3390,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -3406,7 +3406,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "scope_resolution_expression"
+          "name": "scope_resolution"
         },
         {
           "type": "SYMBOL",
@@ -3414,11 +3414,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "member_access"
+          "name": "call"
         },
         {
           "type": "SYMBOL",
-          "name": "function_call"
+          "name": "method_call"
         }
       ]
     },
@@ -4209,7 +4209,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "function_call_with_do_block"
+              "name": "method_call_with_do_block"
             }
           ]
         },
@@ -4340,7 +4340,7 @@
                 },
                 {
                   "type": "SYMBOL",
-                  "name": "function_call_with_do_block"
+                  "name": "method_call_with_do_block"
                 }
               ]
             },
@@ -4460,7 +4460,7 @@
                       },
                       {
                         "type": "SYMBOL",
-                        "name": "function_call_with_do_block"
+                        "name": "method_call_with_do_block"
                       }
                     ]
                   },
@@ -4494,7 +4494,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "function_call_with_do_block"
+                "name": "method_call_with_do_block"
               }
             ]
           }
@@ -4758,16 +4758,16 @@
   "conflicts": [
     [
       "_lhs",
-      "function_call",
-      "function_call_with_do_block"
+      "method_call",
+      "method_call_with_do_block"
     ],
     [
       "_lhs",
-      "function_call"
+      "method_call"
     ],
     [
       "_lhs",
-      "function_call_with_do_block"
+      "method_call_with_do_block"
     ]
   ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1977,7 +1977,7 @@
     },
     "member_access": {
       "type": "PREC_LEFT",
-      "value": 1,
+      "value": 56,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1986,8 +1986,17 @@
             "name": "_primary"
           },
           {
-            "type": "STRING",
-            "value": "."
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "."
+              },
+              {
+                "type": "STRING",
+                "value": "&."
+              }
+            ]
           },
           {
             "type": "SYMBOL",
@@ -2301,6 +2310,48 @@
                   ]
                 },
                 {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ";"
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_identifier"
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ","
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "_identifier"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
                   "type": "STRING",
                   "value": "|"
                 }
@@ -2356,6 +2407,48 @@
                     {
                       "type": "SYMBOL",
                       "name": "formal_parameters"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ";"
+                        },
+                        {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "_identifier"
+                            },
+                            {
+                              "type": "REPEAT",
+                              "content": {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "STRING",
+                                    "value": ","
+                                  },
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "_identifier"
+                                  }
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     },
                     {
                       "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -113,7 +113,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -152,7 +152,7 @@
                         },
                         {
                           "type": "SYMBOL",
-                          "name": "_simple_expression"
+                          "name": "_arg"
                         },
                         {
                           "type": "STRING",
@@ -421,7 +421,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "BLANK"
@@ -443,7 +443,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_simple_expression"
+          "name": "_arg"
         }
       ]
     },
@@ -757,6 +757,31 @@
         }
       ]
     },
+    "super": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "super"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
     "return": {
       "type": "PREC_RIGHT",
       "value": 0,
@@ -807,6 +832,64 @@
         ]
       }
     },
+    "break": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "break"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "next": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "next"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "redo": {
+      "type": "STRING",
+      "value": "redo"
+    },
+    "retry": {
+      "type": "STRING",
+      "value": "retry"
+    },
     "if_modifier": {
       "type": "SEQ",
       "members": [
@@ -823,7 +906,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -849,7 +932,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -875,7 +958,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -901,7 +984,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -930,7 +1013,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -953,7 +1036,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -995,7 +1078,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -1045,7 +1128,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -1100,7 +1183,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "BLANK"
@@ -1211,7 +1294,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -1265,7 +1348,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -1319,7 +1402,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -1579,7 +1662,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_simple_expression"
+          "name": "_arg"
         },
         {
           "type": "REPEAT",
@@ -1592,7 +1675,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               }
             ]
           }
@@ -1603,7 +1686,7 @@
       "type": "PATTERN",
       "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
     },
-    "_simple_expression": {
+    "_arg": {
       "type": "CHOICE",
       "members": [
         {
@@ -1696,31 +1779,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "symbol"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "integer"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "float"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "subshell"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "hash"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "regex"
+          "name": "super"
         }
       ]
     },
@@ -1758,11 +1817,39 @@
         },
         {
           "type": "SYMBOL",
-          "name": "lambda"
+          "name": "array"
         },
         {
           "type": "SYMBOL",
-          "name": "array"
+          "name": "hash"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "subshell"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "integer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "regex"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lambda"
         },
         {
           "type": "SYMBOL",
@@ -1815,6 +1902,22 @@
         {
           "type": "SYMBOL",
           "name": "yield"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "break"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "next"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "redo"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "retry"
         }
       ]
     },
@@ -2071,7 +2174,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2093,7 +2196,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_simple_expression"
+                      "name": "_arg"
                     },
                     {
                       "type": "SYMBOL",
@@ -2146,7 +2249,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_simple_expression"
+            "name": "_arg"
           }
         ]
       }
@@ -2160,7 +2263,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_simple_expression"
+          "name": "_arg"
         }
       ]
     },
@@ -2299,7 +2402,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2316,7 +2419,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2338,7 +2441,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2355,7 +2458,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2381,7 +2484,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2407,7 +2510,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2437,7 +2540,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2488,7 +2591,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2527,7 +2630,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2549,7 +2652,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2566,7 +2669,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2583,7 +2686,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2605,7 +2708,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2631,7 +2734,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2653,7 +2756,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2670,7 +2773,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2692,7 +2795,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2709,7 +2812,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2731,7 +2834,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2773,7 +2876,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2795,7 +2898,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2829,7 +2932,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2851,7 +2954,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2877,7 +2980,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2899,7 +3002,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2916,7 +3019,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2938,7 +3041,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2964,7 +3067,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -2986,7 +3089,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3012,7 +3115,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3034,7 +3137,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3064,7 +3167,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3090,7 +3193,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3112,7 +3215,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3129,7 +3232,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3155,7 +3258,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -3190,7 +3293,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",
@@ -4009,7 +4112,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_simple_expression"
+              "name": "_arg"
             },
             {
               "type": "SYMBOL",
@@ -4140,7 +4243,7 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "_simple_expression"
+                  "name": "_arg"
                 },
                 {
                   "type": "SYMBOL",
@@ -4260,7 +4363,7 @@
                     "members": [
                       {
                         "type": "SYMBOL",
-                        "name": "_simple_expression"
+                        "name": "_arg"
                       },
                       {
                         "type": "SYMBOL",
@@ -4294,7 +4397,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_simple_expression"
+                "name": "_arg"
               },
               {
                 "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -276,7 +276,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_identifier"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -312,7 +312,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_identifier"
+              "name": "identifier"
             },
             {
               "type": "BLANK"
@@ -333,7 +333,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_identifier"
+              "name": "identifier"
             },
             {
               "type": "BLANK"
@@ -351,41 +351,45 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_identifier"
+          "name": "identifier"
         }
       ]
     },
     "keyword_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_identifier"
-        },
-        {
-          "type": "STRING",
-          "value": ":"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "optional_parameter": {
       "type": "SEQ",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_identifier"
+          "name": "identifier"
         },
         {
           "type": "STRING",
@@ -409,7 +413,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_identifier"
+              "name": "identifier"
             },
             {
               "type": "REPEAT",
@@ -422,7 +426,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "_identifier"
+                    "name": "identifier"
                   }
                 ]
               }
@@ -444,7 +448,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_identifier"
+                      "name": "identifier"
                     },
                     {
                       "type": "REPEAT",
@@ -457,7 +461,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "_identifier"
+                            "name": "identifier"
                           }
                         ]
                       }
@@ -506,7 +510,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_identifier"
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -542,7 +546,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_identifier"
+              "name": "identifier"
             },
             {
               "type": "REPEAT",
@@ -555,7 +559,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "_identifier"
+                    "name": "identifier"
                   }
                 ]
               }
@@ -1765,7 +1769,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_identifier"
+            "name": "identifier"
           }
         ]
       }
@@ -1795,7 +1799,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_identifier"
+            "name": "identifier"
           }
         ]
       }
@@ -2110,7 +2114,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_identifier"
+                    "name": "identifier"
                   },
                   {
                     "type": "STRING",
@@ -2256,7 +2260,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_identifier"
+                      "name": "identifier"
                     },
                     {
                       "type": "REPEAT",
@@ -2269,7 +2273,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "_identifier"
+                            "name": "identifier"
                           }
                         ]
                       }
@@ -2903,10 +2907,6 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_identifier"
-        },
-        {
-          "type": "SYMBOL",
           "name": "nil"
         },
         {
@@ -2916,6 +2916,22 @@
         {
           "type": "SYMBOL",
           "name": "boolean"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "instance_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "class_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "global_variable"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
         },
         {
           "type": "SYMBOL",
@@ -3052,9 +3068,21 @@
         }
       ]
     },
-    "_identifier": {
+    "_method_name": {
       "type": "CHOICE",
       "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "operator"
+        },
         {
           "type": "SYMBOL",
           "name": "instance_variable"
@@ -3066,57 +3094,6 @@
         {
           "type": "SYMBOL",
           "name": "global_variable"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        }
-      ]
-    },
-    "_method_name": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "symbol"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "operator"
-        }
-      ]
-    },
-    "_undef_list": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_method_name"
-        },
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_undef_list"
-              },
-              {
-                "type": "STRING",
-                "value": ","
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_method_name"
-              }
-            ]
-          }
         }
       ]
     },
@@ -3128,8 +3105,29 @@
           "value": "undef"
         },
         {
-          "type": "SYMBOL",
-          "name": "_undef_list"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_method_name"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_method_name"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -3232,109 +3230,116 @@
                     "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
                   },
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ".."
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "|"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "^"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "&"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "<=>"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "=="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "==="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "=~"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ">"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ">="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "<"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "<="
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "+"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "-"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "*"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "/"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "%"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "**"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "<<"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": ">>"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "~"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "+@"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "-@"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "[]"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "[]="
-                      }
-                    ]
+                    "type": "PATTERN",
+                    "value": "@[a-zA-Z_][a-zA-Z0-9_]*"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "@@[a-zA-Z_][a-zA-Z0-9_]*"
+                  },
+                  {
+                    "type": "PATTERN",
+                    "value": "\\$(([&`'+])|([1-9][0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ".."
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "|"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "^"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "&"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<=>"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "=="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "==="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "=~"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "+"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "*"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "/"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "%"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "**"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<<"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">>"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "~"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "+@"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "-@"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "[]"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "[]="
                   }
                 ]
               }
@@ -3920,7 +3925,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_identifier"
+                    "name": "identifier"
                   },
                   {
                     "type": "STRING",
@@ -4073,7 +4078,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "_identifier"
+                      "name": "_formal_parameter"
                     }
                   ]
                 },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -109,17 +109,8 @@
           "name": "rescue_modifier"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         }
       ]
     },
@@ -238,55 +229,14 @@
           ]
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_body_statement"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "rescue"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "else"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "ensure"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
@@ -526,55 +476,14 @@
           ]
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_body_statement"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "rescue"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "else"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "ensure"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
@@ -604,55 +513,14 @@
           "name": "_terminator"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_body_statement"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "rescue"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "else"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "ensure"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
@@ -699,55 +567,14 @@
           "name": "_terminator"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_body_statement"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "rescue"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "else"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "ensure"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
@@ -902,17 +729,8 @@
           "value": "if"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         }
       ]
     },
@@ -928,17 +746,8 @@
           "value": "unless"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         }
       ]
     },
@@ -954,17 +763,8 @@
           "value": "while"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         }
       ]
     },
@@ -980,17 +780,8 @@
           "value": "until"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         }
       ]
     },
@@ -1009,17 +800,8 @@
             "value": "rescue"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -1032,17 +814,8 @@
           "value": "while"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "SYMBOL",
@@ -1074,17 +847,8 @@
           "value": "until"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "SYMBOL",
@@ -1124,17 +888,8 @@
           "value": "in"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "SYMBOL",
@@ -1290,17 +1045,8 @@
           "value": "if"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "SYMBOL",
@@ -1344,17 +1090,8 @@
           "value": "unless"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "SYMBOL",
@@ -1398,17 +1135,8 @@
           "value": "elsif"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "SYMBOL",
@@ -1508,55 +1236,14 @@
           "value": "begin"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_body_statement"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "rescue"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "else"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "ensure"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
             }
           ]
         },
@@ -1685,6 +1372,114 @@
     "rescued_exception": {
       "type": "PATTERN",
       "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
+    },
+    "_body_statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rescue"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "rescue"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "else"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "ensure"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "ensure"
+        }
+      ]
     },
     "_arg": {
       "type": "CHOICE",
@@ -2005,81 +1800,59 @@
         ]
       }
     },
-    "method_call_with_do_block": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_variable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scope_resolution"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "call"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "argument_list"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "do_block"
-                  }
-                ]
-              },
-              {
-                "type": "SYMBOL",
-                "name": "do_block"
-              }
-            ]
-          }
-        ]
-      }
-    },
     "method_call": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_variable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scope_resolution"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "call"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "scope_resolution"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "call"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "argument_list"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "scope_resolution"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "call"
+                }
+              ]
+            },
+            {
+              "type": "PREC",
+              "value": 1,
+              "content": {
                 "type": "SEQ",
                 "members": [
                   {
@@ -2091,10 +1864,71 @@
                     "name": "block"
                   }
                 ]
-              },
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_variable"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "scope_resolution"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "call"
+                }
+              ]
+            },
+            {
+              "type": "PREC",
+              "value": -1,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "argument_list"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "do_block"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
               {
-                "type": "SYMBOL",
-                "name": "argument_list"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_variable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "scope_resolution"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "call"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
@@ -2102,8 +1936,38 @@
               }
             ]
           }
-        ]
-      }
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_variable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "scope_resolution"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "call"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "do_block"
+              }
+            ]
+          }
+        }
+      ]
     },
     "argument_list": {
       "type": "PREC_LEFT",
@@ -2291,71 +2155,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "|"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "formal_parameters"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "_identifier"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ","
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "_identifier"
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": "|"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_block_parameters"
             },
             {
               "type": "BLANK"
@@ -2395,71 +2196,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "|"
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "formal_parameters"
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": ";"
-                        },
-                        {
-                          "type": "SEQ",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "_identifier"
-                            },
-                            {
-                              "type": "REPEAT",
-                              "content": {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": ","
-                                  },
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "_identifier"
-                                  }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "type": "BLANK"
-                    }
-                  ]
-                },
-                {
-                  "type": "STRING",
-                  "value": "|"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_block_parameters"
             },
             {
               "type": "BLANK"
@@ -2484,6 +2222,73 @@
         }
       ]
     },
+    "_block_parameters": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "|"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "formal_parameters"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ";"
+                },
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_identifier"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_identifier"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "|"
+        }
+      ]
+    },
     "and": {
       "type": "PREC_LEFT",
       "value": -2,
@@ -2491,34 +2296,16 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "and"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2530,34 +2317,16 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "or"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2573,17 +2342,8 @@
             "value": "not"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2599,17 +2359,8 @@
             "value": "defined?"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2629,17 +2380,8 @@
             "value": "="
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2680,17 +2422,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2719,17 +2452,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2741,51 +2465,24 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "?"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": ":"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2797,17 +2494,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -2823,17 +2511,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2845,34 +2524,16 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "||"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2884,34 +2545,16 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "&&"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2923,17 +2566,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -2965,17 +2599,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -2987,17 +2612,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -3021,17 +2637,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3043,17 +2650,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -3069,17 +2667,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3091,34 +2680,16 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "&"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3130,17 +2701,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -3156,17 +2718,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3178,17 +2731,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -3204,17 +2748,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3226,17 +2761,8 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "CHOICE",
@@ -3256,17 +2782,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3282,17 +2799,8 @@
             "value": "-"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3304,34 +2812,16 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           },
           {
             "type": "STRING",
             "value": "**"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3347,17 +2837,8 @@
             "value": "+"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -3382,45 +2863,40 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
     },
     "_lhs": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_variable"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "scope_resolution"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "element_reference"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "call"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "method_call"
-        }
-      ]
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_variable"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "scope_resolution"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "element_reference"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "call"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "method_call"
+          }
+        ]
+      }
     },
     "_variable": {
       "type": "CHOICE",
@@ -4193,17 +3669,8 @@
           "value": "#{"
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "method_call_with_do_block"
-            }
-          ]
+          "type": "SYMBOL",
+          "name": "_arg"
         },
         {
           "type": "STRING",
@@ -4270,8 +3737,16 @@
               "value": "["
             },
             {
-              "type": "SYMBOL",
-              "name": "_array_items"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_array_items"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "STRING",
@@ -4321,36 +3796,26 @@
       "type": "CHOICE",
       "members": [
         {
+          "type": "SYMBOL",
+          "name": "_arg"
+        },
+        {
           "type": "SEQ",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_arg"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "method_call_with_do_block"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_arg"
+            },
+            {
+              "type": "STRING",
+              "value": ","
             },
             {
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "_array_items"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_array_items"
                 },
                 {
                   "type": "BLANK"
@@ -4358,9 +3823,6 @@
               ]
             }
           ]
-        },
-        {
-          "type": "BLANK"
         }
       ]
     },
@@ -4444,17 +3906,8 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_arg"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "method_call_with_do_block"
-                      }
-                    ]
+                    "type": "SYMBOL",
+                    "name": "_arg"
                   },
                   {
                     "type": "STRING",
@@ -4478,17 +3931,8 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_arg"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "method_call_with_do_block"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_arg"
           }
         ]
       }
@@ -4747,19 +4191,5 @@
       "value": "\\s"
     }
   ],
-  "conflicts": [
-    [
-      "_lhs",
-      "method_call",
-      "method_call_with_do_block"
-    ],
-    [
-      "_lhs",
-      "method_call"
-    ],
-    [
-      "_lhs",
-      "method_call_with_do_block"
-    ]
-  ]
+  "conflicts": []
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -589,7 +589,7 @@
       ]
     },
     "super": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",
@@ -614,7 +614,7 @@
       }
     },
     "return": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",
@@ -639,7 +639,7 @@
       }
     },
     "yield": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",
@@ -664,7 +664,7 @@
       }
     },
     "break": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",
@@ -689,7 +689,7 @@
       }
     },
     "next": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",
@@ -722,72 +722,88 @@
       "value": "retry"
     },
     "if_modifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_statement"
-        },
-        {
-          "type": "STRING",
-          "value": "if"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+      "type": "PREC",
+      "value": 16,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_statement"
+          },
+          {
+            "type": "STRING",
+            "value": "if"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_arg"
+          }
+        ]
+      }
     },
     "unless_modifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_statement"
-        },
-        {
-          "type": "STRING",
-          "value": "unless"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+      "type": "PREC",
+      "value": 16,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_statement"
+          },
+          {
+            "type": "STRING",
+            "value": "unless"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_arg"
+          }
+        ]
+      }
     },
     "while_modifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_statement"
-        },
-        {
-          "type": "STRING",
-          "value": "while"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+      "type": "PREC",
+      "value": 16,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_statement"
+          },
+          {
+            "type": "STRING",
+            "value": "while"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_arg"
+          }
+        ]
+      }
     },
     "until_modifier": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_statement"
-        },
-        {
-          "type": "STRING",
-          "value": "until"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+      "type": "PREC",
+      "value": 16,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_statement"
+          },
+          {
+            "type": "STRING",
+            "value": "until"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_arg"
+          }
+        ]
+      }
     },
     "rescue_modifier": {
       "type": "PREC",
@@ -2044,7 +2060,7 @@
       "type": "PREC_LEFT",
       "value": 1,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
             "type": "CHOICE",
@@ -2060,29 +2076,38 @@
             ]
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_arg"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "argument_pair"
-                    }
-                  ]
-                }
-              ]
-            }
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_arg"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "argument_pair"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_argument_list"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -184,7 +184,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_function_name"
+          "name": "_method_name"
         },
         {
           "type": "CHOICE",
@@ -1280,7 +1280,7 @@
     },
     "pattern": {
       "type": "SYMBOL",
-      "name": "_statement"
+      "name": "_arg"
     },
     "if": {
       "type": "SEQ",
@@ -3467,10 +3467,6 @@
       "type": "PATTERN",
       "value": "\\$(([&`'+])|([1-9][0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))"
     },
-    "constant": {
-      "type": "PATTERN",
-      "value": "[A-Z_][a-zA-Z0-9_]*"
-    },
     "identifier": {
       "type": "PATTERN",
       "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
@@ -3598,14 +3594,10 @@
         {
           "type": "SYMBOL",
           "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "constant"
         }
       ]
     },
-    "_function_name": {
+    "_method_name": {
       "type": "CHOICE",
       "members": [
         {
@@ -3627,7 +3619,7 @@
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_function_name"
+          "name": "_method_name"
         },
         {
           "type": "PREC",
@@ -3645,7 +3637,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "_function_name"
+                "name": "_method_name"
               }
             ]
           }
@@ -3674,11 +3666,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_function_name"
+          "name": "_method_name"
         },
         {
           "type": "SYMBOL",
-          "name": "_function_name"
+          "name": "_method_name"
         }
       ]
     },
@@ -4279,7 +4271,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_array_function_names"
+              "name": "_array_items"
             },
             {
               "type": "STRING",
@@ -4325,7 +4317,7 @@
         }
       ]
     },
-    "_array_function_names": {
+    "_array_items": {
       "type": "CHOICE",
       "members": [
         {
@@ -4356,7 +4348,7 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "_array_function_names"
+                      "name": "_array_items"
                     }
                   ]
                 },
@@ -4387,7 +4379,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_hash_function_names"
+                "name": "_hash_items"
               },
               {
                 "type": "BLANK"
@@ -4401,7 +4393,7 @@
         ]
       }
     },
-    "_hash_function_names": {
+    "_hash_items": {
       "type": "SEQ",
       "members": [
         {
@@ -4423,7 +4415,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "_hash_function_names"
+                      "name": "_hash_items"
                     },
                     {
                       "type": "BLANK"


### PR DESCRIPTION
~~Very much a WIP and I'm still planning to push additional commits.~~ Ready for review now.

- [x] Shorten the names of most of the control flow productions. Many had suffixes like `_statement` which isn't correct as they can be used as expressions. (e.g. `s/begin_statement/begin`).
- [x] Remove regex precedence (not necessary).
- [x] Properly nest `elsif` and `else` in the `if` trees we produce.
- [x] Properly nest `when` and `else` in the `case` trees we produce.
- [x] Remove all unbalanced delimiter parsing and many of the balanced delimeters for strings, regexes, symbols, etc. We can add these back in later, but at this time they are just too high a burden on the dev cycle. Goal is to speed up grammar generate times in the near term.
- [x] `undef` supports a list of arguments now.
- [x] `alias` supports backrefs and other globals.
- [x] Introduce `self` productions.
- [x] Parse a few keywords like `__FILE__`, `__LINE__`, `__ENCODING__`. 
- [x] Produce a single `lambda` production for both forms (`->` and `lambda`).
- [x] `return` with multiple arguments.
- [x] Identify constants, instance variables, class variables, and global variables.
- [x] Refactor so that `rescue`, `ensure`, `else` control flow can be used in other structures than just `begin` (methods for example).
- [x] Move things out of `_statement` and into `_primary` where appropriate (e.g. moving `array` allows things like `[1..10].any? { |i| i > 10 }`).
- [x] Audit usage of precedence.
- [x] Support `super`, `redo`, `retry`, `break`, and `next`.
- [x] Rename `function_call` to `method_call`.
- [x] Rename `member_access` to `call` and `scope_resolution_expression` to just `scope_resolution`.