### PR TITLE
Delimiters and other fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -278,7 +278,7 @@ module.exports = grammar({
       $.retry
     ),
 
-    element_reference: $ => prec.left(1, seq($._primary, '[', $._argument_list, ']')),
+    element_reference: $ => prec.left(1, seq($._primary, '[', $._argument_list_with_trailing_comma, ']')),
     scope_resolution: $ => prec.left(1, seq(optional($._primary), '::', $.identifier)),
     call: $ => prec.left(PREC.BITWISE_AND + 1, seq($._primary, choice('.', '&.'), $.identifier)),
 
@@ -295,14 +295,16 @@ module.exports = grammar({
     },
 
     argument_list: $ => prec.left(1, choice(
-      seq('(', optional($._argument_list), optional($.block_argument), ')'),
+      seq('(', optional($._argument_list_with_trailing_comma), optional($.block_argument), ')'),
       seq($._argument_list, optional($.block_argument))
     )),
 
-    _argument_list: $ => prec.left(1, sepTrailing($._argument_list, choice(
-      $._arg,
-      $.argument_pair
-    ), ',')),
+    _argument_list_with_trailing_comma: $ => prec.left(1, sepTrailing(
+      $._argument_list_with_trailing_comma,
+      choice($._arg, $.argument_pair),
+      ','
+    )),
+    _argument_list: $ => prec.left(1, commaSep1(choice($._arg, $.argument_pair))),
 
     argument_pair: $ => prec.left(1, seq(choice(
       seq($.symbol, '=>'),

--- a/grammar.js
+++ b/grammar.js
@@ -422,7 +422,10 @@ module.exports = grammar({
       seq(":'", $._single_quoted_continuation),
       seq(':"', $._double_quoted_continuation),
       seq('%s', choice(
-        $._uninterpolated_paren
+        $._uninterpolated_angle,
+        $._uninterpolated_bracket,
+        $._uninterpolated_paren,
+        $._uninterpolated_brace
       ))
     ),
 
@@ -438,10 +441,16 @@ module.exports = grammar({
     string: $ => seq(choice(
       $._quoted_string,
       seq(/%Q?/, choice(
-        $._interpolated_paren
+        $._interpolated_angle,
+        $._interpolated_bracket,
+        $._interpolated_paren,
+        $._interpolated_brace
       )),
       seq(/%q/, choice(
-        $._uninterpolated_paren
+        $._uninterpolated_angle,
+        $._uninterpolated_bracket,
+        $._uninterpolated_paren,
+        $._uninterpolated_brace
       ))
     ), repeat($._quoted_string)),
 
@@ -452,24 +461,39 @@ module.exports = grammar({
     _single_quoted_continuation: $ => stringBody(blank(), "'"),
     _double_quoted_continuation: $ => stringBody(blank(), '"', $.interpolation),
 
+    _interpolated_angle: $ => stringBody('<', '>', $.interpolation, $._interpolated_angle),
+    _interpolated_bracket: $ => stringBody('[', ']', $.interpolation, $._interpolated_bracket),
     _interpolated_paren: $ => stringBody('(', ')', $.interpolation, $._interpolated_paren),
+    _interpolated_brace: $ => stringBody('{', '}', $.interpolation, $._interpolated_brace),
+    _uninterpolated_angle: $ => stringBody('<', '>', null, $._uninterpolated_angle),
+    _uninterpolated_bracket: $ => stringBody('[', ']', null, $._uninterpolated_bracket),
     _uninterpolated_paren: $ => stringBody('(', ')', null, $._uninterpolated_paren),
+    _uninterpolated_brace: $ => stringBody('{', '}', null, $._uninterpolated_brace),
     interpolation: $ => seq('#{', $._arg, '}'),
 
     subshell: $ => choice(
       stringBody('`', '`'),
       seq('%x', choice(
-        $._interpolated_paren
+        $._interpolated_angle,
+        $._interpolated_bracket,
+        $._interpolated_paren,
+        $._interpolated_brace
       ))
     ),
 
     array: $ => choice(
       seq('[', optional($._array_items), ']'),
       seq(/%[wi]/, choice(
-        $._uninterpolated_paren
+        $._uninterpolated_angle,
+        $._uninterpolated_bracket,
+        $._uninterpolated_paren,
+        $._uninterpolated_brace
       )),
       seq(/%[WI]/, choice(
-        $._interpolated_paren
+        $._interpolated_angle,
+        $._interpolated_bracket,
+        $._interpolated_paren,
+        $._interpolated_brace
       ))
     ),
 
@@ -486,11 +510,17 @@ module.exports = grammar({
     regex: $ => choice(
       regexBody('/', '/', $.interpolation),
       seq('%r', choice(
-        $._regex_interpolated_paren
+        $._regex_interpolated_angle,
+        $._regex_interpolated_bracket,
+        $._regex_interpolated_paren,
+        $._regex_interpolated_brace
       ))
     ),
 
+    _regex_interpolated_angle: $ => regexBody('<', '>', $.interpolation, $._regex_interpolated_angle),
+    _regex_interpolated_bracket: $ => regexBody('[', ']', $.interpolation, $._regex_interpolated_bracket),
     _regex_interpolated_paren: $ => regexBody('(', ')', $.interpolation, $._regex_interpolated_paren),
+    _regex_interpolated_brace: $ => regexBody('{', '}', $.interpolation, $._regex_interpolated_brace),
 
     lambda: $ => choice(
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -27,6 +27,7 @@ const PREC = {
   UNARY_PLUS: 85,
 };
 
+const integerPattern = /0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/;
 const identifierPattern = /[a-zA-Z_][a-zA-Z0-9_]*(\?|\!)?/;
 // Global variables start with $ and can be:
 // - Regex back references (e.g. $&, $', $', and $+)
@@ -43,6 +44,11 @@ module.exports = grammar({
   extras: $ => [
     $.comment,
     /\s/
+  ],
+
+  conflicts: $ => [
+    // Temporary fix until we can backtrack to parse things like `3.times`
+    [$.integer, $.float],
   ],
 
   rules: {
@@ -431,8 +437,10 @@ module.exports = grammar({
       ))
     ),
 
-    integer: $ => (/0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/),
-    float: $ => (/\d(_?\d)*\.\d(_?\d)*([eE]\d(_?\d)*)?/),
+    integer: $ => (integerPattern),
+    // TODO: When we can backtrack, redefine float as regex instead of seq.
+    // float: $ => (/\d(_?\d)*\.\d(_?\d)*([eE]\d(_?\d)*)?/),
+    float: $ => seq(integerPattern, '.' ,/\d(_?\d)*([eE]\d(_?\d)*)?/),
     boolean: $ => token(choice('true', 'false', 'TRUE', 'FALSE')),
     self: $ => 'self',
     nil: $ => token(choice('nil', 'NIL')),

--- a/grammar.js
+++ b/grammar.js
@@ -580,7 +580,7 @@ function stringBody (open, close, interpolation, self) {
   if (interpolation) {
     contents.push(interpolation)
     disallowedContentChars.push('#')
-    contents.push(/#[^{}]/)
+    contents.push(/#[^{]/)
   }
 
   if (self) {
@@ -625,7 +625,7 @@ function regexBody (open, close, interpolation, self) {
   if (interpolation) {
     contents.push(interpolation)
     disallowedContentChars.push('#')
-    contents.push(/#[^{}]/)
+    contents.push(/#[^{]/)
   }
 
   if (self) {

--- a/grammar.js
+++ b/grammar.js
@@ -387,12 +387,14 @@ module.exports = grammar({
 
     _method_name: $ => choice(
       $.identifier,
+      $.setter,
       $.symbol,
       $.operator,
       $.instance_variable,
       $.class_variable,
       $.global_variable
     ),
+    setter: $ => seq($.identifier, '='),
 
     undef: $ => seq('undef', commaSep1($._method_name)),
     alias: $ => seq('alias', $._method_name, $._method_name),

--- a/grammar.js
+++ b/grammar.js
@@ -193,14 +193,14 @@ module.exports = grammar({
     ensure: $ => seq('ensure', optional($._statements)),
     rescue: $ => seq(
       'rescue',
-      optional($.rescue_arguments),
-      optional(seq('=>', $.rescued_exception)),
+      optional($.exceptions),
+      optional($.exception_variable),
       $._then,
       optional($._statements),
       optional($.rescue)
     ),
-    rescue_arguments: $ => commaSep1($._arg),
-    rescued_exception: $ => (identifierPattern),
+    exceptions: $ => commaSep1($._arg),
+    exception_variable: $ => seq('=>', $._lhs),
 
     _body_statement: $ => choice(
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -431,6 +431,7 @@ module.exports = grammar({
       ))),
       seq(":'", $._single_quoted_continuation),
       seq(':"', $._double_quoted_continuation),
+      ':"#"', // TODO: Remove this hack
       seq('%s', choice(
         $._uninterpolated_angle,
         $._uninterpolated_bracket,
@@ -468,7 +469,7 @@ module.exports = grammar({
 
     _quoted_string: $ => choice(
       seq("'", $._single_quoted_continuation),
-      seq('"', $._double_quoted_continuation)
+      seq('"', choice($._double_quoted_continuation, '#"')) // TODO: Remove this hack
     ),
     _single_quoted_continuation: $ => stringBody(blank(), "'"),
     _double_quoted_continuation: $ => stringBody(blank(), '"', $.interpolation),
@@ -521,11 +522,13 @@ module.exports = grammar({
 
     regex: $ => choice(
       regexBody('/', '/', $.interpolation),
+      '/#/', // TODO: Remove this hack
       seq('%r', choice(
         $._regex_interpolated_angle,
         $._regex_interpolated_bracket,
         $._regex_interpolated_paren,
-        $._regex_interpolated_brace
+        $._regex_interpolated_brace,
+        '<#>', '[#]', '(#)', '{#}' // TODO: Remove this hack
       ))
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -43,7 +43,7 @@ module.exports = grammar({
 
   extras: $ => [
     $.comment,
-    /\s/
+    /\s|\\\n/
   ],
 
   conflicts: $ => [

--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -348,13 +348,13 @@ end
 ---
 
 (program
-  (begin (rescue (rescue_arguments (identifier))))
-  (begin (rescue (rescue_arguments (identifier))))
-  (begin (rescue (rescue_arguments (identifier)) (identifier)))
-  (begin (rescue (rescued_exception) (identifier)))
-  (begin (rescue (rescue_arguments (identifier) (identifier)) (identifier)))
-  (begin (rescue (rescue_arguments (identifier)) (rescued_exception)))
-  (begin (rescue (rescue_arguments (identifier)) (rescued_exception) (identifier))))
+  (begin (rescue (exceptions (identifier))))
+  (begin (rescue (exceptions (identifier))))
+  (begin (rescue (exceptions (identifier)) (identifier)))
+  (begin (rescue (exception_variable (identifier)) (identifier)))
+  (begin (rescue (exceptions (identifier) (identifier)) (identifier)))
+  (begin (rescue (exceptions (identifier)) (exception_variable (identifier))))
+  (begin (rescue (exceptions (identifier)) (exception_variable (identifier)) (identifier))))
 
 =================
 rescue modifier
@@ -384,7 +384,7 @@ end
 
 (program
   (begin (identifier)
-    (rescue (rescue_arguments (identifier)) (retry))
+    (rescue (exceptions (identifier)) (retry))
     (else (identifier))
     (ensure (identifier))))
 

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -31,6 +31,17 @@ end
 (program (method (identifier) (identifier)))
 
 ================
+method as attribute setter
+================
+
+def foo=
+end
+
+---
+
+(program (method (setter (identifier))))
+
+================
 method with call to super
 ================
 

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -389,6 +389,33 @@ print("hello")
   (method_call (identifier) (argument_list (string))))
 
 ===============================
+method call arguments on multiple lines
+===============================
+
+foo a,
+  b, c
+
+---
+
+(program
+  (method_call
+    (identifier)
+    (argument_list (identifier) (identifier) (identifier))))
+
+===============================
+method call with training comma
+===============================
+
+foo(a, b,)
+
+---
+
+(program
+  (method_call
+    (identifier)
+    (argument_list (identifier) (identifier))))
+
+===============================
 method call with receiver
 ===============================
 

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -389,7 +389,7 @@ print("hello")
   (method_call (identifier) (argument_list (string))))
 
 ===============================
-method call arguments on multiple lines
+method call with arguments on multiple lines
 ===============================
 
 foo a,
@@ -653,3 +653,21 @@ end
 ---
 
 (program (lambda (formal_parameters (identifier)) (integer)))
+
+===============================
+backslash-newline as line continuation
+===============================
+
+foo \
+  a, b
+
+"abc \
+de"
+
+---
+
+(program
+  (method_call
+    (identifier)
+    (argument_list (identifier) (identifier)))
+  (string))

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -34,10 +34,11 @@ double quoted symbol
 ====================
 
 :"foo bar"
+:"#"
 
 ---
 
-(program (symbol))
+(program (symbol) (symbol))
 
 =======================================
 double quoted symbol with interpolation
@@ -242,6 +243,16 @@ double-quoted string with backslash and character
 =================================================
 
 "\d"
+
+---
+
+(program (string))
+
+=================================
+double-quoted string with just pound
+=================================
+
+"#"
 
 ---
 
@@ -493,11 +504,13 @@ regular expression with interpolation
 
 /word#{foo}word/
 /word#word/
+/#/
 
 ---
 
 (program
 	(regex (interpolation (identifier)))
+	(regex)
 	(regex))
 
 =====================================================
@@ -505,10 +518,11 @@ percent r regular expression with balanced delimiters
 =====================================================
 
 %r(a(b)c)
+%r(#)
 
 ---
 
-(program (regex))
+(program (regex) (regex))
 
 =======================================================================
 percent r regular expression with balanced delimiters and interpolation

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -53,11 +53,14 @@ double quoted symbol with interpolation
 percent symbol with balanced delimiters
 =======================================
 
+%s{a{b}c}
+%s<a<b>c>
 %s(a(b)c)
+%s[a[b]c]
 
 ---
 
-(program (symbol))
+(program (symbol) (symbol) (symbol) (symbol))
 
 =======
 integer
@@ -258,31 +261,40 @@ escaped interpolation
 percent q string with balanced delimiters
 =========================================
 
+%q<a<b>c>
+%q{a{b}c}
+%q[a[b]c]
 %q(a(b)c)
 
 ---
 
-(program (string))
+(program (string) (string) (string) (string))
 
 =========================================
 percent string with balanced delimiters
 =========================================
 
+%<a<b>c>
+%{a{b}c}
+%[a[b]c]
 %(a(b)c)
 
 ---
 
-(program (string))
+(program (string) (string) (string) (string))
 
 =========================================
 percent Q string with balanced delimiters
 =========================================
 
+%Q<a<b>c>
+%Q{a{b}c}
+%Q[a[b]c]
 %Q(a(b)c)
 
 ---
 
-(program (string))
+(program (string) (string) (string) (string))
 
 ===============
 string chaining

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -72,6 +72,16 @@ integer
 
 (program (integer))
 
+=======
+integer as object
+=======
+
+3.times
+
+---
+
+(program (call (integer) (identifier)))
+
 =======================
 integer with underscore
 =======================

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1306,7 +1306,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "rescue_arguments"
+              "name": "exceptions"
             },
             {
               "type": "BLANK"
@@ -1317,17 +1317,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "=>"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "rescued_exception"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "exception_variable"
             },
             {
               "type": "BLANK"
@@ -1364,7 +1355,7 @@
         }
       ]
     },
-    "rescue_arguments": {
+    "exceptions": {
       "type": "SEQ",
       "members": [
         {
@@ -1389,9 +1380,18 @@
         }
       ]
     },
-    "rescued_exception": {
-      "type": "PATTERN",
-      "value": "[a-zA-Z_][a-zA-Z0-9_]*(\\?|\\!)?"
+    "exception_variable": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lhs"
+        }
+      ]
     },
     "_body_statement": {
       "type": "CHOICE",
@@ -1752,7 +1752,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_argument_list"
+            "name": "_argument_list_with_trailing_comma"
           },
           {
             "type": "STRING",
@@ -2007,7 +2007,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_argument_list"
+                    "name": "_argument_list_with_trailing_comma"
                   },
                   {
                     "type": "BLANK"
@@ -2056,7 +2056,7 @@
         ]
       }
     },
-    "_argument_list": {
+    "_argument_list_with_trailing_comma": {
       "type": "PREC_LEFT",
       "value": 1,
       "content": {
@@ -2100,7 +2100,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_argument_list"
+                    "name": "_argument_list_with_trailing_comma"
                   },
                   {
                     "type": "BLANK"
@@ -2108,6 +2108,53 @@
                 ]
               }
             ]
+          }
+        ]
+      }
+    },
+    "_argument_list": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "argument_pair"
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ","
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_arg"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "argument_pair"
+                    }
+                  ]
+                }
+              ]
+            }
           }
         ]
       }
@@ -3102,6 +3149,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "setter"
+        },
+        {
+          "type": "SYMBOL",
           "name": "symbol"
         },
         {
@@ -3119,6 +3170,19 @@
         {
           "type": "SYMBOL",
           "name": "global_variable"
+        }
+      ]
+    },
+    "setter": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "STRING",
+          "value": "="
         }
       ]
     },
@@ -3409,7 +3473,19 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "_uninterpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "_uninterpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_brace"
                 }
               ]
             }
@@ -3422,8 +3498,21 @@
       "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
     },
     "float": {
-      "type": "PATTERN",
-      "value": "\\d(_?\\d)*\\.\\d(_?\\d)*([eE]\\d(_?\\d)*)?"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
+        },
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\d(_?\\d)*([eE]\\d(_?\\d)*)?"
+        }
+      ]
     },
     "boolean": {
       "type": "TOKEN",
@@ -3503,7 +3592,19 @@
                   "members": [
                     {
                       "type": "SYMBOL",
+                      "name": "_interpolated_angle"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_interpolated_bracket"
+                    },
+                    {
+                      "type": "SYMBOL",
                       "name": "_interpolated_paren"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_interpolated_brace"
                     }
                   ]
                 }
@@ -3521,7 +3622,19 @@
                   "members": [
                     {
                       "type": "SYMBOL",
+                      "name": "_uninterpolated_angle"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_uninterpolated_bracket"
+                    },
+                    {
+                      "type": "SYMBOL",
                       "name": "_uninterpolated_paren"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_uninterpolated_brace"
                     }
                   ]
                 }
@@ -3625,6 +3738,80 @@
         }
       ]
     },
+    "_interpolated_angle": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_angle"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\>\\\\\\\n\\#\\<]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "_interpolated_bracket": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_bracket"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\]\\\\\\\n\\#\\[]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
     "_interpolated_paren": {
       "type": "SEQ",
       "members": [
@@ -3662,6 +3849,101 @@
         }
       ]
     },
+    "_interpolated_brace": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_interpolated_brace"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\}\\\\\\\n\\#\\{]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_uninterpolated_angle": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_uninterpolated_angle"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\>\\\\\\\n\\<]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        }
+      ]
+    },
+    "_uninterpolated_bracket": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_uninterpolated_bracket"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\]\\\\\\\n\\[]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
     "_uninterpolated_paren": {
       "type": "SEQ",
       "members": [
@@ -3688,6 +3970,35 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "_uninterpolated_brace": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_uninterpolated_brace"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\\\.|[^\\}\\\\\\\n\\{]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "}"
         }
       ]
     },
@@ -3748,7 +4059,19 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "_interpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "_interpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_brace"
                 }
               ]
             }
@@ -3796,7 +4119,19 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "_uninterpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "_uninterpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_uninterpolated_brace"
                 }
               ]
             }
@@ -3814,7 +4149,19 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "_interpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "_interpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_interpolated_brace"
                 }
               ]
             }
@@ -4015,11 +4362,97 @@
               "members": [
                 {
                   "type": "SYMBOL",
+                  "name": "_regex_interpolated_angle"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_regex_interpolated_bracket"
+                },
+                {
+                  "type": "SYMBOL",
                   "name": "_regex_interpolated_paren"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_regex_interpolated_brace"
                 }
               ]
             }
           ]
+        }
+      ]
+    },
+    "_regex_interpolated_angle": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_angle"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\<\\>\\[\\\\\\\n\\#]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\>[a-z]*"
+        }
+      ]
+    },
+    "_regex_interpolated_bracket": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_bracket"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\[\\]\\[\\\\\\\n\\#]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\][a-z]*"
         }
       ]
     },
@@ -4057,6 +4490,43 @@
         {
           "type": "PATTERN",
           "value": "\\)[a-z]*"
+        }
+      ]
+    },
+    "_regex_interpolated_brace": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              },
+              {
+                "type": "PATTERN",
+                "value": "#[^{}]"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_regex_interpolated_brace"
+              },
+              {
+                "type": "PATTERN",
+                "value": "\\[[^\\]\\n]*\\]|\\\\.|[^\\{\\}\\[\\\\\\\n\\#]"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PATTERN",
+          "value": "\\}[a-z]*"
         }
       ]
     },
@@ -4221,5 +4691,10 @@
       "value": "\\s"
     }
   ],
-  "conflicts": []
+  "conflicts": [
+    [
+      "integer",
+      "float"
+    ]
+  ]
 }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3462,6 +3462,10 @@
           ]
         },
         {
+          "type": "STRING",
+          "value": ":\"#\""
+        },
+        {
           "type": "SEQ",
           "members": [
             {
@@ -3675,8 +3679,17 @@
               "value": "\""
             },
             {
-              "type": "SYMBOL",
-              "name": "_double_quoted_continuation"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_double_quoted_continuation"
+                },
+                {
+                  "type": "STRING",
+                  "value": "#\""
+                }
+              ]
             }
           ]
         }
@@ -3723,7 +3736,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "PATTERN",
@@ -3756,7 +3769,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -3793,7 +3806,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -3830,7 +3843,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -3867,7 +3880,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -4335,7 +4348,7 @@
                   },
                   {
                     "type": "PATTERN",
-                    "value": "#[^{}]"
+                    "value": "#[^{]"
                   },
                   {
                     "type": "PATTERN",
@@ -4349,6 +4362,10 @@
               "value": "\\/[a-z]*"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": "/#/"
         },
         {
           "type": "SEQ",
@@ -4375,6 +4392,22 @@
                 {
                   "type": "SYMBOL",
                   "name": "_regex_interpolated_brace"
+                },
+                {
+                  "type": "STRING",
+                  "value": "<#>"
+                },
+                {
+                  "type": "STRING",
+                  "value": "[#]"
+                },
+                {
+                  "type": "STRING",
+                  "value": "(#)"
+                },
+                {
+                  "type": "STRING",
+                  "value": "{#}"
                 }
               ]
             }
@@ -4400,7 +4433,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -4437,7 +4470,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -4474,7 +4507,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",
@@ -4511,7 +4544,7 @@
               },
               {
                 "type": "PATTERN",
-                "value": "#[^{}]"
+                "value": "#[^{]"
               },
               {
                 "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4721,7 +4721,7 @@
     },
     {
       "type": "PATTERN",
-      "value": "\\s"
+      "value": "\\s|\\\\\\n"
     }
   ],
   "conflicts": [


### PR DESCRIPTION
- Bring back the balanced delimiters for strings, regexes, symbols, and subshells.
- Hack fix to be able to parse things like `3.times` until we have a better backtrack mechanism in tree-sitter. The problem is that the float regex's `.` is capturing `3.`, but then fails and errors entirely when it finds a `t` next. Instead we need to be able to backtrack and try another option (like an `integer` in a `call`.
- Allow method names to have `=` on the end like `def foo=; end`
- Rename exception list and variable in rescues and relax the captured exception variable to be any `_lhs`.
- Fix for when trailing commas in argument lists are allowed (only when you're using `()` or `[]` around the argument list).
- Hack fix for rules that allow interpolation, but where just a single `#` character is provided.
- Allow `\` at end of line to be used as line continuation.