### PR TITLE
Unify the many operator rules into 'binary' and 'unary'

### DIFF
--- a/grammar_test/control-flow.txt
+++ b/grammar_test/control-flow.txt
@@ -487,6 +487,6 @@ end
 ---
 
 (program (assignment (identifier)
-  (case (assignment (identifier) (bitwise_or (identifier) (identifier)))
+  (case (assignment (identifier) (binary (identifier) (identifier)))
     (when (pattern (identifier))
       (else)))))

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -92,7 +92,7 @@ not foo
 
 ---
 
-(program (not (identifier)))
+(program (unary (identifier)))
 
 ===
 and
@@ -102,7 +102,7 @@ foo and bar
 
 ---
 
-(program (and (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ===
 or
@@ -112,7 +112,7 @@ foo or bar
 
 ---
 
-(program (or (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ====================
 and or associativity
@@ -122,7 +122,7 @@ a or b and c
 
 ---
 
-(program (and (or (identifier) (identifier)) (identifier)))
+(program (binary (binary (identifier) (identifier)) (identifier)))
 
 ========
 defined?
@@ -137,11 +137,11 @@ defined?(@foo)
 ---
 
 (program
-  (defined (identifier))
-  (defined (call (identifier) (identifier)))
-  (defined (identifier))
-  (defined (global_variable))
-  (defined (instance_variable)))
+  (unary (identifier))
+  (unary (call (identifier) (identifier)))
+  (unary (identifier))
+  (unary (global_variable))
+  (unary (instance_variable)))
 
 ==========
 assignment
@@ -194,11 +194,11 @@ x /= y
 ---
 
 (program
-  (math_assignment (identifier) (identifier))
-  (math_assignment (identifier) (identifier))
-  (math_assignment (identifier) (identifier))
-  (math_assignment (identifier) (identifier))
-  (math_assignment (identifier) (identifier)))
+  (operator_assignment (identifier) (identifier))
+  (operator_assignment (identifier) (identifier))
+  (operator_assignment (identifier) (identifier))
+  (operator_assignment (identifier) (identifier))
+  (operator_assignment (identifier) (identifier)))
 
 ==========
 conditional assignment
@@ -210,8 +210,8 @@ x &&= y
 ---
 
 (program
-  (conditional_assignment (identifier) (identifier))
-  (conditional_assignment (identifier) (identifier)))
+  (operator_assignment (identifier) (identifier))
+  (operator_assignment (identifier) (identifier)))
 
 ===========
 conditional
@@ -256,7 +256,7 @@ a || b
 
 ---
 
-(program (boolean_or (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ===========
 boolean and
@@ -266,7 +266,7 @@ a && b
 
 ---
 
-(program (boolean_and (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ==========
 relational
@@ -282,12 +282,12 @@ a !~ b
 ---
 
 (program
-  (relational (identifier) (identifier))
-  (relational (identifier) (identifier))
-  (relational (identifier) (identifier))
-  (relational (identifier) (identifier))
-  (relational (identifier) (identifier))
-  (relational (identifier) (identifier)))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier)))
 
 ==========
 comparison
@@ -301,10 +301,10 @@ a >= b
 ---
 
 (program
-  (comparison (identifier) (identifier))
-  (comparison (identifier) (identifier))
-  (comparison (identifier) (identifier))
-  (comparison (identifier) (identifier)))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier)))
 
 ==========
 bitwise or
@@ -314,7 +314,7 @@ a | b
 
 ---
 
-(program (bitwise_or (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ===========
 bitwise xor
@@ -324,7 +324,7 @@ a ^ b
 
 ---
 
-(program (bitwise_or (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ===========
 bitwise and
@@ -334,7 +334,7 @@ a & b
 
 ---
 
-(program (bitwise_and (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 =====
 shift
@@ -346,8 +346,8 @@ a << b
 ---
 
 (program
-  (shift (identifier) (identifier))
-  (shift (identifier) (identifier)))
+  (binary (identifier) (identifier))
+  (binary (identifier) (identifier)))
 
 ========
 additive
@@ -357,7 +357,7 @@ a + b
 
 ---
 
-(program (additive (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ==============
 multiplicative
@@ -367,7 +367,7 @@ a * b
 
 ---
 
-(program (multiplicative (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ===========
 unary minus
@@ -377,7 +377,7 @@ unary minus
 
 ---
 
-(program (unary_minus (identifier)))
+(program (unary (identifier)))
 
 ===========
 exponential
@@ -387,7 +387,7 @@ a ** b
 
 ---
 
-(program (exponential (identifier) (identifier)))
+(program (binary (identifier) (identifier)))
 
 ==========
 complement
@@ -397,7 +397,7 @@ complement
 
 ---
 
-(program (complement (identifier)))
+(program (unary (identifier)))
 
 ===============================
 method call
@@ -610,7 +610,7 @@ foo(bar, baz) { quux }
   (method_call (identifier) (block (formal_parameters (identifier)) (identifier)))
   (method_call (identifier) (argument_list (method_call
     (call (identifier) (identifier))
-    (block (formal_parameters (identifier)) (comparison (identifier) (integer))))))
+    (block (formal_parameters (identifier)) (binary (identifier) (integer))))))
 
   (method_call
     (identifier)

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -376,7 +376,7 @@ array as object
 ---
 (program
 	(method_call (call (array (integer) (integer)) (identifier))
-		(block (formal_parameters (identifier)) (comparison (identifier) (integer)))))
+		(block (formal_parameters (identifier)) (binary (identifier) (integer)))))
 
 =========================
 array with trailing comma

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1510,31 +1510,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "and"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "or"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "not"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "defined"
-        },
-        {
-          "type": "SYMBOL",
           "name": "assignment"
         },
         {
           "type": "SYMBOL",
-          "name": "math_assignment"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "conditional_assignment"
+          "name": "operator_assignment"
         },
         {
           "type": "SYMBOL",
@@ -1546,51 +1526,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "boolean_or"
+          "name": "binary"
         },
         {
           "type": "SYMBOL",
-          "name": "boolean_and"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "relational"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "comparison"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "bitwise_or"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "bitwise_and"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "shift"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "additive"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "multiplicative"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "unary_minus"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "exponential"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "complement"
+          "name": "unary"
         },
         {
           "type": "SYMBOL",
@@ -2365,82 +2305,6 @@
         }
       ]
     },
-    "and": {
-      "type": "PREC_LEFT",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "STRING",
-            "value": "and"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "or": {
-      "type": "PREC_LEFT",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "STRING",
-            "value": "or"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "not": {
-      "type": "PREC_RIGHT",
-      "value": 5,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "not"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "defined": {
-      "type": "PREC",
-      "value": 10,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "defined?"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
     "assignment": {
       "type": "PREC_RIGHT",
       "value": 15,
@@ -2471,7 +2335,7 @@
         ]
       }
     },
-    "math_assignment": {
+    "operator_assignment": {
       "type": "PREC_RIGHT",
       "value": 15,
       "content": {
@@ -2503,29 +2367,7 @@
               {
                 "type": "STRING",
                 "value": "/="
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "conditional_assignment": {
-      "type": "PREC_RIGHT",
-      "value": 15,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_lhs"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
+              },
               {
                 "type": "STRING",
                 "value": "||="
@@ -2602,357 +2444,435 @@
         ]
       }
     },
-    "boolean_or": {
-      "type": "PREC_LEFT",
-      "value": 30,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "STRING",
-            "value": "||"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
+    "binary": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_LEFT",
+          "value": -2,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "and"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
           }
-        ]
-      }
-    },
-    "boolean_and": {
-      "type": "PREC_LEFT",
-      "value": 30,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "STRING",
-            "value": "&&"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": -2,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "or"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
           }
-        ]
-      }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 30,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "||"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 30,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "&&"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 60,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "<<"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">>"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 40,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "=="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "!="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "==="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<=>"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "=~"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "!~"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 45,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "<"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">="
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 55,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "&"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 50,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "^"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "|"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 65,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "+"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 70,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "*"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "/"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "%"
+                  }
+                ]
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 80,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "**"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              }
+            ]
+          }
+        }
+      ]
     },
-    "relational": {
-      "type": "PREC_RIGHT",
-      "value": 40,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "CHOICE",
+    "unary": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 10,
+          "content": {
+            "type": "SEQ",
             "members": [
               {
                 "type": "STRING",
-                "value": "=="
+                "value": "defined?"
               },
               {
-                "type": "STRING",
-                "value": "!="
-              },
-              {
-                "type": "STRING",
-                "value": "==="
-              },
-              {
-                "type": "STRING",
-                "value": "<=>"
-              },
-              {
-                "type": "STRING",
-                "value": "=~"
-              },
-              {
-                "type": "STRING",
-                "value": "!~"
+                "type": "SYMBOL",
+                "name": "_arg"
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
           }
-        ]
-      }
-    },
-    "comparison": {
-      "type": "PREC_LEFT",
-      "value": 45,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "CHOICE",
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 5,
+          "content": {
+            "type": "SEQ",
             "members": [
               {
                 "type": "STRING",
-                "value": "<"
+                "value": "not"
               },
               {
-                "type": "STRING",
-                "value": "<="
-              },
-              {
-                "type": "STRING",
-                "value": ">"
-              },
-              {
-                "type": "STRING",
-                "value": ">="
+                "type": "SYMBOL",
+                "name": "_arg"
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
           }
-        ]
-      }
-    },
-    "bitwise_or": {
-      "type": "PREC_LEFT",
-      "value": 50,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "CHOICE",
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 75,
+          "content": {
+            "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "^"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "+"
+                  }
+                ]
               },
               {
-                "type": "STRING",
-                "value": "|"
+                "type": "SYMBOL",
+                "name": "_arg"
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
           }
-        ]
-      }
-    },
-    "bitwise_and": {
-      "type": "PREC_LEFT",
-      "value": 55,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "STRING",
-            "value": "&"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "shift": {
-      "type": "PREC_LEFT",
-      "value": 60,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "CHOICE",
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 85,
+          "content": {
+            "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "<<"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "!"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "~"
+                  }
+                ]
               },
               {
-                "type": "STRING",
-                "value": ">>"
+                "type": "SYMBOL",
+                "name": "_arg"
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
           }
-        ]
-      }
-    },
-    "additive": {
-      "type": "PREC_LEFT",
-      "value": 65,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "-"
-              },
-              {
-                "type": "STRING",
-                "value": "+"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "multiplicative": {
-      "type": "PREC_LEFT",
-      "value": 70,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "*"
-              },
-              {
-                "type": "STRING",
-                "value": "/"
-              },
-              {
-                "type": "STRING",
-                "value": "%"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "unary_minus": {
-      "type": "PREC_RIGHT",
-      "value": 75,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "-"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "exponential": {
-      "type": "PREC_RIGHT",
-      "value": 80,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          },
-          {
-            "type": "STRING",
-            "value": "**"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "unary_plus": {
-      "type": "PREC_RIGHT",
-      "value": 85,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "+"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
-    },
-    "complement": {
-      "type": "PREC_RIGHT",
-      "value": 85,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "!"
-              },
-              {
-                "type": "STRING",
-                "value": "~"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
-          }
-        ]
-      }
+        }
+      ]
     },
     "assignment_list": {
       "type": "SYMBOL",


### PR DESCRIPTION
This makes the parse table way smaller, avoiding the unsigned integer overflow problem.