### PR TITLE
Parse super as a method

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -134,7 +134,6 @@ module.exports = grammar({
       'end'
     ),
 
-    super: $ => prec.left(seq('super', optional($.argument_list))),
     return: $ => prec.left(seq('return', optional($.argument_list))),
     yield: $ => prec.left(seq('yield', optional($.argument_list))),
     break: $ => prec.left(seq('break', optional($.argument_list))),
@@ -238,8 +237,7 @@ module.exports = grammar({
       $.conditional,
       $.range,
       $.binary,
-      $.unary,
-      $.super
+      $.unary
     ),
 
     _primary: $ => choice(

--- a/grammar_test/declarations.txt
+++ b/grammar_test/declarations.txt
@@ -49,9 +49,19 @@ def foo
   super
 end
 
+def foo
+  super.bar a, b
+end
+
 ---
 
-(program (method (identifier) (super)))
+(program
+  (method (identifier) (identifier))
+  (method
+    (identifier)
+    (method_call
+      (call (identifier) (identifier))
+      (argument_list (identifier) (identifier)))))
 
 ================
 method with args

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -633,31 +633,6 @@
         }
       ]
     },
-    "super": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "super"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "argument_list"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
-        ]
-      }
-    },
     "return": {
       "type": "PREC_LEFT",
       "value": 0,
@@ -1576,10 +1551,6 @@
         {
           "type": "SYMBOL",
           "name": "unary"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "super"
         }
       ]
     },


### PR DESCRIPTION
Things like:

``` ruby
def foo
  super.bar a, b
end
```

are failing b/c we don't treat `super` as a method call. This fixes that, by no longer having a rule specifically for `super` and instead relying on `method_call`. We could duplicate `method_call` and `call` parsing for super, but that doesn't seem worth it.