### PR TITLE
Handle parsing array literals with rest splat syntax

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -374,11 +374,11 @@ module.exports = grammar({
       $._mlhs,
       choice(
         $._variable,
-        $.rest_assignment
+        $.rest_argument
       ),
       ','
     )),
-    rest_assignment: $ => seq('*', optional($._variable)),
+    rest_argument: $ => seq('*', optional($._variable)),
     _lhs: $ => prec.left(choice(
       $._variable,
       $.scope_resolution,
@@ -522,7 +522,7 @@ module.exports = grammar({
       ))
     ),
 
-    _array_items: $ => sepTrailing($._array_items, $._arg, ','),
+    _array_items: $ => sepTrailing($._array_items, choice($.rest_argument, $._arg), ','),
 
     hash: $ => prec(1, seq('{', optional($._hash_items), '}')),
     _hash_items: $ => seq($.pair, optional(seq(',', optional($._hash_items)))),

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -165,8 +165,8 @@ x, *args = [1, 2]
 
 (program
   (assignment (left_assignment_list (identifier) (identifier)) (array (integer) (integer)))
-  (assignment (left_assignment_list (identifier) (rest_assignment)) (array (integer) (integer)))
-  (assignment (left_assignment_list (identifier) (rest_assignment (identifier))) (array (integer) (integer))))
+  (assignment (left_assignment_list (identifier) (rest_argument)) (array (integer) (integer)))
+  (assignment (left_assignment_list (identifier) (rest_argument (identifier))) (array (integer) (integer))))
 
 ==========
 multiple assignment with multiple right hand sides

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -362,10 +362,13 @@ array
 =====
 
 [ foo, bar ]
+[foo, *bar]
 
 ---
 
-(program (array (identifier) (identifier)))
+(program
+	(array (identifier) (identifier))
+	(array (identifier) (rest_argument (identifier))))
 
 =====
 array as object

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2968,7 +2968,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "rest_assignment"
+                "name": "rest_argument"
               }
             ]
           },
@@ -2984,7 +2984,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "rest_assignment"
+                    "name": "rest_argument"
                   }
                 ]
               },
@@ -3009,7 +3009,7 @@
         ]
       }
     },
-    "rest_assignment": {
+    "rest_argument": {
       "type": "SEQ",
       "members": [
         {
@@ -4271,15 +4271,33 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_arg"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "rest_argument"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_arg"
+            }
+          ]
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_arg"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "rest_argument"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
+              ]
             },
             {
               "type": "STRING",


### PR DESCRIPTION
Allowing parsing of array literals constructed with splat/rest arguments like:

``` ruby
a = [foo, *bar]
```

This also renames `s/rest_assignment/rest_argument` since it's used in multiple places now.