### PR TITLE
Parse rest arguments in method calls

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -294,16 +294,25 @@ module.exports = grammar({
 
     _argument_list_with_trailing_comma: $ => prec.left(1, sepTrailing(
       $._argument_list_with_trailing_comma,
-      choice($._arg, $.argument_pair),
+      choice(
+        $._arg,
+        $.rest_argument,
+        $.argument_pair
+      ),
       ','
     )),
-    _argument_list: $ => prec.left(1, commaSep1(choice($._arg, $.argument_pair))),
+    _argument_list: $ => prec.left(1, commaSep1(choice(
+      $._arg,
+      $.rest_argument,
+      $.argument_pair
+    ))),
 
     argument_pair: $ => prec.left(1, seq(choice(
       seq($.symbol, '=>'),
       seq($.identifier, ':')
     ), $._arg)),
 
+    rest_argument: $ => seq('*', $._arg),
     block_argument: $ => seq('&', $._arg),
 
     do_block: $ => $._do_block,
@@ -374,11 +383,11 @@ module.exports = grammar({
       $._mlhs,
       choice(
         $._variable,
-        $.rest_argument
+        $.rest_assignment
       ),
       ','
     )),
-    rest_argument: $ => seq('*', optional($._variable)),
+    rest_assignment: $ => prec(-1, seq('*', optional($._variable))),
     _lhs: $ => prec.left(choice(
       $._variable,
       $.scope_resolution,

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -165,8 +165,8 @@ x, *args = [1, 2]
 
 (program
   (assignment (left_assignment_list (identifier) (identifier)) (array (integer) (integer)))
-  (assignment (left_assignment_list (identifier) (rest_argument)) (array (integer) (integer)))
-  (assignment (left_assignment_list (identifier) (rest_argument (identifier))) (array (integer) (integer))))
+  (assignment (left_assignment_list (identifier) (rest_assignment)) (array (integer) (integer)))
+  (assignment (left_assignment_list (identifier) (rest_assignment (identifier))) (array (integer) (integer))))
 
 ==========
 multiple assignment with multiple right hand sides
@@ -559,6 +559,21 @@ end
   (method_call (identifier)
     (argument_list (symbol) (lambda (formal_parameters (identifier)) (integer)))
     (do_block)))
+
+===============================
+method calls with rest argument
+===============================
+
+foo(*bar)
+foo(x, *bar)
+foo(*bar.baz)
+
+---
+
+(program
+  (method_call (identifier) (argument_list (rest_argument (identifier))))
+  (method_call (identifier) (argument_list (identifier) (rest_argument (identifier))))
+  (method_call (identifier) (argument_list (rest_argument (call (identifier) (identifier))))))
 
 ============================
 method call without parens

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2027,6 +2027,10 @@
               },
               {
                 "type": "SYMBOL",
+                "name": "rest_argument"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "argument_pair"
               }
             ]
@@ -2040,6 +2044,10 @@
                   {
                     "type": "SYMBOL",
                     "name": "_arg"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "rest_argument"
                   },
                   {
                     "type": "SYMBOL",
@@ -2083,6 +2091,10 @@
               },
               {
                 "type": "SYMBOL",
+                "name": "rest_argument"
+              },
+              {
+                "type": "SYMBOL",
                 "name": "argument_pair"
               }
             ]
@@ -2102,6 +2114,10 @@
                     {
                       "type": "SYMBOL",
                       "name": "_arg"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "rest_argument"
                     },
                     {
                       "type": "SYMBOL",
@@ -2158,6 +2174,19 @@
           }
         ]
       }
+    },
+    "rest_argument": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_arg"
+        }
+      ]
     },
     "block_argument": {
       "type": "SEQ",
@@ -2968,7 +2997,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "rest_argument"
+                "name": "rest_assignment"
               }
             ]
           },
@@ -2984,7 +3013,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "rest_argument"
+                    "name": "rest_assignment"
                   }
                 ]
               },
@@ -3009,26 +3038,30 @@
         ]
       }
     },
-    "rest_argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "*"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_variable"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+    "rest_assignment": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "*"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_variable"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "_lhs": {
       "type": "PREC_LEFT",


### PR DESCRIPTION
Rest (splat) arguments in method calls were previously causing errors, this fixes that.

```ruby
foo(*bar)
```