### PR TITLE
Collapse up to one pair rule that allows any _arg as the key

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -297,20 +297,15 @@ module.exports = grammar({
       choice(
         $._arg,
         $.rest_argument,
-        $.argument_pair
+        $.pair
       ),
       ','
     )),
     _argument_list: $ => prec.left(1, commaSep1(choice(
       $._arg,
       $.rest_argument,
-      $.argument_pair
+      $.pair
     ))),
-
-    argument_pair: $ => prec.left(1, seq(choice(
-      seq($.symbol, '=>'),
-      seq($.identifier, ':')
-    ), $._arg)),
 
     rest_argument: $ => seq('*', $._arg),
     block_argument: $ => seq('&', $._arg),

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -491,13 +491,17 @@ method call with hash args
 ===============================
 
 foo(:a => true)
+foo([] => 1)
+foo(bar => 1)
 foo :a => true, :c => 1
 
 ---
 
 (program
-  (method_call (identifier) (argument_list (argument_pair (symbol) (boolean))))
-  (method_call (identifier) (argument_list (argument_pair (symbol) (boolean)) (argument_pair (symbol) (integer)))))
+  (method_call (identifier) (argument_list (pair (symbol) (boolean))))
+  (method_call (identifier) (argument_list (pair (array) (integer))))
+  (method_call (identifier) (argument_list (pair (identifier) (integer))))
+  (method_call (identifier) (argument_list (pair (symbol) (boolean)) (pair (symbol) (integer)))))
 
 ===============================
 method call with keyword args
@@ -509,8 +513,8 @@ foo a: true
 ---
 
 (program
-  (method_call (identifier) (argument_list (argument_pair (identifier) (boolean))))
-  (method_call (identifier) (argument_list (argument_pair (identifier) (boolean)))))
+  (method_call (identifier) (argument_list (pair (identifier) (boolean))))
+  (method_call (identifier) (argument_list (pair (identifier) (boolean)))))
 
 ===============================
 method call with block argument
@@ -544,7 +548,7 @@ foo :bar, -> (a) { where(:c => b) }
       (symbol)
       (lambda
         (formal_parameters (identifier))
-        (method_call (identifier) (argument_list (argument_pair (symbol) (identifier))))))))
+        (method_call (identifier) (argument_list (pair (symbol) (identifier))))))))
 
 ===============================
 method call lambda argument and do block

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -466,10 +466,15 @@ hash with expression keys
 =========================
 
 { "a" => 1, "b" => 2 }
+{ [] => 1 }
+{ foo => 1 }
 
 ---
 
-(program (hash (pair (string) (integer)) (pair (string) (integer))))
+(program
+	(hash (pair (string) (integer)) (pair (string) (integer)))
+	(hash (pair (array) (integer)))
+	(hash (pair (identifier) (integer))))
 
 ======================
 hash with keyword keys

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2031,7 +2031,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "argument_pair"
+                "name": "pair"
               }
             ]
           },
@@ -2051,7 +2051,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "argument_pair"
+                    "name": "pair"
                   }
                 ]
               },
@@ -2095,7 +2095,7 @@
               },
               {
                 "type": "SYMBOL",
-                "name": "argument_pair"
+                "name": "pair"
               }
             ]
           },
@@ -2121,56 +2121,12 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "argument_pair"
+                      "name": "pair"
                     }
                   ]
                 }
               ]
             }
-          }
-        ]
-      }
-    },
-    "argument_pair": {
-      "type": "PREC_LEFT",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "symbol"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "=>"
-                  }
-                ]
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "identifier"
-                  },
-                  {
-                    "type": "STRING",
-                    "value": ":"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_arg"
           }
         ]
       }


### PR DESCRIPTION
There were previously two almost identical rules for pair (one used for constructing hash literals, and the other for method arguments). This collapses into a single pair rule with the more powerful ability to parse any valid `_arg` as the key in a pair. Valid ruby code like this was previously failing to parse:

```ruby
foo([] => 1)
foo(bar => 1)
```