### PR TITLE
Use \S to cleanup char literal regex

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -555,7 +555,7 @@ module.exports = grammar({
 
     chained_string: $ => seq($.string, repeat1($.string)),
 
-    _character_literal: $ => /\?(\\[^ \t\n]({[0-9]*}|-[^ \t\n]([MC]-[^ \t\n])?)?|[^ \t\n])[\s]/,
+    _character_literal: $ => /\?(\\\S({[0-9]*}|-\S([MC]-\S)?)?|\S)[\s]/,
 
     string: $ => choice(
       $._simple_string,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4090,7 +4090,7 @@
     },
     "_character_literal": {
       "type": "PATTERN",
-      "value": "\\?(\\\\[^ \\t\\n]({[0-9]*}|-[^ \\t\\n]([MC]-[^ \\t\\n])?)?|[^ \\t\\n])[\\s]"
+      "value": "\\?(\\\\\\S({[0-9]*}|-\\S([MC]-\\S)?)?|\\S)[\\s]"
     },
     "string": {
       "type": "CHOICE",


### PR DESCRIPTION
Depends on https://github.com/tree-sitter/tree-sitter/pull/55 which allows us to use `\S`.

It's very possible that this regex can be further simplified. Here's some test data of valid character literals and a [good reference](https://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html).

``` ruby
?a
?"a   # Should not match
?abc  # Should not match
?\n
?\\
?\u{41}
?\C-a
?\M-\C-a
?\C-\M-a
```