### PR TITLE
Upgrade tree-sitter to allow backtracking

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -26,8 +26,6 @@ const PREC = {
   COMPLEMENT: 85,
 };
 
-const integerPattern = /0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/;
-const floatPattern = /\d(_?\d)*([eE][-+]?\d(_?\d)*)?/;
 const identifierPattern = /[a-z_][a-zA-Z0-9_]*(\?|\!)?/;
 const constantPattern = /[A-Z][a-zA-Z0-9_]*(\?|\!)?/;
 
@@ -61,7 +59,7 @@ module.exports = grammar({
     $._heredoc_body_end,
     $.heredoc_beginning,
     $._line_break,
-    $._forward_slash,
+    '/',
     $._element_reference_left_bracket,
     $._block_ampersand,
     $._splat_star,
@@ -76,11 +74,6 @@ module.exports = grammar({
   extras: $ => [
     $.comment,
     /\s|\\\n/
-  ],
-
-  conflicts: $ => [
-    // Temporary fix until we can backtrack to parse things like `3.times`
-    [$.integer, $.float],
   ],
 
   rules: {
@@ -443,7 +436,7 @@ module.exports = grammar({
       prec.left(PREC.BITWISE_AND, seq($._arg, '&', $._arg)),
       prec.left(PREC.BITWISE_OR, seq($._arg, choice('^', '|'), $._arg)),
       prec.left(PREC.ADDITIVE, seq($._arg, choice($._binary_minus, '+'), $._arg)),
-      prec.left(PREC.MULTIPLICATIVE, seq($._arg, choice($._binary_star, $._forward_slash, '%'), $._arg)),
+      prec.left(PREC.MULTIPLICATIVE, seq($._arg, choice($._binary_star, '/', '%'), $._arg)),
       prec.right(PREC.EXPONENTIAL, seq($._arg, '**', $._arg))
     ),
 
@@ -495,9 +488,8 @@ module.exports = grammar({
       'then', 'true', 'undef', 'when', 'yield', 'if', 'unless', 'while', 'until'
     ),
     operator: $ => choice(
-      $._forward_slash,
       '..', '|', '^', '&', '<=>', '==', '===', '=~', '>', '>=', '<', '<=', '+',
-      '-', '*', '%', '!', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]=', '`'
+      '-', '*', '/', '%', '!', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]=', '`'
     ),
 
     _method_name: $ => choice(
@@ -550,13 +542,9 @@ module.exports = grammar({
       )
     )),
 
-    integer: $ => integerPattern,
-    // TODO: When we can backtrack, redefine float as regex instead of seq.
-    // float: $ => (/\d(_?\d)*(\.\d)?(_?\d)*([eE]\d(_?\d)*)?/),
-    float: $ => choice(
-      seq(integerPattern, '.', floatPattern),
-      floatPattern
-    ),
+    integer: $ => /0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/,
+
+    float: $ => /\d(_?\d)*(\.\d)?(_?\d)*([eE]?[\+-]?\d(_?\d)*)?/,
     super: $ => 'super',
     true: $ => choice('true', 'TRUE'),
     false: $ => choice('false', 'FALSE'),
@@ -652,7 +640,6 @@ module.exports = grammar({
 
     empty_statement: $ => prec(-1, ';'),
 
-    _forward_slash: $ => '/',
     _terminator: $ => choice(
       $._line_break,
       $.heredoc_end,

--- a/grammar.js
+++ b/grammar.js
@@ -531,17 +531,6 @@ module.exports = grammar({
       )
     ),
 
-    // Fallback to catch :name
-    _simple_symbol: $ => token(seq(
-      ':',
-      choice(
-        identifierPattern,
-        instanceVariablePattern,
-        classVariablePattern,
-        globalVariablePattern
-      )
-    )),
-
     integer: $ => /0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\d(_?\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*/,
 
     float: $ => /\d(_?\d)*(\.\d)?(_?\d)*([eE]?[\+-]?\d(_?\d)*)?/,

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
   "author": "Rob Rix",
   "license": "MIT",
   "dependencies": {
-    "bindings": "1.2.x",
     "nan": "^2.4.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": ">= 0.4.5"
+    "tree-sitter-cli": ">= 0.5.0"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4060,39 +4060,6 @@
         }
       ]
     },
-    "_simple_symbol": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": ":"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "[a-z_][a-zA-Z0-9_]*(\\?|\\!)?"
-              },
-              {
-                "type": "PATTERN",
-                "value": "@[a-zA-Z_][a-zA-Z0-9_]*"
-              },
-              {
-                "type": "PATTERN",
-                "value": "@@[a-zA-Z_][a-zA-Z0-9_]*"
-              },
-              {
-                "type": "PATTERN",
-                "value": "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))"
-              }
-            ]
-          }
-        ]
-      }
-    },
     "integer": {
       "type": "PATTERN",
       "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3183,8 +3183,8 @@
                     "name": "_binary_star"
                   },
                   {
-                    "type": "SYMBOL",
-                    "name": "_forward_slash"
+                    "type": "STRING",
+                    "value": "/"
                   },
                   {
                     "type": "STRING",
@@ -3746,10 +3746,6 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_forward_slash"
-        },
-        {
           "type": "STRING",
           "value": ".."
         },
@@ -3808,6 +3804,10 @@
         {
           "type": "STRING",
           "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "/"
         },
         {
           "type": "STRING",
@@ -4098,30 +4098,8 @@
       "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
     },
     "float": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "PATTERN",
-              "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
-            },
-            {
-              "type": "STRING",
-              "value": "."
-            },
-            {
-              "type": "PATTERN",
-              "value": "\\d(_?\\d)*([eE][-+]?\\d(_?\\d)*)?"
-            }
-          ]
-        },
-        {
-          "type": "PATTERN",
-          "value": "\\d(_?\\d)*([eE][-+]?\\d(_?\\d)*)?"
-        }
-      ]
+      "type": "PATTERN",
+      "value": "\\d(_?\\d)*(\\.\\d)?(_?\\d)*([eE]?[\\+-]?\\d(_?\\d)*)?"
     },
     "super": {
       "type": "STRING",
@@ -4732,10 +4710,6 @@
         "value": ";"
       }
     },
-    "_forward_slash": {
-      "type": "STRING",
-      "value": "/"
-    },
     "_terminator": {
       "type": "CHOICE",
       "members": [
@@ -4764,40 +4738,119 @@
       "value": "\\s|\\\\\\n"
     }
   ],
-  "conflicts": [
-    [
-      "integer",
-      "float"
-    ]
-  ],
+  "conflicts": [],
   "externals": [
-    "_simple_string",
-    "_simple_symbol",
-    "_simple_subshell",
-    "_simple_regex",
-    "_simple_word_list",
-    "_simple_heredoc_body",
-    "_string_beginning",
-    "_symbol_beginning",
-    "_subshell_beginning",
-    "_regex_beginning",
-    "_word_list_beginning",
-    "_heredoc_body_beginning",
-    "_string_middle",
-    "_heredoc_body_middle",
-    "_string_end",
-    "_heredoc_body_end",
-    "heredoc_beginning",
-    "_line_break",
-    "_forward_slash",
-    "_element_reference_left_bracket",
-    "_block_ampersand",
-    "_splat_star",
-    "_argument_list_left_paren",
-    "_scope_double_colon",
-    "_keyword_colon",
-    "_unary_minus",
-    "_binary_minus",
-    "_binary_star"
+    {
+      "type": "SYMBOL",
+      "name": "_simple_string"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_symbol"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_subshell"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_regex"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_word_list"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_simple_heredoc_body"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_string_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_symbol_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_subshell_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_regex_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_word_list_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_heredoc_body_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_string_middle"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_heredoc_body_middle"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_string_end"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_heredoc_body_end"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "heredoc_beginning"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_line_break"
+    },
+    {
+      "type": "STRING",
+      "value": "/"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_element_reference_left_bracket"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_block_ampersand"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_splat_star"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_argument_list_left_paren"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_scope_double_colon"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_keyword_colon"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_unary_minus"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_binary_minus"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_binary_star"
+    }
   ]
 }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -252,9 +252,13 @@ struct Scanner {
     if (lexer->lookahead == '?' || lexer->lookahead == '!') {
       advance(lexer);
     }
+
     if (lexer->lookahead == '=') {
+      lexer->mark_end(lexer);
       advance(lexer);
-      if (lexer->lookahead == '>') return false;
+      if (lexer->lookahead != '>') {
+        lexer->mark_end(lexer);
+      }
     }
 
     return true;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -84,7 +84,11 @@ struct Scanner {
     lexer->advance(lexer, true);
   }
 
-  void reset() {}
+  void reset() {
+    has_leading_whitespace = false;
+    literal_stack.clear();
+    open_heredocs.clear();
+  }
 
   bool serialize(TSExternalTokenState state) { return true; }
 

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -26,6 +26,7 @@ typedef struct {
 
 typedef struct {
   void (*advance)(void *, bool);
+  void (*mark_end)(void *);
   int32_t lookahead;
   TSSymbol result_symbol;
 } TSLexer;
@@ -91,32 +92,32 @@ typedef struct TSLanguage {
  *  Lexer Macros
  */
 
-#define START_LEXER() \
-  int32_t lookahead;  \
-  next_state:         \
+#define START_LEXER()           \
+  bool result = false;          \
+  int32_t lookahead;            \
+  next_state:                   \
   lookahead = lexer->lookahead;
 
-#define ADVANCE(state_value)                   \
-  {                                            \
+#define ADVANCE(state_value)      \
+  {                               \
     lexer->advance(lexer, false); \
-    state = state_value;                       \
-    goto next_state;                           \
+    state = state_value;          \
+    goto next_state;              \
   }
 
-#define SKIP(state_value)                     \
-  {                                           \
+#define SKIP(state_value)        \
+  {                              \
     lexer->advance(lexer, true); \
-    state = state_value;                      \
-    goto next_state;                          \
+    state = state_value;         \
+    goto next_state;             \
   }
 
-#define ACCEPT_TOKEN(symbol_value)       \
-  {                                      \
-    lexer->result_symbol = symbol_value; \
-    return true;                         \
-  }
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
 
-#define LEX_ERROR() return false
+#define END_STATE() return result;
 
 /*
  *  Parse Table Macros


### PR DESCRIPTION
The latest tree-sitter features let us clean up the grammar a bit:

* We can distinguish between floats (`123.456`) from method calls on numbers (`123.to_s`) within the lexer by using backtracking, so we don't need a `conflict` between `float` and `call` (https://github.com/tree-sitter/tree-sitter/pull/68).
* Similarly, we can distinguish setter symbols (`:foo=`) from symbols followed by hash rockets (`:foo=>`) within the lexer, so we can tokenize symbols entirely in the external scanner, instead of having to fall back on the internal scanner.
* The external scanner needs to know if the `/` operator is valid. We can now specify that operator as an external directly using a string literal, instead of having to give it a name (https://github.com/tree-sitter/tree-sitter/pull/70). 

/cc @tclem 
