### PR TITLE
Use wide-char version of ctype.h functions

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,7 +1,7 @@
 #include <tree_sitter/parser.h>
 #include <vector>
 #include <string>
-#include <cctype>
+#include <cwctype>
 
 namespace {
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -241,13 +241,13 @@ struct Scanner {
       advance(lexer);
     }
 
-    if (isalpha(lexer->lookahead) || (lexer->lookahead == '_')) {
+    if (iswalpha(lexer->lookahead) || (lexer->lookahead == '_')) {
       advance(lexer);
     } else if (!scan_operator(lexer)) {
       return false;
     }
 
-    while (isalnum(lexer->lookahead) || (lexer->lookahead == '_')) {
+    while (iswalnum(lexer->lookahead) || (lexer->lookahead == '_')) {
       advance(lexer);
     }
 
@@ -469,10 +469,10 @@ struct Scanner {
         break;
 
       default:
-        if (isalnum(lexer->lookahead) || lexer->lookahead == '_') {
+        if (iswalnum(lexer->lookahead) || lexer->lookahead == '_') {
           result += lexer->lookahead;
           advance(lexer);
-          while (isalnum(lexer->lookahead) || lexer->lookahead == '_') {
+          while (iswalnum(lexer->lookahead) || lexer->lookahead == '_') {
             result += lexer->lookahead;
             advance(lexer);
           }
@@ -540,7 +540,7 @@ struct Scanner {
     for (;;) {
       if (literal.nesting_depth == 0) {
         if (literal.type == Literal::REGEX) {
-          while (islower(lexer->lookahead)) {
+          while (iswlower(lexer->lookahead)) {
             advance(lexer);
           }
         }


### PR DESCRIPTION
isalnum is only defined if the input is in the ASCII range. Nothing bad happens
on mac afaict but will cause an out-of-bounds read on Linux:

```
==11146== ERROR: libFuzzer: deadly signal
    #0 0x649030 in fuzzer::Fuzzer::CrashCallback() /src/libfuzzer/FuzzerLoop.cpp:195:5
    #1 0x648fd9 in fuzzer::Fuzzer::StaticCrashSignalCallback() /src/libfuzzer/FuzzerLoop.cpp:179:6
    #2 0x7f118dd6638f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1138f)
    #3 0x7f118d396d0d in isalnum (/lib/x86_64-linux-gnu/libc.so.6+0x2dd0d)
    #4 0x42d44a in (anonymous namespace)::Scanner::scan_symbol_identifier(TSLexer*) /src/tree-sitter/tree-sitter-ruby/src/scanner.cc:250:12
    #5 0x42be29 in (anonymous namespace)::Scanner::scan(TSLexer*, bool const*) /src/tree-sitter/tree-sitter-ruby/src/scanner.cc:727:18
    #6 0x62eb83 in parser__lex /src/tree-sitter/src/runtime/parser.c:271:30
    #7 0x62a05c in parser__advance /src/tree-sitter/src/runtime/parser.c:1097:21
    #8 0x629789 in parser_parse /src/tree-sitter/src/runtime/parser.c:1298:9
    #9 0x62617d in ts_document_parse_with_options /src/tree-sitter/src/runtime/document.c:136:16
    #10 0x42b053 in LLVMFuzzerTestOneInput /src/tree-sitter/../fuzzer.cc:21:3
    #11 0x64a164 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:460:13
    #12 0x64a4be in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:399:3
    #13 0x63c890 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:268:6
    #14 0x64090b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:683:9
    #15 0x63c58c in main /src/libfuzzer/FuzzerMain.cpp:20:10
    #16 0x7f118d38982f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #17 0x405928 in _start (/out/ruby_fuzzer+0x405928)
```