### PR TITLE
Treat single CR characters as whitespace, not as line breaks

### DIFF
--- a/grammar_test/single-cr-as-whitespace.rb
+++ b/grammar_test/single-cr-as-whitespace.rb
@@ -1,0 +1,9 @@
+==================================
+Single CR characters as whitespace
+==================================
+
+puts"hi"
+
+---
+
+(program (method_call (identifier) (argument_list (string))))

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -118,10 +118,9 @@ struct Scanner {
       switch (lexer->lookahead) {
         case ' ':
         case '\t':
+        case '\r':
           skip(lexer);
           break;
-        case '\r':
-          if (lexer->lookahead == '\n') skip(lexer);
         case '\n':
           if (!open_heredocs.empty() && !*found_heredoc_starting_linebreak) {
             skip(lexer);


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-ruby/issues/50