### PR TITLE
Additional improvements to the ruby grammar

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -919,17 +919,19 @@ lambda { lambda }
   (lambda (block (lambda))))
 
 ==================
-lambda expression with body
+lambda expressions
 ==================
 
 lambda { foo }
 lambda(&block) { foo }
+lambda(&lambda{})
 
 ---
 
 (program
   (lambda (block (identifier)))
-  (lambda (lambda_parameters (block_parameter (identifier))) (block (identifier))))
+  (lambda (lambda_parameters (block_parameter (identifier))) (block (identifier)))
+  (lambda (lambda_parameters (block_parameter (lambda (block))))))
 
 ====================
 lambda expression with an arg

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -913,8 +913,7 @@ lambda {}
 
 ---
 
-(program
-  (lambda (block)))
+(program (method_call (identifier) (argument_list (hash))))
 
 ==================
 lambda expressions
@@ -927,9 +926,9 @@ lambda(&lambda{})
 ---
 
 (program
-  (lambda (block (identifier)))
+  (method_call (identifier) (block (identifier)))
   (method_call (identifier) (argument_list (block_argument (identifier))) (block (identifier)))
-  (method_call (identifier) (argument_list (block_argument (lambda (block))))))
+  (method_call (identifier) (argument_list (block_argument (method_call (identifier) (argument_list (hash)))))))
 
 ====================
 lambda expression with an arg
@@ -939,7 +938,7 @@ lambda { |foo| 1 }
 
 ---
 
-(program (lambda (block (block_parameters (identifier)) (integer))))
+(program (method_call (identifier) (block (block_parameters (identifier)) (integer))))
 
 ===========================
 lambda expression with multiple args
@@ -952,10 +951,7 @@ lambda { |a, b, c|
 
 ---
 
-(program (lambda (block
-  (block_parameters (identifier) (identifier) (identifier))
-  (integer)
-  (integer))))
+(program (method_call (identifier) (block (block_parameters (identifier) (identifier) (identifier)) (integer) (integer))))
 
 ===========================
 lambda expression with trailing comma
@@ -967,9 +963,7 @@ lambda { |a, b,|
 
 ---
 
-(program (lambda (block
-  (block_parameters (identifier) (identifier))
-  (integer))))
+(program (method_call (identifier) (block (block_parameters (identifier) (identifier)) (integer))))
 
 ===========================
 lambda expression with optional arg
@@ -981,9 +975,7 @@ lambda { |a, b=nil|
 
 ---
 
-(program (lambda (block
-  (block_parameters (identifier) (optional_parameter (identifier) (nil)))
-  (integer))))
+(program (method_call (identifier) (block (block_parameters (identifier) (optional_parameter (identifier) (nil))) (integer))))
 
 ===========================
 lambda expression with keyword arg
@@ -995,9 +987,9 @@ lambda { |a, b: nil|
 
 ---
 
-(program (lambda (block
-  (block_parameters (identifier) (keyword_parameter (identifier) (nil)))
-  (integer))))
+(program (method_call
+  (identifier)
+  (block (block_parameters (identifier) (keyword_parameter (identifier) (nil))) (integer))))
 
 ====================
 lambda expression with do end
@@ -1009,9 +1001,7 @@ end
 
 ---
 
-(program (lambda (do_block
-  (block_parameters (identifier))
-  (integer))))
+(program (method_call (identifier) (do_block (block_parameters (identifier)) (integer))))
 
 ============================
 lambda and proc as variables
@@ -1025,8 +1015,8 @@ proc = proc {}
 
 (program
   (assignment (identifier) (call (constant) (identifier)))
-  (assignment (identifier) (lambda (block)))
-  (assignment (identifier) (lambda (block))))
+  (assignment (identifier) (method_call (identifier) (argument_list (hash))))
+  (assignment (identifier) (method_call (identifier) (argument_list (hash)))))
 
 ===============================
 backslash-newline as line continuation

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -923,10 +923,13 @@ lambda expression with body
 ==================
 
 lambda { foo }
+lambda(&block) { foo }
 
 ---
 
-(program (lambda (block (identifier))))
+(program
+  (lambda (block (identifier)))
+  (lambda (lambda_parameters (block_parameter (identifier))) (block (identifier))))
 
 ====================
 lambda expression with an arg

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -910,13 +910,11 @@ empty lambda expression
 ==============
 
 lambda {}
-lambda { lambda }
 
 ---
 
 (program
-  (lambda (block))
-  (lambda (block (lambda))))
+  (lambda (block)))
 
 ==================
 lambda expressions
@@ -930,8 +928,8 @@ lambda(&lambda{})
 
 (program
   (lambda (block (identifier)))
-  (lambda (lambda_parameters (block_parameter (identifier))) (block (identifier)))
-  (lambda (lambda_parameters (block_parameter (lambda (block))))))
+  (method_call (identifier) (argument_list (block_argument (identifier))) (block (identifier)))
+  (method_call (identifier) (argument_list (block_argument (lambda (block))))))
 
 ====================
 lambda expression with an arg
@@ -1014,6 +1012,21 @@ end
 (program (lambda (do_block
   (block_parameters (identifier))
   (integer))))
+
+============================
+lambda and proc as variables
+============================
+
+proc = Proc.new
+lambda = lambda {}
+proc = proc {}
+
+---
+
+(program
+  (assignment (identifier) (call (constant) (identifier)))
+  (assignment (identifier) (lambda (block)))
+  (assignment (identifier) (lambda (block))))
 
 ===============================
 backslash-newline as line continuation

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -339,6 +339,16 @@ complex
 
 (program (unary (complex)) (complex) (complex) (complex) (complex) (complex))
 
+========
+rational
+========
+
+2/3r
+
+---
+
+(program (binary (integer) (rational (integer))))
+
 =======
 boolean
 =======

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -10,11 +10,13 @@ symbol
 :@foo_0123_bar
 :@@foo
 :$foo
+:$0
 :_bar
 
 ---
 
 (program
+  (symbol)
   (symbol)
   (symbol)
   (symbol)

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1319,6 +1319,7 @@ lambda literal with an arg
 -> (foo) { 1 }
 -> *foo { 1 }
 -> foo: 1 { 2 }
+-> foo, bar { 2 }
 
 ---
 
@@ -1326,7 +1327,8 @@ lambda literal with an arg
   (lambda (lambda_parameters (identifier)) (block (integer)))
   (lambda (lambda_parameters (identifier)) (block (integer)))
   (lambda (lambda_parameters (splat_parameter (identifier))) (block (integer)))
-  (lambda (lambda_parameters (keyword_parameter (identifier) (integer))) (block (integer))))
+  (lambda (lambda_parameters (keyword_parameter (identifier) (integer))) (block (integer)))
+  (lambda (lambda_parameters (identifier) (identifier)) (block (integer))))
 
 ===========================
 lambda literal with multiple args

--- a/grammar.js
+++ b/grammar.js
@@ -307,6 +307,7 @@ module.exports = grammar({
       $.integer,
       $.float,
       $.complex,
+      $.rational,
       $.string,
       $.chained_string,
       $.keyword__FILE__,
@@ -564,6 +565,7 @@ module.exports = grammar({
 
     float: $ => /\d(_?\d)*(\.\d)?(_?\d)*([eE]?[\+-]?\d(_?\d)*)?/,
     complex: $ => prec.right(PREC.UNARY_MINUS + 1, /(\d+)?(\+|-)?(\d+)i/),
+    rational: $ => seq($.integer, 'r'),
     super: $ => 'super',
     true: $ => choice('true', 'TRUE'),
     false: $ => choice('false', 'FALSE'),

--- a/grammar.js
+++ b/grammar.js
@@ -502,7 +502,11 @@ module.exports = grammar({
 
     constant: $ => /[A-Z][a-zA-Z0-9_]*(\?|\!)?/,
 
-    identifier: $ => /[a-z_][a-zA-Z0-9_]*(\?|\!)?/,
+    identifier: $ => choice(
+      /[a-z_][a-zA-Z0-9_]*(\?|\!)?/,
+      $._proc_keyword,
+      $._lambda_keyword
+    ),
 
     instance_variable: $ => /@[a-zA-Z_][a-zA-Z0-9_]*/,
 
@@ -662,9 +666,18 @@ module.exports = grammar({
     ),
 
     lambda: $ => choice(
-      prec.left(seq(choice('lambda', 'proc'), optional($.lambda_parameters), optional(choice($.block, $.do_block)))),
+      prec.left(1, seq(
+        choice($._lambda_keyword, $._proc_keyword),
+        choice(
+          $.lambda_parameters,
+          seq(optional($.lambda_parameters), choice($.block, $.do_block))
+        )
+      )),
       seq('->', optional($.lambda_parameters), choice($.block, $.do_block))
     ),
+
+    _proc_keyword: $ => 'proc',
+    _lambda_keyword: $ => 'lambda',
 
     empty_statement: $ => prec(-1, ';'),
 

--- a/grammar.js
+++ b/grammar.js
@@ -151,7 +151,7 @@ module.exports = grammar({
     destructured_parameter: $ => seq('(', commaSep1($._formal_parameter), ')'),
     splat_parameter: $ => seq('*', optional($.identifier)),
     hash_splat_parameter: $ => seq('**', optional($.identifier)),
-    block_parameter: $ => seq('&', $._arg),
+    block_parameter: $ => seq('&', choice($.identifier, $.lambda)),
     keyword_parameter: $ => prec.right(PREC.BITWISE_OR + 1, seq($.identifier, $._keyword_colon, optional($._arg))),
     optional_parameter: $ => prec(PREC.BITWISE_OR + 1, seq($.identifier, '=', $._arg)),
 
@@ -662,7 +662,7 @@ module.exports = grammar({
     ),
 
     lambda: $ => choice(
-      prec.left(seq('lambda', optional($.lambda_parameters), optional(choice($.block, $.do_block)))),
+      prec.left(seq(choice('lambda', 'proc'), optional($.lambda_parameters), optional(choice($.block, $.do_block)))),
       seq('->', optional($.lambda_parameters), choice($.block, $.do_block))
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -662,7 +662,7 @@ module.exports = grammar({
     ),
 
     lambda: $ => choice(
-      prec.left(seq('lambda', optional(choice($.block, $.do_block)))),
+      prec.left(seq('lambda', optional($.lambda_parameters), optional(choice($.block, $.do_block)))),
       seq('->', optional($.lambda_parameters), choice($.block, $.do_block))
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -502,11 +502,7 @@ module.exports = grammar({
 
     constant: $ => /[A-Z][a-zA-Z0-9_]*(\?|\!)?/,
 
-    identifier: $ => choice(
-      /[a-z_][a-zA-Z0-9_]*(\?|\!)?/,
-      $._proc_keyword,
-      $._lambda_keyword
-    ),
+    identifier: $ => /[a-z_][a-zA-Z0-9_]*(\?|\!)?/,
 
     instance_variable: $ => /@[a-zA-Z_][a-zA-Z0-9_]*/,
 
@@ -665,19 +661,7 @@ module.exports = grammar({
       )
     ),
 
-    lambda: $ => choice(
-      prec.left(1, seq(
-        choice($._lambda_keyword, $._proc_keyword),
-        choice(
-          $.lambda_parameters,
-          seq(optional($.lambda_parameters), choice($.block, $.do_block))
-        )
-      )),
-      seq('->', optional($.lambda_parameters), choice($.block, $.do_block))
-    ),
-
-    _proc_keyword: $ => 'proc',
-    _lambda_keyword: $ => 'lambda',
+    lambda: $ => seq('->', optional($.lambda_parameters), choice($.block, $.do_block)),
 
     empty_statement: $ => prec(-1, ';'),
 

--- a/grammar.js
+++ b/grammar.js
@@ -126,10 +126,10 @@ module.exports = grammar({
       seq($._simple_formal_parameter, ',', commaSep1($._formal_parameter), $._terminator)
     )),
 
-    lambda_parameters: $ => choice(
+    lambda_parameters: $ => prec.right(choice(
       seq('(', commaSep($._formal_parameter), ')'),
-      $._simple_formal_parameter
-    ),
+      commaSep1($._simple_formal_parameter)
+    )),
 
     block_parameters: $ => seq(
       '|',

--- a/grammar.js
+++ b/grammar.js
@@ -151,7 +151,7 @@ module.exports = grammar({
     destructured_parameter: $ => seq('(', commaSep1($._formal_parameter), ')'),
     splat_parameter: $ => seq('*', optional($.identifier)),
     hash_splat_parameter: $ => seq('**', optional($.identifier)),
-    block_parameter: $ => seq('&', $.identifier),
+    block_parameter: $ => seq('&', $._arg),
     keyword_parameter: $ => prec.right(PREC.BITWISE_OR + 1, seq($.identifier, $._keyword_colon, optional($._arg))),
     optional_parameter: $ => prec(PREC.BITWISE_OR + 1, seq($.identifier, '=', $._arg)),
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,9 @@
-module.exports = require("./build/Release/tree_sitter_ruby_binding");
+try {
+  module.exports = require("./build/Release/tree_sitter_ruby_binding");
+} catch (error) {
+  try {
+    module.exports = require("./build/Debug/tree_sitter_ruby_binding");
+  } catch (_) {
+    throw error
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "tree-sitter-cli": "^0.6.6"
   },
   "scripts": {
-    "build": "tree-sitter generate && node-gyp build",
+    "build": "tree-sitter generate && node-gyp build --debug",
     "test": "tree-sitter test && script/parse-examples"
   },
   "repository": "https://github.com/tree-sitter/tree-sitter-ruby"

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -3,9 +3,26 @@
 set -e
 
 # tree-sitter parse $(find examples/ruby_spec/language -name *.rb) -q -t
-for f in $(find examples/ruby_spec/language -name *.rb); do
-  if [[ $f = 'examples/ruby_spec/language/string_spec.rb' ]]; then
-    continue
-  fi
-  tree-sitter parse $f -q -t
+for d in language; do
+
+  for f in $(find examples/ruby_spec/$d -name "*.rb"); do
+    # TODO: Fix these known issues:
+    #   - [ ] String literals delimited with `=`, e.g. `%=hi=`
+    #   - [ ] Issue with << operator mistaken for heredocs, e.g. `send(@method){|r,i| r<<i}`
+    #   - [ ] defined as local var, e.g. `defn.send(@method, defined)`
+    #   - [ ] Unicode character in symbols, variables, etc, e.g. `:êad`
+    #   - [ ] Unicode characters in constants, e.g. `CS_CONSTλ = :const_unicode`
+    if [[ $f = 'examples/ruby_spec/language/string_spec.rb' || \
+          $f = 'examples/ruby_spec/core/enumerable/shared/inject.rb' || \
+          $f = 'examples/ruby_spec/core/method/shared/eql.rb' || \
+          $f = 'examples/ruby_spec/core/symbol/encoding_spec.rb' || \
+          $f = 'examples/ruby_spec/core/module/fixtures/constant_unicode.rb' || \
+          $f = 'examples/ruby_spec/core/marshal/shared/load.rb' || \
+          $f = 'examples/ruby_spec/core/module/fixtures/name.rb' || \
+          $f = 'examples/ruby_spec/core/io/write_spec.rb' ]]; then
+      continue
+    fi
+    tree-sitter parse $f -q -t
+  done
+
 done

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -746,8 +746,17 @@
           "value": "&"
         },
         {
-          "type": "SYMBOL",
-          "name": "_arg"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "identifier"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "lambda"
+            }
+          ]
         }
       ]
     },
@@ -4680,8 +4689,17 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "lambda"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "lambda"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "proc"
+                  }
+                ]
               },
               {
                 "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3659,21 +3659,8 @@
       "value": "[A-Z][a-zA-Z0-9_]*(\\?|\\!)?"
     },
     "identifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "PATTERN",
-          "value": "[a-z_][a-zA-Z0-9_]*(\\?|\\!)?"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_proc_keyword"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_lambda_keyword"
-        }
-      ]
+      "type": "PATTERN",
+      "value": "[a-z_][a-zA-Z0-9_]*(\\?|\\!)?"
     },
     "instance_variable": {
       "type": "PATTERN",
@@ -4693,112 +4680,38 @@
       ]
     },
     "lambda": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "PREC_LEFT",
-          "value": 1,
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_lambda_keyword"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_proc_keyword"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "lambda_parameters"
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "lambda_parameters"
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "block"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "do_block"
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
+          "type": "STRING",
+          "value": "->"
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "->"
+              "type": "SYMBOL",
+              "name": "lambda_parameters"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "lambda_parameters"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "block"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "block"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "do_block"
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "do_block"
             }
           ]
         }
       ]
-    },
-    "_proc_keyword": {
-      "type": "STRING",
-      "value": "proc"
-    },
-    "_lambda_keyword": {
-      "type": "STRING",
-      "value": "lambda"
     },
     "empty_statement": {
       "type": "PREC",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4662,6 +4662,18 @@
                 "type": "CHOICE",
                 "members": [
                   {
+                    "type": "SYMBOL",
+                    "name": "lambda_parameters"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
                     "type": "CHOICE",
                     "members": [
                       {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -432,59 +432,84 @@
       }
     },
     "lambda_parameters": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "("
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_formal_parameter"
+                      },
+                      {
+                        "type": "REPEAT",
+                        "content": {
+                          "type": "SEQ",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_formal_parameter"
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_simple_formal_parameter"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "_formal_parameter"
+                      "type": "STRING",
+                      "value": ","
                     },
                     {
-                      "type": "REPEAT",
-                      "content": {
-                        "type": "SEQ",
-                        "members": [
-                          {
-                            "type": "STRING",
-                            "value": ","
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "_formal_parameter"
-                          }
-                        ]
-                      }
+                      "type": "SYMBOL",
+                      "name": "_simple_formal_parameter"
                     }
                   ]
-                },
-                {
-                  "type": "BLANK"
                 }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_simple_formal_parameter"
-        }
-      ]
+              }
+            ]
+          }
+        ]
+      }
     },
     "block_parameters": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -747,7 +747,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "_arg"
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3659,8 +3659,21 @@
       "value": "[A-Z][a-zA-Z0-9_]*(\\?|\\!)?"
     },
     "identifier": {
-      "type": "PATTERN",
-      "value": "[a-z_][a-zA-Z0-9_]*(\\?|\\!)?"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PATTERN",
+          "value": "[a-z_][a-zA-Z0-9_]*(\\?|\\!)?"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_proc_keyword"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lambda_keyword"
+        }
+      ]
     },
     "instance_variable": {
       "type": "PATTERN",
@@ -4684,7 +4697,7 @@
       "members": [
         {
           "type": "PREC_LEFT",
-          "value": 0,
+          "value": 1,
           "content": {
             "type": "SEQ",
             "members": [
@@ -4692,12 +4705,12 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "STRING",
-                    "value": "lambda"
+                    "type": "SYMBOL",
+                    "name": "_lambda_keyword"
                   },
                   {
-                    "type": "STRING",
-                    "value": "proc"
+                    "type": "SYMBOL",
+                    "name": "_proc_keyword"
                   }
                 ]
               },
@@ -4709,28 +4722,34 @@
                     "name": "lambda_parameters"
                   },
                   {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "CHOICE",
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "block"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "lambda_parameters"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
                       },
                       {
-                        "type": "SYMBOL",
-                        "name": "do_block"
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "block"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "do_block"
+                          }
+                        ]
                       }
                     ]
-                  },
-                  {
-                    "type": "BLANK"
                   }
                 ]
               }
@@ -4772,6 +4791,14 @@
           ]
         }
       ]
+    },
+    "_proc_keyword": {
+      "type": "STRING",
+      "value": "proc"
+    },
+    "_lambda_keyword": {
+      "type": "STRING",
+      "value": "lambda"
     },
     "empty_statement": {
       "type": "PREC",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1952,6 +1952,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "rational"
+        },
+        {
+          "type": "SYMBOL",
           "name": "string"
         },
         {
@@ -4122,6 +4126,19 @@
         "type": "PATTERN",
         "value": "(\\d+)?(\\+|-)?(\\d+)i"
       }
+    },
+    "rational": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "integer"
+        },
+        {
+          "type": "STRING",
+          "value": "r"
+        }
+      ]
     },
     "super": {
       "type": "STRING",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -300,7 +300,7 @@ struct Scanner {
       advance(lexer);
     }
 
-    if (iswalpha(lexer->lookahead) || (lexer->lookahead == '_')) {
+    if (iswalnum(lexer->lookahead) || (lexer->lookahead == '_')) {
       advance(lexer);
     } else if (!scan_operator(lexer)) {
       return false;


### PR DESCRIPTION
- [x] Support for symbols like `:$0`. Fixes #58 
- [x] Allow multiple parameters without parens in lambdas
- [x] Support `2/3r` style rational number syntax
- [x] Allow `lambda` keyword to take arguments
- [x] `lambda` and `proc` can also be identifiers