### PR TITLE
Allow class <<self to parse

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -392,6 +392,9 @@ singleton class
 class << self
 end
 
+class <<self
+end
+
 class << Foo
 end
 
@@ -401,6 +404,7 @@ end
 ---
 
 (program
+  (singleton_class (self))
   (singleton_class (self))
   (singleton_class (constant))
   (singleton_class (scope_resolution (constant) (constant))))

--- a/grammar.js
+++ b/grammar.js
@@ -169,7 +169,7 @@ module.exports = grammar({
 
     singleton_class: $ => seq(
       'class',
-      $._singleton_class_left_angle_left_langle,
+      alias($._singleton_class_left_angle_left_langle, '<<'),
       $._arg,
       $._terminator,
       optional($._body_statement),

--- a/grammar.js
+++ b/grammar.js
@@ -57,7 +57,8 @@ module.exports = grammar({
     $._keyword_colon,
     $._unary_minus,
     $._binary_minus,
-    $._binary_star
+    $._binary_star,
+    $._singleton_class_left_angle_left_langle
   ],
 
   extras: $ => [
@@ -168,7 +169,7 @@ module.exports = grammar({
 
     singleton_class: $ => seq(
       'class',
-      '<<',
+      $._singleton_class_left_angle_left_langle,
       $._arg,
       $._terminator,
       optional($._body_statement),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -885,8 +885,13 @@
           "value": "class"
         },
         {
-          "type": "SYMBOL",
-          "name": "_singleton_class_left_angle_left_langle"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_singleton_class_left_angle_left_langle"
+          },
+          "named": false,
+          "value": "<<"
         },
         {
           "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -885,8 +885,8 @@
           "value": "class"
         },
         {
-          "type": "STRING",
-          "value": "<<"
+          "type": "SYMBOL",
+          "name": "_singleton_class_left_angle_left_langle"
         },
         {
           "type": "SYMBOL",
@@ -4862,6 +4862,10 @@
     {
       "type": "SYMBOL",
       "name": "_binary_star"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_singleton_class_left_angle_left_langle"
     }
   ],
   "inline": []

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -36,7 +36,8 @@ enum TokenType {
   KEYWORD_COLON,
   UNARY_MINUS,
   BINARY_MINUS,
-  BINARY_STAR
+  BINARY_STAR,
+  SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE
 };
 
 struct Literal {
@@ -677,6 +678,17 @@ struct Scanner {
       advance(lexer);
       if (lexer->lookahead != '&' && lexer->lookahead != '.' && lexer->lookahead != '=' && lexer->lookahead != ' ' && lexer->lookahead != '\t' && !lookahead_is_line_end(lexer)) {
         lexer->result_symbol = BLOCK_AMPERSAND;
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    if (valid_symbols[SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE] && lexer->lookahead == '<') {
+      advance(lexer);
+      if (lexer->lookahead == '<') {
+        advance(lexer);
+        lexer->result_symbol = SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE;
         return true;
       } else {
         return false;


### PR DESCRIPTION
Fixes an issue with parsing the `<<` syntax used to extend the definition of a class singleton when there is no space between the `<<` and the class name.

``` ruby
class Foo
  class <<self
  end
end
```

The `<<self` was getting parsed as heredoc beginning and then later failing when there was no end. This fixes that.