### PR TITLE
Faster and more comprehensive example smoke testing

### DIFF
--- a/script/known_failures.txt
+++ b/script/known_failures.txt
@@ -1,0 +1,8 @@
+examples/ruby_spec/language/string_spec.rb
+examples/ruby_spec/core/enumerable/shared/inject.rb
+examples/ruby_spec/core/method/shared/eql.rb
+examples/ruby_spec/core/symbol/encoding_spec.rb
+examples/ruby_spec/core/module/fixtures/constant_unicode.rb
+examples/ruby_spec/core/marshal/shared/load.rb
+examples/ruby_spec/core/module/fixtures/name.rb
+examples/ruby_spec/core/io/write_spec.rb

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -2,27 +2,22 @@
 
 set -e
 
-# tree-sitter parse $(find examples/ruby_spec/language -name *.rb) -q -t
-for d in language; do
-
-  for f in $(find examples/ruby_spec/$d -name "*.rb"); do
-    # TODO: Fix these known issues:
-    #   - [ ] String literals delimited with `=`, e.g. `%=hi=`
-    #   - [ ] Issue with << operator mistaken for heredocs, e.g. `send(@method){|r,i| r<<i}`
-    #   - [ ] defined as local var, e.g. `defn.send(@method, defined)`
-    #   - [ ] Unicode character in symbols, variables, etc, e.g. `:êad`
-    #   - [ ] Unicode characters in constants, e.g. `CS_CONSTλ = :const_unicode`
-    if [[ $f = 'examples/ruby_spec/language/string_spec.rb' || \
-          $f = 'examples/ruby_spec/core/enumerable/shared/inject.rb' || \
-          $f = 'examples/ruby_spec/core/method/shared/eql.rb' || \
-          $f = 'examples/ruby_spec/core/symbol/encoding_spec.rb' || \
-          $f = 'examples/ruby_spec/core/module/fixtures/constant_unicode.rb' || \
-          $f = 'examples/ruby_spec/core/marshal/shared/load.rb' || \
-          $f = 'examples/ruby_spec/core/module/fixtures/name.rb' || \
-          $f = 'examples/ruby_spec/core/io/write_spec.rb' ]]; then
-      continue
-    fi
-    tree-sitter parse $f -q -t
+# TODO: Fix these known issues:
+#   - [ ] String literals delimited with `=`, e.g. `%=hi=`
+#   - [ ] Issue with << operator mistaken for heredocs, e.g. `send(@method){|r,i| r<<i}`
+#   - [ ] defined as local var, e.g. `defn.send(@method, defined)`
+#   - [ ] Unicode character in symbols, variables, etc, e.g. `:êad`
+#   - [ ] Unicode characters in constants, e.g. `CS_CONSTλ = :const_unicode`
+known_failures=$(cat script/known_failures.txt)
+examples_to_parse=$(
+  # Just parse language and core specs
+  for d in language core; do
+    for example in $(find examples/ruby_spec/$d -name '*.rb'); do
+      if [[ ! $known_failures == *$example* ]]; then
+        echo $example
+      fi
+    done
   done
+)
 
-done
+echo $examples_to_parse | xargs -n 5000 tree-sitter parse -qt


### PR DESCRIPTION
Takes some inspiration from @maxbrunsfeld script in [tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash/blob/master/script/parse-examples.sh) to speed up example testing (really just a pass/fail smoke test).

- [x] Create specific list of files we are ignoring
- [x] Parse both core and language dirs in the ruby spec project
- [x] Use `xargs` trick to deal with argument list limits and invoke `tree-sitter parse` with batches of file paths.