### PR TITLE
Use external scanner to detect reserved identifiers used as keyword args

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -651,7 +651,7 @@ foo B: true
 (program
   (method_call (identifier) (argument_list (pair (identifier) (true))))
   (method_call (identifier) (argument_list (pair (identifier) (true))))
-  (method_call (identifier) (argument_list (pair (constant) (true)))))
+  (method_call (identifier) (argument_list (pair (identifier) (true)))))
 
 ===============================
 method call with reserved keyword args

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -654,6 +654,89 @@ foo B: true
   (method_call (identifier) (argument_list (pair (constant) (true)))))
 
 ===============================
+method call with reserved keyword args
+===============================
+
+foo(if: true)
+foo alias: true
+foo and: true
+foo begin: true
+foo break: true
+foo case: true
+foo class: true
+foo def: true
+foo defined: true
+foo do: true
+foo else: true
+foo elsif: true
+foo end: true
+foo ensure: true
+foo false: true
+foo for: true
+foo if: true
+foo in: true
+foo module: true
+foo next: true
+foo nil: true
+foo not: true
+foo or: true
+foo redo: true
+foo rescue: true
+foo retry: true
+foo return: true
+foo self: true
+foo super: true
+foo then: true
+foo true: true
+foo undef: true
+foo unless: true
+foo until: true
+foo when: true
+foo while: true
+foo yield: true
+
+---
+
+(program
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true))))
+  (method_call (identifier) (argument_list (pair (identifier) (true)))))
+
+===============================
 method call with paren args
 ===============================
 

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1169,10 +1169,15 @@ hash with keyword keys
 ======================
 
 { a: 1, b: 2, "c": 3 }
+{a:1, b:2, "c":3 }
 
 ---
 
 (program
+  (hash
+    (pair (identifier) (integer))
+    (pair (identifier) (integer))
+    (pair (string) (integer)))
   (hash
     (pair (identifier) (integer))
     (pair (identifier) (integer))

--- a/grammar.js
+++ b/grammar.js
@@ -59,7 +59,7 @@ module.exports = grammar({
     $._binary_minus,
     $._binary_star,
     $._singleton_class_left_angle_left_langle,
-    $._reserved_keyword_identifier
+    $._identifier_hash_key
   ],
 
   extras: $ => [
@@ -620,7 +620,7 @@ module.exports = grammar({
             ),
             $._keyword_colon
           ),
-          alias($._reserved_keyword_identifier, $.identifier)
+          alias($._identifier_hash_key, $.identifier)
         ),
         $._arg
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -58,7 +58,8 @@ module.exports = grammar({
     $._unary_minus,
     $._binary_minus,
     $._binary_star,
-    $._singleton_class_left_angle_left_langle
+    $._singleton_class_left_angle_left_langle,
+    $._reserved_keyword_identifier
   ],
 
   extras: $ => [
@@ -495,13 +496,6 @@ module.exports = grammar({
 
     global_variable: $ => /\$-?(([!@&`'+~=/\\,;.<>*$?:"])|([0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))/,
 
-    reserved_identifier: $ => choice(
-      'alias', 'and', 'begin', 'break', 'case', 'class', 'def', 'defined', 'do',
-      'else', 'elsif', 'end', 'ensure', 'false', 'for', 'in', 'module', 'next',
-      'nil', 'not', 'or', 'redo', 'rescue', 'retry', 'return', 'self', 'super',
-      'then', 'true', 'undef', 'when', 'yield', 'if', 'unless', 'while', 'until'
-    ),
-
     operator: $ => choice(
       '..', '|', '^', '&', '<=>', '==', '===', '=~', '>', '>=', '<', '<=', '+',
       '-', '*', '/', '%', '!', '!~', '**', '<<', '>>', '~', '+@', '-@', '[]', '[]=', '`'
@@ -622,11 +616,11 @@ module.exports = grammar({
             choice(
               $.identifier,
               $.constant,
-              alias($.reserved_identifier, $.identifier),
               $.string
             ),
             $._keyword_colon
-          )
+          ),
+          alias($._reserved_keyword_identifier, $.identifier)
         ),
         $._arg
       ),

--- a/script/known_failures.txt
+++ b/script/known_failures.txt
@@ -3,6 +3,5 @@ examples/ruby_spec/core/enumerable/shared/inject.rb
 examples/ruby_spec/core/method/shared/eql.rb
 examples/ruby_spec/core/symbol/encoding_spec.rb
 examples/ruby_spec/core/module/fixtures/constant_unicode.rb
-examples/ruby_spec/core/marshal/shared/load.rb
 examples/ruby_spec/core/module/fixtures/name.rb
 examples/ruby_spec/core/io/write_spec.rb

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3560,155 +3560,6 @@
       "type": "PATTERN",
       "value": "\\$-?(([!@&`'+~=\\/\\\\,;.<>*$?:\"])|([0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))"
     },
-    "reserved_identifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "alias"
-        },
-        {
-          "type": "STRING",
-          "value": "and"
-        },
-        {
-          "type": "STRING",
-          "value": "begin"
-        },
-        {
-          "type": "STRING",
-          "value": "break"
-        },
-        {
-          "type": "STRING",
-          "value": "case"
-        },
-        {
-          "type": "STRING",
-          "value": "class"
-        },
-        {
-          "type": "STRING",
-          "value": "def"
-        },
-        {
-          "type": "STRING",
-          "value": "defined"
-        },
-        {
-          "type": "STRING",
-          "value": "do"
-        },
-        {
-          "type": "STRING",
-          "value": "else"
-        },
-        {
-          "type": "STRING",
-          "value": "elsif"
-        },
-        {
-          "type": "STRING",
-          "value": "end"
-        },
-        {
-          "type": "STRING",
-          "value": "ensure"
-        },
-        {
-          "type": "STRING",
-          "value": "false"
-        },
-        {
-          "type": "STRING",
-          "value": "for"
-        },
-        {
-          "type": "STRING",
-          "value": "in"
-        },
-        {
-          "type": "STRING",
-          "value": "module"
-        },
-        {
-          "type": "STRING",
-          "value": "next"
-        },
-        {
-          "type": "STRING",
-          "value": "nil"
-        },
-        {
-          "type": "STRING",
-          "value": "not"
-        },
-        {
-          "type": "STRING",
-          "value": "or"
-        },
-        {
-          "type": "STRING",
-          "value": "redo"
-        },
-        {
-          "type": "STRING",
-          "value": "rescue"
-        },
-        {
-          "type": "STRING",
-          "value": "retry"
-        },
-        {
-          "type": "STRING",
-          "value": "return"
-        },
-        {
-          "type": "STRING",
-          "value": "self"
-        },
-        {
-          "type": "STRING",
-          "value": "super"
-        },
-        {
-          "type": "STRING",
-          "value": "then"
-        },
-        {
-          "type": "STRING",
-          "value": "true"
-        },
-        {
-          "type": "STRING",
-          "value": "undef"
-        },
-        {
-          "type": "STRING",
-          "value": "when"
-        },
-        {
-          "type": "STRING",
-          "value": "yield"
-        },
-        {
-          "type": "STRING",
-          "value": "if"
-        },
-        {
-          "type": "STRING",
-          "value": "unless"
-        },
-        {
-          "type": "STRING",
-          "value": "while"
-        },
-        {
-          "type": "STRING",
-          "value": "until"
-        }
-      ]
-    },
     "operator": {
       "type": "CHOICE",
       "members": [
@@ -4467,15 +4318,6 @@
                             "name": "constant"
                           },
                           {
-                            "type": "ALIAS",
-                            "content": {
-                              "type": "SYMBOL",
-                              "name": "reserved_identifier"
-                            },
-                            "named": true,
-                            "value": "identifier"
-                          },
-                          {
                             "type": "SYMBOL",
                             "name": "string"
                           }
@@ -4486,6 +4328,15 @@
                         "name": "_keyword_colon"
                       }
                     ]
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_reserved_keyword_identifier"
+                    },
+                    "named": true,
+                    "value": "identifier"
                   }
                 ]
               },
@@ -4736,6 +4587,10 @@
     {
       "type": "SYMBOL",
       "name": "_singleton_class_left_angle_left_langle"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_reserved_keyword_identifier"
     }
   ],
   "inline": []

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4333,7 +4333,7 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "SYMBOL",
-                      "name": "_reserved_keyword_identifier"
+                      "name": "_identifier_hash_key"
                     },
                     "named": true,
                     "value": "identifier"
@@ -4590,7 +4590,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_reserved_keyword_identifier"
+      "name": "_identifier_hash_key"
     }
   ],
   "inline": []

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -81,7 +81,7 @@ TokenType SIMPLE_TOKEN_TYPES[] = {
 };
 
 // Can be used as keyword arguments syntax for hash parameter in a method call (e.g. `foo unless: true`).
-string RESERVED_IDENTIFIERS[] = {
+vector<string> RESERVED_IDENTIFIERS = {
   "alias",
   "and",
   "begin",
@@ -797,12 +797,8 @@ struct Scanner {
     }
 
     if (valid_symbols[RESERVED_KEYWORD_IDENTIFIER] && iswalpha(lexer->lookahead)) {
-      vector<string> matching_identifiers;
       size_t position_in_word = 0;
-
-      for (const string &identifier : RESERVED_IDENTIFIERS) {
-        matching_identifiers.push_back(identifier);
-      }
+      vector<string> matching_identifiers(RESERVED_IDENTIFIERS);
 
       for (;;) {
         if (lexer->lookahead == 0) break;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -797,7 +797,6 @@ struct Scanner {
     }
 
     if (valid_symbols[RESERVED_KEYWORD_IDENTIFIER] && iswalpha(lexer->lookahead)) {
-      // printf("-----> scanning for reserved keywords, lookahead = '%c'\n", lexer->lookahead);
       vector<string> matching_identifiers;
       size_t position_in_word = 0;
 
@@ -809,13 +808,10 @@ struct Scanner {
         if (lexer->lookahead == 0) break;
 
         for (vector<string>::iterator iter = matching_identifiers.begin(); iter != matching_identifiers.end();) {
-          // printf("-----> trying to match \"%s\": ", iter->c_str());
           if (position_in_word < iter->length() && lexer->lookahead == (*iter)[position_in_word]) {
-            // printf("matched '%c'\n", lexer->lookahead);
             ++iter;
           } else {
             matching_identifiers.erase(iter);
-            // printf("not matched\n");
           }
         }
 
@@ -829,7 +825,6 @@ struct Scanner {
             if(position_in_word == iter->length()) {
               advance(lexer);
               lexer->result_symbol = RESERVED_KEYWORD_IDENTIFIER;
-              // printf("-----> done, found reserved keyword identifier \"%s\"\n", iter->c_str());
               return true;
             }
           }
@@ -837,7 +832,6 @@ struct Scanner {
         }
       }
 
-      // printf("-----> done\n");
       return false;
     }
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -38,7 +38,7 @@ enum TokenType {
   BINARY_MINUS,
   BINARY_STAR,
   SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE,
-  RESERVED_KEYWORD_IDENTIFIER
+  IDENTIFIER_HASH_KEY
 };
 
 struct Literal {
@@ -78,46 +78,6 @@ TokenType SIMPLE_TOKEN_TYPES[] = {
   SIMPLE_SUBSHELL,
   SIMPLE_REGEX,
   SIMPLE_WORD_LIST,
-};
-
-// Can be used as keyword arguments syntax for hash parameter in a method call (e.g. `foo unless: true`).
-vector<string> RESERVED_IDENTIFIERS = {
-  "alias",
-  "and",
-  "begin",
-  "break",
-  "case",
-  "class",
-  "def",
-  "defined",
-  "do",
-  "else",
-  "elsif",
-  "end",
-  "ensure",
-  "false",
-  "for",
-  "if",
-  "in",
-  "module",
-  "next",
-  "nil",
-  "not",
-  "or",
-  "redo",
-  "rescue",
-  "retry",
-  "return",
-  "self",
-  "super",
-  "then",
-  "true",
-  "undef",
-  "unless",
-  "until",
-  "when",
-  "while",
-  "yield",
 };
 
 struct Scanner {
@@ -796,39 +756,25 @@ struct Scanner {
       }
     }
 
-    if (valid_symbols[RESERVED_KEYWORD_IDENTIFIER] && iswalpha(lexer->lookahead)) {
-      size_t position_in_word = 0;
-      vector<string> matching_identifiers(RESERVED_IDENTIFIERS);
-
+    if (valid_symbols[IDENTIFIER_HASH_KEY]) {
       for (;;) {
         if (lexer->lookahead == 0) break;
 
-        for (vector<string>::iterator iter = matching_identifiers.begin(); iter != matching_identifiers.end();) {
-          if (position_in_word < iter->length() && lexer->lookahead == (*iter)[position_in_word]) {
-            ++iter;
-          } else {
-            matching_identifiers.erase(iter);
-          }
-        }
-
-        if (matching_identifiers.empty()) break;
-
-        advance(lexer);
-        position_in_word++;
-
-        if(lexer->lookahead == ':') {
-          for (vector<string>::iterator iter = matching_identifiers.begin(); iter != matching_identifiers.end(); ++iter) {
-            if(position_in_word == iter->length()) {
-              advance(lexer);
-              lexer->result_symbol = RESERVED_KEYWORD_IDENTIFIER;
+        if (iswalpha(lexer->lookahead)) {
+          advance(lexer);
+          if (lexer->lookahead == ':') {
+            advance(lexer);
+            if (lexer->lookahead != ':') {
+              lexer->result_symbol = IDENTIFIER_HASH_KEY;
               return true;
+            } else {
+              return false;
             }
           }
+        } else {
           break;
         }
       }
-
-      return false;
     }
 
     if (valid_symbols[STRING_MIDDLE] && ! literal_stack.empty()) {


### PR DESCRIPTION
Takes over from https://github.com/tree-sitter/tree-sitter-ruby/pull/62 and allows us to parse things like:

``` ruby
some_method_call if: true
```

Thanks for the suggestion to detect this in the scanner @maxbrunsfeld - that worked pretty well and I spent some time making it so that we can just maintain a list of these and add/remove as there may be more reserved words I don't know about. I'd love a little review here as my C++ is a bit rusty.