### PR TITLE
Heredoc method continuation fix

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -748,7 +748,7 @@ SQL
   (argument_list)))
 
 ========================================
-heredocs with method continuation part 2
+heredocs with suffix dot method continuation
 ========================================
 
 joins(<<~SQL).
@@ -760,9 +760,29 @@ where("a")
 
 (program
   (method_call
+    (call (method_call (identifier) (argument_list (heredoc_beginning))) (heredoc_end) (identifier))
+    (argument_list (string))))
+
+========================================
+multiple heredocs with method continuation
+========================================
+
+joins(<<~SQL).where(<<~SQL).
+  `one`
+SQL
+  `two`
+SQL
+group("b")
+
+---
+
+(program
+  (method_call
     (call
-      (method_call (identifier) (argument_list (heredoc_beginning)))
-      (heredoc_end) (identifier))
+      (method_call
+        (call (method_call (identifier) (argument_list (heredoc_beginning))) (identifier))
+        (argument_list (heredoc_beginning)))
+      (heredoc_end) (heredoc_end) (identifier))
     (argument_list (string))))
 
 ========================================

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -748,6 +748,24 @@ SQL
   (argument_list)))
 
 ========================================
+heredocs with method continuation part 2
+========================================
+
+joins(<<~SQL).
+   `foo`
+SQL
+where("a")
+
+---
+
+(program
+  (method_call
+    (call
+      (method_call (identifier) (argument_list (heredoc_beginning)))
+      (heredoc_end) (identifier))
+    (argument_list (string))))
+
+========================================
 heredocs with interpolation
 ========================================
 

--- a/grammar.js
+++ b/grammar.js
@@ -343,6 +343,7 @@ module.exports = grammar({
     call: $ => prec.left(PREC.BITWISE_AND + 1, seq(
       $._primary,
       choice('.', '&.'),
+      optional($.heredoc_end),
       choice($.identifier, $.operator, $.constant, $.argument_list_with_parens)
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -343,7 +343,7 @@ module.exports = grammar({
     call: $ => prec.left(PREC.BITWISE_AND + 1, seq(
       $._primary,
       choice('.', '&.'),
-      optional($.heredoc_end),
+      repeat($.heredoc_end),
       choice($.identifier, $.operator, $.constant, $.argument_list_with_parens)
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2132,6 +2132,18 @@
             "members": [
               {
                 "type": "SYMBOL",
+                "name": "heredoc_end"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
                 "name": "identifier"
               },
               {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2128,16 +2128,11 @@
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "heredoc_end"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "REPEAT",
+            "content": {
+              "type": "SYMBOL",
+              "name": "heredoc_end"
+            }
           },
           {
             "type": "CHOICE",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -229,6 +229,7 @@ struct Scanner {
           if (!open_heredocs.empty() && !*found_heredoc_starting_linebreak) {
             skip(lexer);
             *found_heredoc_starting_linebreak = true;
+            // printf("found_heredoc_starting_linebreak\n");
             return true;
           } else if (valid_symbols[LINE_BREAK]) {
             advance(lexer);
@@ -704,6 +705,7 @@ struct Scanner {
     }
 
     if (valid_symbols[HEREDOC_BODY_BEGINNING] && !open_heredocs.empty() && found_heredoc_starting_linebreak) {
+      // printf("scanning for heredoc body beginning");
       if (literal_stack.empty()) {
         switch (scan_heredoc_content(lexer)) {
           case Error:

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -229,7 +229,6 @@ struct Scanner {
           if (!open_heredocs.empty() && !*found_heredoc_starting_linebreak) {
             skip(lexer);
             *found_heredoc_starting_linebreak = true;
-            // printf("found_heredoc_starting_linebreak\n");
             return true;
           } else if (valid_symbols[LINE_BREAK]) {
             advance(lexer);
@@ -705,7 +704,6 @@ struct Scanner {
     }
 
     if (valid_symbols[HEREDOC_BODY_BEGINNING] && !open_heredocs.empty() && found_heredoc_starting_linebreak) {
-      // printf("scanning for heredoc body beginning");
       if (literal_stack.empty()) {
         switch (scan_heredoc_content(lexer)) {
           case Error:


### PR DESCRIPTION
Fix for heredocs that use a suffix `.` for method continuation like:

``` Ruby
joins(<<~SQL).
   `foo`
SQL
where("a")
```

Based on #67
