### PR TITLE
Parse non-ascii identifiers

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -316,13 +316,17 @@ end
 class ::Foo::Bar
 end
 
+class Cß
+end
+
 ---
 
 (program
   (class (constant))
   (class (constant))
   (class (scope_resolution (constant) (constant)))
-  (class (scope_resolution (scope_resolution (constant)) (constant))))
+  (class (scope_resolution (scope_resolution (constant)) (constant)))
+  (class (constant)))
 
 ==============
 empty subclass

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -153,6 +153,7 @@ defined? Foo.bar
 defined?(foo)
 defined?($foo)
 defined?(@foo)
+defined?(@äö)
 
 ---
 
@@ -161,6 +162,7 @@ defined?(@foo)
   (unary (call (constant) (identifier)))
   (unary (parenthesized_statements (identifier)))
   (unary (parenthesized_statements (global_variable)))
+  (unary (parenthesized_statements (instance_variable)))
   (unary (parenthesized_statements (instance_variable))))
 
 ==========

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -12,10 +12,12 @@ symbol
 :$foo
 :$0
 :_bar
+:åäö
 
 ---
 
 (program
+  (symbol)
   (symbol)
   (symbol)
   (symbol)
@@ -1399,3 +1401,22 @@ end
 ---
 
 (program (lambda (lambda_parameters (identifier)) (do_block (integer))))
+
+====================
+non-ascii identifiers
+====================
+
+Cß
+@äö
+@@äö
+:äö
+äö
+
+---
+
+(program
+  (constant)
+  (instance_variable)
+  (class_variable)
+  (symbol)
+  (identifier))

--- a/grammar.js
+++ b/grammar.js
@@ -26,6 +26,10 @@ const PREC = {
   COMPLEMENT: 85,
 };
 
+const IDENTIFIER_CHARS = /[^\s:;`"'@$#.,|^&<=>+\-*/\\%?!~()\[\]{}]*/;
+const LOWER_ALPHA_CHAR = /[^\sA-Z0-9:;`"'@$#.,|^&<=>+\-*/\\%?!~()\[\]{}]/;
+const ALPHA_CHAR = /[^\s0-9:;`"'@$#.,|^&<=>+\-*/\\%?!~()\[\]{}]/;
+
 module.exports = grammar({
   name: 'ruby',
 
@@ -487,13 +491,13 @@ module.exports = grammar({
       $.constant
     )),
 
-    constant: $ => /[A-Z][a-zA-Z0-9_]*(\?|\!)?/,
+    constant: $ => token(seq(/[A-Z]/, IDENTIFIER_CHARS, /(\?|\!)?/)),
 
-    identifier: $ => /[a-z_][a-zA-Z0-9_]*(\?|\!)?/,
+    identifier: $ => token(seq(LOWER_ALPHA_CHAR, IDENTIFIER_CHARS, /(\?|\!)?/)),
 
-    instance_variable: $ => /@[a-zA-Z_][a-zA-Z0-9_]*/,
+    instance_variable: $ => token(seq('@', ALPHA_CHAR, IDENTIFIER_CHARS)),
 
-    class_variable: $ => /@@[a-zA-Z_][a-zA-Z0-9_]*/,
+    class_variable: $ => token(seq('@@', ALPHA_CHAR, IDENTIFIER_CHARS)),
 
     global_variable: $ => /\$-?(([!@&`'+~=/\\,;.<>*$?:"])|([0-9]*)|([a-zA-Z_][a-zA-Z0-9_]*))/,
 

--- a/script/known_failures.txt
+++ b/script/known_failures.txt
@@ -1,7 +1,1 @@
-examples/ruby_spec/language/string_spec.rb
 examples/ruby_spec/core/enumerable/shared/inject.rb
-examples/ruby_spec/core/method/shared/eql.rb
-examples/ruby_spec/core/symbol/encoding_spec.rb
-examples/ruby_spec/core/module/fixtures/constant_unicode.rb
-examples/ruby_spec/core/module/fixtures/name.rb
-examples/ruby_spec/core/io/write_spec.rb

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3548,20 +3548,84 @@
       }
     },
     "constant": {
-      "type": "PATTERN",
-      "value": "[A-Z][a-zA-Z0-9_]*(\\?|\\!)?"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[A-Z]"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\s:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]*"
+          },
+          {
+            "type": "PATTERN",
+            "value": "(\\?|\\!)?"
+          }
+        ]
+      }
     },
     "identifier": {
-      "type": "PATTERN",
-      "value": "[a-z_][a-zA-Z0-9_]*(\\?|\\!)?"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "PATTERN",
+            "value": "[^\\sA-Z0-9:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\s:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]*"
+          },
+          {
+            "type": "PATTERN",
+            "value": "(\\?|\\!)?"
+          }
+        ]
+      }
     },
     "instance_variable": {
-      "type": "PATTERN",
-      "value": "@[a-zA-Z_][a-zA-Z0-9_]*"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "@"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\s0-9:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\s:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]*"
+          }
+        ]
+      }
     },
     "class_variable": {
-      "type": "PATTERN",
-      "value": "@@[a-zA-Z_][a-zA-Z0-9_]*"
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "@@"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\s0-9:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]"
+          },
+          {
+            "type": "PATTERN",
+            "value": "[^\\s:;`\"'@$#.,|^&<=>+\\-*\\/\\\\%?!~()\\[\\]{}]*"
+          }
+        ]
+      }
     },
     "global_variable": {
       "type": "PATTERN",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,11 +1,13 @@
 #include <tree_sitter/parser.h>
 #include <vector>
+#include <set>
 #include <string>
 #include <cwctype>
 
 namespace {
 
 using std::vector;
+using std::set;
 using std::string;
 
 enum TokenType {
@@ -78,6 +80,45 @@ TokenType SIMPLE_TOKEN_TYPES[] = {
   SIMPLE_SUBSHELL,
   SIMPLE_REGEX,
   SIMPLE_WORD_LIST,
+};
+
+// const IDENTIFIER_CHARS = /[^\s:;`"'@$#.,|^&<=>+\-*/\\%?!~()\[\]{}]*/;
+set<char> NON_ALPHA_NUM_CHARS = {
+  '\n',
+  '\r',
+  '\t',
+  ' ',
+  ':',
+  ';',
+  '`',
+  '"',
+  '\'',
+  '@',
+  '$',
+  '#',
+  '.',
+  ',',
+  '|',
+  '^',
+  '&',
+  '<',
+  '=',
+  '>',
+  '+',
+  '-',
+  '*',
+  '/',
+  '\\',
+  '%',
+  '?',
+  '!',
+  '~',
+  '(',
+  ')',
+  '[',
+  ']',
+  '{',
+  '}',
 };
 
 struct Scanner {
@@ -295,6 +336,10 @@ struct Scanner {
     }
   }
 
+  bool is_iden_char(char c) {
+    return NON_ALPHA_NUM_CHARS.find(c) == NON_ALPHA_NUM_CHARS.end();
+  }
+
   bool scan_symbol_identifier(TSLexer *lexer) {
     if (lexer->lookahead == '@') {
       advance(lexer);
@@ -305,13 +350,13 @@ struct Scanner {
       advance(lexer);
     }
 
-    if (iswalnum(lexer->lookahead) || (lexer->lookahead == '_')) {
+    if (is_iden_char(lexer->lookahead)) {
       advance(lexer);
     } else if (!scan_operator(lexer)) {
       return false;
     }
 
-    while (iswalnum(lexer->lookahead) || (lexer->lookahead == '_')) {
+    while (is_iden_char(lexer->lookahead)) {
       advance(lexer);
     }
 


### PR DESCRIPTION
This let's us remove all but one known failure in `script/parse-examples`.