### PR TITLE
Test and fix IDENTIFIER_HASH_KEY consuming and not returning

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1154,9 +1154,17 @@ division without spaces
 h/w
 "#{foo}"
 
+Time.at(timestamp/1000)
+"#{timestamp}"
+
 ---
 
-(program (binary (identifier) (identifier)) (string (identifier)))
+(program
+  (binary (identifier) (identifier)) (string (identifier))
+  (method_call
+    (call (constant) (identifier))
+    (argument_list (binary (identifier) (integer))))
+  (string (identifier)))
 
 ===============================
 regex as parameter

--- a/grammar.js
+++ b/grammar.js
@@ -614,22 +614,18 @@ module.exports = grammar({
     ),
 
     pair: $ => prec(-1, choice(
+      seq($._arg, '=>', $._arg),
       seq(
         choice(
-          seq($._arg, '=>'),
-          seq(
-            choice(
-              $.identifier,
-              $.constant,
-              $.string
-            ),
-            $._keyword_colon
-          ),
-          alias($._identifier_hash_key, $.identifier)
+          alias($._identifier_hash_key, $.identifier),
+          $.identifier,
+          $.constant,
+          $.string
         ),
+        $._keyword_colon,
         $._arg
       ),
-      choice($.hash_splat_argument)
+      $.hash_splat_argument
     )),
 
     regex: $ => choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4359,57 +4359,12 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_arg"
-                      },
-                      {
-                        "type": "STRING",
-                        "value": "=>"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "SYMBOL",
-                            "name": "identifier"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "constant"
-                          },
-                          {
-                            "type": "SYMBOL",
-                            "name": "string"
-                          }
-                        ]
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "_keyword_colon"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_identifier_hash_key"
-                    },
-                    "named": true,
-                    "value": "identifier"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "STRING",
+                "value": "=>"
               },
               {
                 "type": "SYMBOL",
@@ -4418,13 +4373,47 @@
             ]
           },
           {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_identifier_hash_key"
+                    },
+                    "named": true,
+                    "value": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "constant"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "string"
+                  }
+                ]
+              },
+              {
                 "type": "SYMBOL",
-                "name": "hash_splat_argument"
+                "name": "_keyword_colon"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
               }
             ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "hash_splat_argument"
           }
         ]
       }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -803,11 +803,13 @@ struct Scanner {
     }
 
     if (valid_symbols[IDENTIFIER_HASH_KEY]) {
+      size_t consumed = 0;
       for (;;) {
         if (lexer->lookahead == 0) break;
 
         if (iswalpha(lexer->lookahead)) {
           advance(lexer);
+          consumed++;
           if (lexer->lookahead == ':') {
             advance(lexer);
             if (lexer->lookahead != ':') {
@@ -817,8 +819,10 @@ struct Scanner {
               return false;
             }
           }
-        } else {
+        } else if (consumed == 0) {
           break;
+        } else {
+          return false;
         }
       }
     }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -802,29 +802,19 @@ struct Scanner {
       }
     }
 
-    if (valid_symbols[IDENTIFIER_HASH_KEY]) {
-      size_t consumed = 0;
-      for (;;) {
-        if (lexer->lookahead == 0) break;
+    if (valid_symbols[IDENTIFIER_HASH_KEY] && iswalpha(lexer->lookahead)) {
+      while (iswalpha(lexer->lookahead)) advance(lexer);
+      lexer->mark_end(lexer);
 
-        if (iswalpha(lexer->lookahead)) {
-          advance(lexer);
-          consumed++;
-          if (lexer->lookahead == ':') {
-            advance(lexer);
-            if (lexer->lookahead != ':') {
-              lexer->result_symbol = IDENTIFIER_HASH_KEY;
-              return true;
-            } else {
-              return false;
-            }
-          }
-        } else if (consumed == 0) {
-          break;
-        } else {
-          return false;
+      if (lexer->lookahead == ':') {
+        advance(lexer);
+        if (lexer->lookahead != ':') {
+          lexer->result_symbol = IDENTIFIER_HASH_KEY;
+          return true;
         }
       }
+
+      return false;
     }
 
     if (valid_symbols[STRING_MIDDLE] && ! literal_stack.empty()) {


### PR DESCRIPTION
The new scanner code for identifier hash keys in #70 has a bug that breaks `/` and regex ambiguities because it consumes but doesn't return if a hash key is not found. This fixes that. 🎩 @maxbrunsfeld 