### PR TITLE
Fix precedence of empty block vs empty hash

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -604,6 +604,29 @@ foo.(1, 2)
   (call (identifier) (argument_list_with_parens (integer) (integer))))
 
 ===============================
+implicit call with block
+===============================
+
+a.() {}
+a.(b: c) do
+  d
+end
+
+---
+
+(program
+  (method_call
+    (call
+      (identifier)
+      (argument_list_with_parens))
+    (block))
+  (method_call
+    (call
+      (identifier)
+      (argument_list_with_parens (pair (identifier) (identifier))))
+    (do_block (identifier))))
+
+===============================
 call with operator method name
 ===============================
 
@@ -1008,7 +1031,7 @@ lambda {}
 
 ---
 
-(program (method_call (identifier) (argument_list (hash))))
+(program (method_call (identifier) (block)))
 
 ==================
 lambda expressions
@@ -1023,7 +1046,7 @@ lambda(&lambda{})
 (program
   (method_call (identifier) (block (identifier)))
   (method_call (identifier) (argument_list (block_argument (identifier))) (block (identifier)))
-  (method_call (identifier) (argument_list (block_argument (method_call (identifier) (argument_list (hash)))))))
+  (method_call (identifier) (argument_list (block_argument (method_call (identifier) (block))))))
 
 ====================
 lambda expression with an arg
@@ -1110,8 +1133,8 @@ proc = proc {}
 
 (program
   (assignment (identifier) (call (constant) (identifier)))
-  (assignment (identifier) (method_call (identifier) (argument_list (hash))))
-  (assignment (identifier) (method_call (identifier) (argument_list (hash)))))
+  (assignment (identifier) (method_call (identifier) (block)))
+  (assignment (identifier) (method_call (identifier) (block))))
 
 ===============================
 backslash-newline as line continuation

--- a/grammar.js
+++ b/grammar.js
@@ -407,12 +407,12 @@ module.exports = grammar({
       'end'
     ),
 
-    block: $ => seq(
+    block: $ => prec(PREC.CURLY_BLOCK, seq(
       '{',
       optional($.block_parameters),
       optional($._statements),
       '}'
-    ),
+    )),
 
     assignment: $ => choice(
       prec(1, seq($._lhs, '=', $._arg_or_splat_arg)),
@@ -602,12 +602,12 @@ module.exports = grammar({
       )
     ),
 
-    hash: $ => prec(1, seq(
+    hash: $ => seq(
       '{',
       optional($._hash_items),
       optional($.heredoc_end),
       '}'
-    )),
+    ),
     _hash_items: $ => seq(
       $.pair,
       optional(prec.right(seq(',', optional($.heredoc_end), optional($._hash_items))))

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
   "author": "Rob Rix",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.4.0",
-    "npm": "^5.8.0"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "tree-sitter-cli": "^0.11.2"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2621,41 +2621,45 @@
       ]
     },
     "block": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "block_parameters"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        }
-      ]
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "block_parameters"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_statements"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          }
+        ]
+      }
     },
     "assignment": {
       "type": "CHOICE",
@@ -4255,45 +4259,41 @@
       ]
     },
     "hash": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "{"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_hash_items"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "heredoc_end"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "}"
-          }
-        ]
-      }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_hash_items"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "heredoc_end"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
     },
     "_hash_items": {
       "type": "SEQ",


### PR DESCRIPTION
For some reason, we had explicitly given the `hash` rule a higher precedence than `block`, even though the opposite is correct; `puts {}` parses as a call with an empty block, not an empty hash.

A adjusted several existing tests that had incorrect assertions and added one new test specifically about dot calls with blocks.

Fixes #74