### PR TITLE
Insert 'line break' tokens at included range boundaries

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1198,11 +1198,11 @@ Time.at(timestamp/1000)
 ---
 
 (program
-  (binary (identifier) (identifier)) (string (identifier))
+  (binary (identifier) (identifier)) (string (interpolation (identifier)))
   (method_call
     (call (constant) (identifier))
     (argument_list (binary (identifier) (integer))))
-  (string (identifier)))
+  (string (interpolation (identifier))))
 
 ===============================
 regex as parameter

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -122,7 +122,7 @@ double quoted symbol with interpolation
 
 ---
 
-(program (symbol (identifier)))
+(program (symbol (interpolation (identifier))))
 
 =========================================
 percent symbol with unbalanced delimiters
@@ -488,8 +488,8 @@ interpolation
 ---
 
 (program
-  (string (identifier))
-  (string (unless_modifier (string) (identifier))))
+  (string (interpolation (identifier)))
+  (string (interpolation (unless_modifier (string) (identifier)))))
 
 =====================
 escaped interpolation
@@ -664,7 +664,7 @@ nested strings with different delimiters
 ---
 
 (program
-  (string (regex (subshell))))
+  (string (interpolation (regex (interpolation (subshell))))))
 
 ========================================
 basic heredocs
@@ -837,11 +837,11 @@ return
 (program
   (heredoc_beginning)
   (heredoc_end
-    (array (integer) (string (integer)) (integer))
-    (integer)
-    (call (identifier) (identifier))
-    (if_modifier (identifier) (identifier))
-    (call (method_call (identifier) (argument_list (integer) (identifier))) (identifier)))
+    (interpolation (array (integer) (string (interpolation (integer))) (integer)))
+    (interpolation (integer))
+    (interpolation (call (identifier) (identifier)))
+    (interpolation (if_modifier (identifier) (identifier)))
+    (interpolation (call (method_call (identifier) (argument_list (integer) (identifier))) (identifier))))
   (return))
 
 ========================================
@@ -918,7 +918,9 @@ foo(<<-STR.strip_heredoc.tr()
     (argument_list
       (method_call
         (call (call (heredoc_beginning) (identifier)) (identifier))
-        (argument_list (heredoc_end (call (method_call (identifier) (argument_list)) (identifier))))))))
+        (argument_list
+          (heredoc_end
+            (interpolation (call (method_call (identifier) (argument_list)) (identifier)))))))))
 
 ========================================
 multiple heredocs
@@ -1074,7 +1076,7 @@ percent W array with interpolations
 
 ---
 
-(program (array (identifier)))
+(program (array (interpolation (identifier))))
 
 =====================
 empty percent i array
@@ -1106,15 +1108,15 @@ percent i array
 
 (program (array))
 
-=============================
-percent I array with captures
-=============================
+====================================
+percent I array with interpolations
+====================================
 
 %I(a #{b} c)
 
 ---
 
-(program (array (identifier)))
+(program (array (interpolation (identifier))))
 
 ==========
 empty hash
@@ -1315,7 +1317,7 @@ regular expression with interpolation
 ---
 
 (program
-  (regex (identifier))
+  (regex (interpolation (identifier)))
   (regex)
   (regex))
 
@@ -1354,7 +1356,7 @@ percent r regular expression with unbalanced delimiters and interpolation
 
 ---
 
-(program (regex (identifier)))
+(program (regex (interpolation (identifier))))
 
 =======================================================================
 percent r regular expression with balanced delimiters and interpolation
@@ -1364,7 +1366,7 @@ percent r regular expression with balanced delimiters and interpolation
 
 ---
 
-(program (regex (identifier)))
+(program (regex (interpolation (identifier))))
 
 ==============
 empty function

--- a/grammar.js
+++ b/grammar.js
@@ -541,8 +541,8 @@ module.exports = grammar({
       $._simple_symbol,
       seq(
         $._symbol_beginning,
-        repeat(seq($._statement, $._string_middle)),
-        $._statement,
+        repeat(seq($.interpolation, $._string_middle)),
+        $.interpolation,
         $._string_end
       )
     ),
@@ -562,13 +562,16 @@ module.exports = grammar({
 
     _character_literal: $ => /\?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S)/,
 
+    interpolation: $ => seq(
+      '#{', $._statement, '}'
+    ),
+
     string: $ => choice(
       $._simple_string,
       $._character_literal,
       seq(
         $._string_beginning,
-        repeat(seq($._statement, $._string_middle)),
-        $._statement,
+        sep1($.interpolation, $._string_middle),
         $._string_end
       )
     ),
@@ -577,8 +580,7 @@ module.exports = grammar({
       $._simple_subshell,
       seq(
         $._subshell_beginning,
-        repeat(seq($._statement, $._string_middle)),
-        $._statement,
+        sep1($.interpolation, $._string_middle),
         $._string_end
       )
     ),
@@ -587,8 +589,7 @@ module.exports = grammar({
       $._simple_heredoc_body,
       seq(
         $._heredoc_body_beginning,
-        repeat(seq($._statement, $._heredoc_body_middle)),
-        $._statement,
+        sep1($.interpolation, $._heredoc_body_middle),
         $._heredoc_body_end
       )
     ),
@@ -598,8 +599,7 @@ module.exports = grammar({
       $._simple_word_list,
       seq(
         $._word_list_beginning,
-        repeat(seq($._statement, $._string_middle)),
-        $._statement,
+        sep1($.interpolation, $._string_middle),
         $._string_end
       )
     ),
@@ -634,8 +634,7 @@ module.exports = grammar({
       $._simple_regex,
       seq(
         $._regex_beginning,
-        repeat(seq($._statement, $._string_middle)),
-        $._statement,
+        sep1($.interpolation, $._string_middle),
         $._string_end
       )
     ),

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.12.6"
+    "tree-sitter-cli": "^0.13.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build --debug",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3937,7 +3937,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "_statement"
+                    "name": "interpolation"
                   },
                   {
                     "type": "SYMBOL",
@@ -3948,7 +3948,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "_statement"
+              "name": "interpolation"
             },
             {
               "type": "SYMBOL",
@@ -4050,6 +4050,23 @@
       "type": "PATTERN",
       "value": "\\?(\\\\\\S({[0-9]*}|[0-9]*|-\\S([MC]-\\S)?)?|\\S)"
     },
+    "interpolation": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#{"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_statement"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
     "string": {
       "type": "CHOICE",
       "members": [
@@ -4069,24 +4086,29 @@
               "name": "_string_beginning"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_statement"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_string_middle"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "interpolation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_string_middle"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "interpolation"
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_statement"
+                }
+              ]
             },
             {
               "type": "SYMBOL",
@@ -4111,24 +4133,29 @@
               "name": "_subshell_beginning"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_statement"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_string_middle"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "interpolation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_string_middle"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "interpolation"
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_statement"
+                }
+              ]
             },
             {
               "type": "SYMBOL",
@@ -4153,24 +4180,29 @@
               "name": "_heredoc_body_beginning"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_statement"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_heredoc_body_middle"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "interpolation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_heredoc_body_middle"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "interpolation"
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_statement"
+                }
+              ]
             },
             {
               "type": "SYMBOL",
@@ -4232,24 +4264,29 @@
               "name": "_word_list_beginning"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_statement"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_string_middle"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "interpolation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_string_middle"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "interpolation"
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_statement"
+                }
+              ]
             },
             {
               "type": "SYMBOL",
@@ -4449,24 +4486,29 @@
               "name": "_regex_beginning"
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_statement"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_string_middle"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "interpolation"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_string_middle"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "interpolation"
+                      }
+                    ]
                   }
-                ]
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_statement"
+                }
+              ]
             },
             {
               "type": "SYMBOL",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -219,6 +219,12 @@ struct Scanner {
 
   bool scan_whitespace(TSLexer *lexer, const bool *valid_symbols, bool *found_heredoc_starting_linebreak) {
     for (;;) {
+      if (valid_symbols[LINE_BREAK] && lexer->is_at_included_range_start(lexer)) {
+        lexer->mark_end(lexer);
+        lexer->result_symbol = LINE_BREAK;
+        return true;
+      }
+
       switch (lexer->lookahead) {
         case ' ':
         case '\t':

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -235,7 +235,6 @@ struct Scanner {
           if (!open_heredocs.empty() && !*found_heredoc_starting_linebreak) {
             skip(lexer);
             *found_heredoc_starting_linebreak = true;
-            return true;
           } else if (valid_symbols[LINE_BREAK]) {
             advance(lexer);
             lexer->mark_end(lexer);
@@ -248,8 +247,8 @@ struct Scanner {
             }
           } else {
             skip(lexer);
-            break;
           }
+          break;
         case '\\':
           skip(lexer);
           if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
@@ -564,15 +563,6 @@ struct Scanner {
     }
   }
 
-  bool scan_interpolation_close(TSLexer *lexer) {
-    if (lexer->lookahead == '}') {
-      advance(lexer);
-      return true;
-    } else {
-      return false;
-    }
-  }
-
   string scan_heredoc_word(TSLexer *lexer) {
     string result;
     int32_t quote;
@@ -619,14 +609,17 @@ struct Scanner {
 
     for (;;) {
       if (position_in_word == heredoc.word.size()) {
+        lexer->mark_end(lexer);
         while (lexer->lookahead == ' ' || lexer->lookahead == '\t') advance(lexer);
         if (lookahead_is_line_end(lexer)) {
           open_heredocs.erase(open_heredocs.begin());
           return End;
         }
       }
+
       if (lexer->lookahead == 0) {
         open_heredocs.erase(open_heredocs.begin());
+        lexer->mark_end(lexer);
         return End;
       }
 
@@ -637,6 +630,7 @@ struct Scanner {
         position_in_word = 0;
         look_for_heredoc_end = false;
         if (lexer->lookahead == '#') {
+          lexer->mark_end(lexer);
           advance(lexer);
           if (lexer->lookahead == '{') {
             advance(lexer);
@@ -666,6 +660,7 @@ struct Scanner {
             advance(lexer);
           }
         }
+        lexer->mark_end(lexer);
         return End;
       }
 
@@ -676,6 +671,7 @@ struct Scanner {
         literal.nesting_depth++;
         advance(lexer);
       } else if (literal.allows_interpolation && lexer->lookahead == '#') {
+        lexer->mark_end(lexer);
         advance(lexer);
         if (lexer->lookahead == '{') {
           advance(lexer);
@@ -686,6 +682,7 @@ struct Scanner {
         advance(lexer);
       } else if (lexer->lookahead == 0) {
         advance(lexer);
+        lexer->mark_end(lexer);
         return Error;
       } else {
         advance(lexer);
@@ -706,18 +703,16 @@ struct Scanner {
     if (!scan_whitespace(lexer, valid_symbols, &found_heredoc_starting_linebreak)) return false;
     if (lexer->result_symbol == LINE_BREAK) return true;
 
-    if (valid_symbols[HEREDOC_BODY_MIDDLE] && !open_heredocs.empty()) {
-      if (scan_interpolation_close(lexer)) {
-        switch (scan_heredoc_content(lexer)) {
-          case Error:
-            return false;
-          case Interpolation:
-            lexer->result_symbol = HEREDOC_BODY_MIDDLE;
-            return true;
-          case End:
-            lexer->result_symbol = HEREDOC_BODY_END;
-            return true;
-        }
+    if (valid_symbols[HEREDOC_BODY_MIDDLE] && !valid_symbols[LINE_BREAK] && !open_heredocs.empty()) {
+      switch (scan_heredoc_content(lexer)) {
+        case Error:
+          return false;
+        case Interpolation:
+          lexer->result_symbol = HEREDOC_BODY_MIDDLE;
+          return true;
+        case End:
+          lexer->result_symbol = HEREDOC_BODY_END;
+          return true;
       }
     }
 
@@ -831,19 +826,16 @@ struct Scanner {
 
     if (valid_symbols[STRING_MIDDLE] && ! literal_stack.empty()) {
       Literal &literal = literal_stack.back();
-
-      if (scan_interpolation_close(lexer)) {
-        switch (scan_content(lexer, literal)) {
-          case Error:
-            return false;
-          case Interpolation:
-            lexer->result_symbol = STRING_MIDDLE;
-            return true;
-          case End:
-            literal_stack.pop_back();
-            lexer->result_symbol = STRING_END;
-            return true;
-        }
+      switch (scan_content(lexer, literal)) {
+        case Error:
+          return false;
+        case Interpolation:
+          lexer->result_symbol = STRING_MIDDLE;
+          return true;
+        case End:
+          literal_stack.pop_back();
+          lexer->result_symbol = STRING_END;
+          return true;
       }
     }
 

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -25,13 +25,16 @@ typedef struct {
   bool named : 1;
 } TSSymbolMetadata;
 
-typedef struct {
-  void (*advance)(void *, bool);
-  void (*mark_end)(void *);
-  uint32_t (*get_column)(void *);
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
   int32_t lookahead;
   TSSymbol result_symbol;
-} TSLexer;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(TSLexer *);
+};
 
 typedef enum {
   TSParseActionTypeShift,


### PR DESCRIPTION
Depends on https://github.com/tree-sitter/tree-sitter/pull/183

When parsing multiple disjoint ranges of text, we now insert 'line break' tokens in between each range. This prevent parse errors when parsing ERB code like this.

```erb
<div id=<%= get_id %>><%= get_content %></div>
```

We've also changed the way string interpolations are parsed. There is now an explicit node for the `interpolation` itself, which contains the interpolated statement, as well as anonymous nodes for the `#{` and `}` delimiters. These things are important for syntax highlighting.

As a happy accident, the change that we made regarding interpolations resulted in a considerably smaller parse table. The binary size is now down to 6.6MB.

/cc @tclem and @robrix since this changes the shape of the parse trees.

🍐'd with @queerviolet 