### PR TITLE
Add some structure to strings and literals

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -819,7 +819,7 @@ foo *(bar.baz)
 (program
   (method_call (identifier) (argument_list (splat_argument (identifier))))
   (method_call (identifier) (argument_list (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (array))))
+  (method_call (identifier) (argument_list (splat_argument (word_array))))
   (method_call (identifier) (argument_list (splat_argument (parenthesized_statements (call (identifier) (identifier)))))))
 
 ===============================

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1046,7 +1046,7 @@ empty percent w array
 
 ---
 
-(program (array))
+(program (word_array))
 
 ==========================
 unbalanced percent w array
@@ -1056,7 +1056,7 @@ unbalanced percent w array
 
 ---
 
-(program (array))
+(program (word_array))
 
 ===============
 percent w array
@@ -1066,7 +1066,7 @@ percent w array
 
 ---
 
-(program (array))
+(program (word_array))
 
 ===================================
 percent W array with interpolations
@@ -1076,7 +1076,7 @@ percent W array with interpolations
 
 ---
 
-(program (array (interpolation (identifier))))
+(program (word_array (interpolation (identifier))))
 
 =====================
 empty percent i array
@@ -1086,7 +1086,7 @@ empty percent i array
 
 ---
 
-(program (array))
+(program (word_array))
 
 ==========================
 unbalanced percent i array
@@ -1096,7 +1096,7 @@ unbalanced percent i array
 
 ---
 
-(program (array))
+(program (word_array))
 
 ===============
 percent i array
@@ -1106,7 +1106,7 @@ percent i array
 
 ---
 
-(program (array))
+(program (word_array))
 
 ====================================
 percent I array with interpolations
@@ -1116,7 +1116,7 @@ percent I array with interpolations
 
 ---
 
-(program (array (interpolation (identifier))))
+(program (word_array (interpolation (identifier))))
 
 ==========
 empty hash

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -638,17 +638,17 @@ foo(?/)
 ---
 
 (program
-  (string)
-  (string)
-  (string)
-  (string)
-  (string)
-  (string)
-  (string)
-  (string)
-  (string)
-  (string)
-  (method_call (identifier) (argument_list (string))))
+  (character)
+  (character)
+  (character)
+  (character)
+  (character)
+  (character)
+  (character)
+  (character)
+  (character)
+  (character)
+  (method_call (identifier) (argument_list (character))))
 
 ========================================
 nested strings with different delimiters

--- a/grammar.js
+++ b/grammar.js
@@ -304,6 +304,7 @@ module.exports = grammar({
       $.complex,
       $.rational,
       $.string,
+      $.character,
       $.chained_string,
       $.regex,
       $.lambda,
@@ -560,7 +561,7 @@ module.exports = grammar({
 
     chained_string: $ => seq($.string, repeat1($.string)),
 
-    _character_literal: $ => /\?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S)/,
+    character: $ => /\?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S)/,
 
     interpolation: $ => seq(
       '#{', $._statement, '}'
@@ -568,7 +569,6 @@ module.exports = grammar({
 
     string: $ => choice(
       $._simple_string,
-      $._character_literal,
       seq(
         $._string_beginning,
         sep1($.interpolation, $._string_middle),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1893,6 +1893,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "character"
+        },
+        {
+          "type": "SYMBOL",
           "name": "chained_string"
         },
         {
@@ -4046,7 +4050,7 @@
         }
       ]
     },
-    "_character_literal": {
+    "character": {
       "type": "PATTERN",
       "value": "\\?(\\\\\\S({[0-9]*}|[0-9]*|-\\S([MC]-\\S)?)?|\\S)"
     },
@@ -4073,10 +4077,6 @@
         {
           "type": "SYMBOL",
           "name": "_simple_string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_character_literal"
         },
         {
           "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1294,10 +1294,14 @@
           ]
         },
         {
+          "type": "SYMBOL",
+          "name": "_terminator"
+        },
+        {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "_terminator"
+            "type": "STRING",
+            "value": ";"
           }
         },
         {
@@ -1861,6 +1865,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "word_array"
+        },
+        {
+          "type": "SYMBOL",
           "name": "hash"
         },
         {
@@ -2084,7 +2092,7 @@
                     "type": "ALIAS",
                     "content": {
                       "type": "SYMBOL",
-                      "name": "_scope_double_colon"
+                      "name": "_infix_scope_colons"
                     },
                     "named": false,
                     "value": "::"
@@ -2587,20 +2595,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "block_parameters"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_terminator"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "block_parameters"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_terminator"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -3920,48 +3933,6 @@
         }
       }
     },
-    "symbol": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_simple_symbol"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_symbol_beginning"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "interpolation"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_string_middle"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "interpolation"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_string_end"
-            }
-          ]
-        }
-      ]
-    },
     "integer": {
       "type": "PATTERN",
       "value": "0b[01](_?[01])*|0[oO]?[0-7](_?[0-7])*|(0d)?\\d(_?\\d)*|0x[0-9a-fA-F](_?[0-9a-fA-F])*"
@@ -4072,227 +4043,272 @@
       ]
     },
     "string": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_simple_string"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_start"
+          },
+          "named": false,
+          "value": "\""
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_string_beginning"
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "interpolation"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_string_middle"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_string_end"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_string_content"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              }
+            ]
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_end"
+          },
+          "named": false,
+          "value": "\""
         }
       ]
     },
     "subshell": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_subshell_start"
+          },
+          "named": false,
+          "value": "`"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_string_content"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              }
+            ]
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_end"
+          },
+          "named": false,
+          "value": "`"
+        }
+      ]
+    },
+    "word_array": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_word_list_start"
+          },
+          "named": false,
+          "value": "%w("
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_string_content"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              }
+            ]
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_end"
+          },
+          "named": false,
+          "value": ")"
+        }
+      ]
+    },
+    "symbol": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_simple_subshell"
+          "name": "_simple_symbol"
         },
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_subshell_beginning"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_symbol_start"
+              },
+              "named": false,
+              "value": ":\""
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "interpolation"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_string_middle"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_string_content"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "interpolation"
                   }
-                }
-              ]
+                ]
+              }
             },
             {
-              "type": "SYMBOL",
-              "name": "_string_end"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_string_end"
+              },
+              "named": false,
+              "value": "\""
             }
           ]
+        }
+      ]
+    },
+    "regex": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_regex_start"
+          },
+          "named": false,
+          "value": "/"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_string_content"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              }
+            ]
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_end"
+          },
+          "named": false,
+          "value": "/"
         }
       ]
     },
     "heredoc_end": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_simple_heredoc_body"
+          "name": "_heredoc_body_start"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_heredoc_body_beginning"
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "interpolation"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_heredoc_body_middle"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_heredoc_body_end"
-            }
-          ]
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_heredoc_content"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "interpolation"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_heredoc_body_end"
         }
       ]
     },
     "array": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": "["
+              "type": "SYMBOL",
+              "name": "_argument_list_with_trailing_comma"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_argument_list_with_trailing_comma"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "heredoc_end"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "]"
+              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_simple_word_list"
-        },
-        {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_word_list_beginning"
+              "name": "heredoc_end"
             },
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "interpolation"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_string_middle"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_string_end"
+              "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },
@@ -4471,53 +4487,6 @@
         ]
       }
     },
-    "regex": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_simple_regex"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_regex_beginning"
-            },
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "interpolation"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_string_middle"
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "interpolation"
-                      }
-                    ]
-                  }
-                }
-              ]
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_string_end"
-            }
-          ]
-        }
-      ]
-    },
     "lambda": {
       "type": "SEQ",
       "members": [
@@ -4592,7 +4561,7 @@
   "externals": [
     {
       "type": "SYMBOL",
-      "name": "_simple_string"
+      "name": "_line_break"
     },
     {
       "type": "SYMBOL",
@@ -4600,51 +4569,35 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_simple_subshell"
+      "name": "_string_start"
     },
     {
       "type": "SYMBOL",
-      "name": "_simple_regex"
+      "name": "_symbol_start"
     },
     {
       "type": "SYMBOL",
-      "name": "_simple_word_list"
+      "name": "_subshell_start"
     },
     {
       "type": "SYMBOL",
-      "name": "_simple_heredoc_body"
+      "name": "_regex_start"
     },
     {
       "type": "SYMBOL",
-      "name": "_string_beginning"
+      "name": "_word_list_start"
     },
     {
       "type": "SYMBOL",
-      "name": "_symbol_beginning"
+      "name": "_heredoc_body_start"
     },
     {
       "type": "SYMBOL",
-      "name": "_subshell_beginning"
+      "name": "_string_content"
     },
     {
       "type": "SYMBOL",
-      "name": "_regex_beginning"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_word_list_beginning"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_heredoc_body_beginning"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_string_middle"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_heredoc_body_middle"
+      "name": "_heredoc_content"
     },
     {
       "type": "SYMBOL",
@@ -4657,10 +4610,6 @@
     {
       "type": "SYMBOL",
       "name": "heredoc_beginning"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_line_break"
     },
     {
       "type": "STRING",
@@ -4684,7 +4633,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_scope_double_colon"
+      "name": "_infix_scope_colons"
     },
     {
       "type": "SYMBOL",


### PR DESCRIPTION
This PR changes the way strings and other string-like literals are parsed in a few ways. There are two small changes that required the tests to be tweaked:

* Character literals are now parsed as `character` nodes instead of appearing just like strings.
* `%w`, `%W`, `%i`, and `%I` literals are now parsed as `word_array` instead of just `array`, so they can be differentiated.

There is also a significant internal change that does *not* affect the tests: the beginning and end delimiters of literals are parsed as separate anonymous tokens, whereas before they were just included as part of the string node itself. This makes it possible to discern the actual content of the string based on the syntax tree alone.

This last change required big changes to the external scanner. I also spent some time refactoring the surrounding code in the external scanner, so there's a pretty big diff there.