### PR TITLE
Create separate nodes for bare words in string/symbol arrays

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -819,7 +819,7 @@ foo *(bar.baz)
 (program
   (method_call (identifier) (argument_list (splat_argument (identifier))))
   (method_call (identifier) (argument_list (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (word_array))))
+  (method_call (identifier) (argument_list (splat_argument (string_array (bare_string) (bare_string)))))
   (method_call (identifier) (argument_list (splat_argument (parenthesized_statements (call (identifier) (identifier)))))))
 
 ===============================

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -1048,7 +1048,7 @@ empty percent w array
 
 ---
 
-(program (word_array))
+(program (string_array))
 
 ==========================
 unbalanced percent w array
@@ -1058,7 +1058,7 @@ unbalanced percent w array
 
 ---
 
-(program (word_array))
+(program (string_array (bare_string) (bare_string)))
 
 ===============
 percent w array
@@ -1068,7 +1068,7 @@ percent w array
 
 ---
 
-(program (word_array))
+(program (string_array (bare_string) (bare_string)))
 
 ===================================
 percent W array with interpolations
@@ -1078,7 +1078,10 @@ percent W array with interpolations
 
 ---
 
-(program (word_array (interpolation (identifier))))
+(program (string_array
+  (bare_string)
+  (bare_string (interpolation (identifier)))
+  (bare_string)))
 
 =====================
 empty percent i array
@@ -1088,7 +1091,7 @@ empty percent i array
 
 ---
 
-(program (word_array))
+(program (symbol_array))
 
 ==========================
 unbalanced percent i array
@@ -1098,7 +1101,7 @@ unbalanced percent i array
 
 ---
 
-(program (word_array))
+(program (symbol_array (bare_symbol) (bare_symbol)))
 
 ===============
 percent i array
@@ -1108,7 +1111,7 @@ percent i array
 
 ---
 
-(program (word_array))
+(program (symbol_array (bare_symbol) (bare_symbol)))
 
 ====================================
 percent I array with interpolations
@@ -1118,7 +1121,27 @@ percent I array with interpolations
 
 ---
 
-(program (word_array (interpolation (identifier))))
+(program (symbol_array
+  (bare_symbol)
+  (bare_symbol (interpolation (identifier)))
+  (bare_symbol)))
+
+====================================
+percent i array with spaces
+====================================
+
+%I{
+  *
+  /#{something}+
+  ok
+}
+
+---
+
+(program (symbol_array
+  (bare_symbol)
+  (bare_symbol (interpolation (identifier)))
+  (bare_symbol)))
 
 ==========
 empty hash

--- a/grammar.js
+++ b/grammar.js
@@ -42,7 +42,8 @@ module.exports = grammar({
     $._symbol_start,
     $._subshell_start,
     $._regex_start,
-    $._word_list_start,
+    $._string_array_start,
+    $._symbol_array_start,
     $._heredoc_body_start,
     $._string_content,
     $._heredoc_content,
@@ -297,7 +298,8 @@ module.exports = grammar({
       $.parenthesized_statements,
       $._lhs,
       $.array,
-      $.word_array,
+      $.string_array,
+      $.symbol_array,
       $.hash,
       $.subshell,
       $.symbol,
@@ -560,31 +562,41 @@ module.exports = grammar({
 
     string: $ => seq(
       alias($._string_start, '"'),
-      repeat(choice($._string_content, $.interpolation)),
+      optional($._literal_contents),
       alias($._string_end, '"')
     ),
 
     subshell: $ => seq(
       alias($._subshell_start, '`'),
-      repeat(choice($._string_content, $.interpolation)),
+      optional($._literal_contents),
       alias($._string_end, '`')
     ),
 
-    word_array: $ => seq(
-      alias($._word_list_start, '%w('),
-      repeat(choice($._string_content, $.interpolation)),
+    string_array: $ => seq(
+      alias($._string_array_start, '%w('),
+      optional(/\s+/),
+      sep(alias($._literal_contents, $.bare_string), /\s+/),
+      optional(/\s+/),
+      alias($._string_end, ')')
+    ),
+
+    symbol_array: $ => seq(
+      alias($._symbol_array_start, '%i('),
+      optional(/\s+/),
+      sep(alias($._literal_contents, $.bare_symbol), /\s+/),
+      optional(/\s+/),
       alias($._string_end, ')')
     ),
 
     symbol: $ => choice($._simple_symbol, seq(
       alias($._symbol_start, ':"'),
-      repeat(choice($._string_content, $.interpolation)),
+      optional($._literal_contents),
       alias($._string_end, '"')
     )),
 
     regex: $ => seq(
       alias($._regex_start, '/'),
-      repeat(choice($._string_content, $.interpolation)),
+      optional($._literal_contents),
       alias($._string_end, '/')
     ),
 
@@ -593,6 +605,8 @@ module.exports = grammar({
       repeat(choice($._heredoc_content, $.interpolation)),
       $.heredoc_end
     ),
+
+    _literal_contents: $ => repeat1(choice($._string_content, $.interpolation)),
 
     array: $ => seq(
       '[',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1865,7 +1865,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "word_array"
+          "name": "string_array"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "symbol_array"
         },
         {
           "type": "SYMBOL",
@@ -4055,20 +4059,16 @@
           "value": "\""
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_string_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_literal_contents"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "ALIAS",
@@ -4094,20 +4094,16 @@
           "value": "`"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_string_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_literal_contents"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "ALIAS",
@@ -4120,33 +4116,174 @@
         }
       ]
     },
-    "word_array": {
+    "string_array": {
       "type": "SEQ",
       "members": [
         {
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "_word_list_start"
+            "name": "_string_array_start"
           },
           "named": false,
           "value": "%w("
         },
         {
-          "type": "REPEAT",
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "\\s+"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_literal_contents"
+                  },
+                  "named": true,
+                  "value": "bare_string"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "\\s+"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_literal_contents"
+                        },
+                        "named": true,
+                        "value": "bare_string"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "\\s+"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "ALIAS",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_string_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              }
-            ]
-          }
+            "type": "SYMBOL",
+            "name": "_string_end"
+          },
+          "named": false,
+          "value": ")"
+        }
+      ]
+    },
+    "symbol_array": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_symbol_array_start"
+          },
+          "named": false,
+          "value": "%i("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "\\s+"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_literal_contents"
+                  },
+                  "named": true,
+                  "value": "bare_symbol"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "\\s+"
+                      },
+                      {
+                        "type": "ALIAS",
+                        "content": {
+                          "type": "SYMBOL",
+                          "name": "_literal_contents"
+                        },
+                        "named": true,
+                        "value": "bare_symbol"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "PATTERN",
+              "value": "\\s+"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "ALIAS",
@@ -4179,20 +4316,16 @@
               "value": ":\""
             },
             {
-              "type": "REPEAT",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_string_content"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "interpolation"
-                  }
-                ]
-              }
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_literal_contents"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "ALIAS",
@@ -4220,20 +4353,16 @@
           "value": "/"
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_string_content"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "interpolation"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_literal_contents"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "ALIAS",
@@ -4274,6 +4403,22 @@
           "name": "heredoc_end"
         }
       ]
+    },
+    "_literal_contents": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_string_content"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "interpolation"
+          }
+        ]
+      }
     },
     "array": {
       "type": "SEQ",
@@ -4585,7 +4730,11 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_word_list_start"
+      "name": "_string_array_start"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_symbol_array_start"
     },
     {
       "type": "SYMBOL",


### PR DESCRIPTION
Fixes #6
Fixes #80

There are now distinct `string_array` and `symbol_array` nodes. Their children are `bare_string` and `bare_symbol` respectively.