### PR TITLE
Add Prebuild support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,16 @@ node_js:
 
 os:
 - linux
-- osx
 
-compiler: clang-3.6
-
-env:
-  - CXX=clang-3.6
+matrix:
+  include:
+    - os: osx
+      env: COMPILER=clang++
+      osx_image: xcode9.2
+      compiler: clang
+    - os: linux
+      env: CXX=clang-3.6
+      compiler: clang-3.6
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: false
 node_js:
   - "node"
 
+os:
+- linux
+- osx
+
 compiler: clang-3.6
 
 env:
@@ -17,6 +21,11 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - clang-3.6
+
+script:
+  - npm test
+  - npm run prebuild
+  - npm run prebuild:upload -u ${PREBUILD_UPLOAD}
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,15 @@ addons:
     packages:
       - clang-3.6
 
-script:
-  - npm test
-  - npm run prebuild
-  - npm run prebuild:upload -u ${PREBUILD_UPLOAD}
-
 branches:
   only:
     - master
+    - /^v.*$/
+
+deploy:
+  provider: script
+  script: npm run prebuild && npm run prebuild:upload -u ${PREBUILD_UPLOAD}
+  skip_cleanup: true
+  on:
+    all_branches: true
+    tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
 
 platform:
   - x64
+  - x86
 
 install:
   - ps: Install-Product node $env:nodejs_version
@@ -14,6 +15,8 @@ install:
 
 test_script:
   - npm run test-windows
+  - npm run prebuild
+  - npm run prebuild:upload -u %PREBUILD_UPLOAD%
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,12 @@ install:
 
 test_script:
   - npm run test-windows
-  - npm run prebuild
-  - npm run prebuild:upload -u %PREBUILD_UPLOAD%
 
 build: off
 
 branches:
   only:
     - master
+    - /^v.*$/
+
+deploy_script: IF "%APPVEYOR_REPO_TAG%" == "true" (npm run prebuild && npm run prebuild:upload -u %PREBUILD_UPLOAD%)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "author": "Rob Rix",
   "license": "MIT",
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.10.0",
+    "prebuild-install": "^5.0.0"
   },
   "devDependencies": {
     "prebuild": "^7.6.0",
@@ -18,6 +19,7 @@
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build --debug",
+    "install": "prebuild-install || node-gyp rebuild",
     "prebuild": "prebuild --all --strip --verbose",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
+    "prebuild": "^7.6.0",
     "tree-sitter-cli": "^0.13.1"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build --debug",
+    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"
   },


### PR DESCRIPTION
This support is along the same lines as tree-sitter/node-tree-sitter#19 but with modifications to support the compiler settings + tree-sitter-cli tests

MacOS doesn't version clang the same way as Linux so I set it to a 9.x version of XCode running on 10.12