### PR TITLE
Parse escape sequences in literals

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1170,7 +1170,7 @@ foo \
   (method_call
     (identifier)
     (argument_list (identifier) (identifier)))
-  (string)
+  (string (escape_sequence))
   (method_call
     (identifier)
     (argument_list (string))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -387,34 +387,19 @@ single-quoted string
 (program (string) (string) (string))
 
 ==============================================
-single-quoted string with escaped single quote
+single-quoted strings with backslashes
 ==============================================
 
 '\''
+'\\ \n'
+'\x00\x01\x02'
 
 ---
 
-(program (string))
-
-===========================================
-single-quoted string with escaped backslash
-===========================================
-
-'\\'
-
----
-
-(program (string))
-
-=================================================
-single-quoted string with backslash and character
-=================================================
-
-'\d'
-
----
-
-(program (string))
+(program
+  (string)
+  (string)
+  (string))
 
 =================================================
 single-quoted string with pound and curly brace
@@ -439,34 +424,21 @@ double-quoted string
 (program (string) (string) (string))
 
 ==============================================
-double-quoted string with escaped double quote
+double-quoted strings with escape sequences
 ==============================================
 
 "\""
-
----
-
-(program (string))
-
-===========================================
-double-quoted string with escaped backslash
-===========================================
-
 "\\"
-
----
-
-(program (string))
-
-=================================================
-double-quoted string with backslash and character
-=================================================
-
 "\d"
+"\#{foo}"
 
 ---
 
-(program (string))
+(program
+  (string (escape_sequence))
+  (string (escape_sequence))
+  (string (escape_sequence))
+  (string (escape_sequence)))
 
 =================================
 double-quoted string with just pound
@@ -490,16 +462,6 @@ interpolation
 (program
   (string (interpolation (identifier)))
   (string (interpolation (unless_modifier (string) (identifier)))))
-
-=====================
-escaped interpolation
-=====================
-
-"\#{foo}"
-
----
-
-(program (string))
 
 ===========================================
 percent q string with unbalanced delimiters
@@ -988,7 +950,9 @@ backticks subshell with escape
 
 ---
 
-(program (subshell))
+(program (subshell
+  (escape_sequence)
+  (escape_sequence)))
 
 ===========
 empty array

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -633,7 +633,7 @@ basic heredocs
 ========================================
 
 <<TEXT
-heredoc content
+heredoc \x01 content
 TEXT
 
 <<TEXT1
@@ -665,7 +665,7 @@ heredoc content
 ---
 
 (program
-  (heredoc_beginning) (heredoc_body (heredoc_end))
+  (heredoc_beginning) (heredoc_body (escape_sequence) (heredoc_end))
   (heredoc_beginning) (heredoc_body (heredoc_end))
   (heredoc_beginning) (heredoc_body (heredoc_end))
   (heredoc_beginning) (heredoc_body (heredoc_end))

--- a/grammar.js
+++ b/grammar.js
@@ -606,7 +606,23 @@ module.exports = grammar({
       $.heredoc_end
     ),
 
-    _literal_contents: $ => repeat1(choice($._string_content, $.interpolation)),
+    _literal_contents: $ => repeat1(choice(
+      $._string_content,
+      $.interpolation,
+      $.escape_sequence
+    )),
+
+    // https://ruby-doc.org/core-2.5.0/doc/syntax/literals_rdoc.html#label-Strings
+    escape_sequence: $ => token(seq(
+      '\\',
+      choice(
+        /[^ux0-7]/,          // single character
+        /x[0-9a-fA-F]{1,2}/, // hex code
+        /[0-7]{1,3}/,        // octal
+        /u[0-9a-fA-F]{4}/,   // single unicode
+        /u{[0-9a-fA-F ]+}/,  // multiple unicode
+      )
+    )),
 
     array: $ => seq(
       '[',

--- a/grammar.js
+++ b/grammar.js
@@ -602,7 +602,11 @@ module.exports = grammar({
 
     heredoc_body: $ => seq(
       $._heredoc_body_start,
-      repeat(choice($._heredoc_content, $.interpolation)),
+      repeat(choice(
+        $._heredoc_content,
+        $.interpolation,
+        $.escape_sequence
+      )),
       $.heredoc_end
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4394,6 +4394,10 @@
               {
                 "type": "SYMBOL",
                 "name": "interpolation"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "escape_sequence"
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4416,6 +4416,47 @@
           {
             "type": "SYMBOL",
             "name": "interpolation"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "escape_sequence"
+          }
+        ]
+      }
+    },
+    "escape_sequence": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "\\"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "[^ux0-7]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "x[0-9a-fA-F]{1,2}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-7]{1,3}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "u[0-9a-fA-F]{4}"
+              },
+              {
+                "type": "PATTERN",
+                "value": "u{[0-9a-fA-F ]+}"
+              }
+            ]
           }
         ]
       }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -608,6 +608,16 @@ struct Scanner {
       } else {
         position_in_word = 0;
         look_for_heredoc_end = false;
+
+        if (lexer->lookahead == '\\') {
+          if (has_content) {
+            lexer->result_symbol = HEREDOC_CONTENT;
+            return true;
+          } else {
+            return false;
+          }
+        }
+
         if (lexer->lookahead == '#') {
           advance(lexer);
           if (lexer->lookahead == '{') {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -638,7 +638,7 @@ struct Scanner {
     }
   }
 
-  bool scan_content(TSLexer *lexer) {
+  bool scan_literal_content(TSLexer *lexer) {
     Literal &literal = literal_stack.back();
     bool has_content = false;
     bool stop_on_space = literal.type == SYMBOL_ARRAY_START || literal.type == STRING_ARRAY_START;
@@ -687,8 +687,18 @@ struct Scanner {
           }
         }
       } else if (lexer->lookahead == '\\') {
-        advance(lexer);
-        advance(lexer);
+        if (literal.allows_interpolation) {
+          if (has_content) {
+            lexer->mark_end(lexer);
+            lexer->result_symbol = STRING_CONTENT;
+            return true;
+          } else {
+            return false;
+          }
+        } else {
+          advance(lexer);
+          advance(lexer);
+        }
       } else if (lexer->lookahead == 0) {
         advance(lexer);
         lexer->mark_end(lexer);
@@ -748,7 +758,7 @@ struct Scanner {
     // Contents of literals, which match any character except for some close delimiter
     if (!valid_symbols[STRING_START]) {
       if (valid_symbols[STRING_CONTENT] && !literal_stack.empty()) {
-        return scan_content(lexer);
+        return scan_literal_content(lexer);
       }
       if (valid_symbols[HEREDOC_CONTENT] && !open_heredocs.empty()) {
         return scan_heredoc_content(lexer);


### PR DESCRIPTION
This PR adds explicit syntax nodes for escape sequences within string, symbol, subshell, heredoc, and regex literals.