### PR TITLE
Use immediate token API for preceding-whitespace-sensitive tokens

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -51,14 +51,10 @@ module.exports = grammar({
     $.heredoc_end,
     $.heredoc_beginning,
 
-    // Whitespace-sensitive tokens
+    // Tokens that require lookahead
     '/',
-    $._element_reference_left_bracket,
     $._block_ampersand,
     $._splat_star,
-    $._argument_list_left_paren,
-    $._infix_scope_colons,
-    $._keyword_colon,
     $._unary_minus,
     $._binary_minus,
     $._binary_star,
@@ -161,7 +157,7 @@ module.exports = grammar({
     splat_parameter: $ => seq('*', optional($.identifier)),
     hash_splat_parameter: $ => seq('**', optional($.identifier)),
     block_parameter: $ => seq('&', choice($.identifier, $.lambda)),
-    keyword_parameter: $ => prec.right(PREC.BITWISE_OR + 1, seq($.identifier, $._keyword_colon, optional($._arg))),
+    keyword_parameter: $ => prec.right(PREC.BITWISE_OR + 1, seq($.identifier, token.immediate(':'), optional($._arg))),
     optional_parameter: $ => prec(PREC.BITWISE_OR + 1, seq($.identifier, '=', $._arg)),
 
     class: $ => seq(
@@ -337,7 +333,7 @@ module.exports = grammar({
 
     element_reference: $ => prec.left(1, seq(
       $._primary,
-      alias($._element_reference_left_bracket, '['),
+      token.immediate('['),
       optional($._argument_list_with_trailing_comma),
       optional($.heredoc_body),
       ']'
@@ -346,7 +342,7 @@ module.exports = grammar({
     scope_resolution: $ => prec.left(1, seq(
       choice(
         '::',
-        seq($._primary, alias($._infix_scope_colons, '::'))
+        seq($._primary, token.immediate('::'))
       ),
       choice($.identifier, $.constant)
     )),
@@ -381,7 +377,7 @@ module.exports = grammar({
     argument_list_with_parens: $ => $._argument_list_with_parens,
 
     _argument_list_with_parens: $ => seq(
-      alias($._argument_list_left_paren, '('),
+      token.immediate('('),
       optional($._argument_list_with_trailing_comma),
       optional($.heredoc_body),
       ')'
@@ -656,7 +652,7 @@ module.exports = grammar({
           alias($.constant, $.symbol),
           $.string
         ),
-        alias($._keyword_colon, ':'),
+        token.immediate(':'),
         $._arg
       ),
       $.hash_splat_argument

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "prebuild": "^7.6.0",
-    "tree-sitter-cli": "^0.13.1"
+    "tree-sitter-cli": "^0.13.4"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build --debug",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -764,8 +764,11 @@
             "name": "identifier"
           },
           {
-            "type": "SYMBOL",
-            "name": "_keyword_colon"
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            }
           },
           {
             "type": "CHOICE",
@@ -2033,13 +2036,11 @@
             "name": "_primary"
           },
           {
-            "type": "ALIAS",
+            "type": "IMMEDIATE_TOKEN",
             "content": {
-              "type": "SYMBOL",
-              "name": "_element_reference_left_bracket"
-            },
-            "named": false,
-            "value": "["
+              "type": "STRING",
+              "value": "["
+            }
           },
           {
             "type": "CHOICE",
@@ -2093,13 +2094,11 @@
                     "name": "_primary"
                   },
                   {
-                    "type": "ALIAS",
+                    "type": "IMMEDIATE_TOKEN",
                     "content": {
-                      "type": "SYMBOL",
-                      "name": "_infix_scope_colons"
-                    },
-                    "named": false,
-                    "value": "::"
+                      "type": "STRING",
+                      "value": "::"
+                    }
                   }
                 ]
               }
@@ -2419,13 +2418,11 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "ALIAS",
+          "type": "IMMEDIATE_TOKEN",
           "content": {
-            "type": "SYMBOL",
-            "name": "_argument_list_left_paren"
-          },
-          "named": false,
-          "value": "("
+            "type": "STRING",
+            "value": "("
+          }
         },
         {
           "type": "CHOICE",
@@ -4656,13 +4653,11 @@
                 ]
               },
               {
-                "type": "ALIAS",
+                "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "_keyword_colon"
-                },
-                "named": false,
-                "value": ":"
+                  "type": "STRING",
+                  "value": ":"
+                }
               },
               {
                 "type": "SYMBOL",
@@ -4811,27 +4806,11 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_element_reference_left_bracket"
-    },
-    {
-      "type": "SYMBOL",
       "name": "_block_ampersand"
     },
     {
       "type": "SYMBOL",
       "name": "_splat_star"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_argument_list_left_paren"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_infix_scope_colons"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_keyword_colon"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -29,12 +29,8 @@ enum TokenType {
 
   // Whitespace-sensitive tokens
   FORWARD_SLASH,
-  ELEMENT_REFERENCE_LEFT_BRACKET,
   BLOCK_AMPERSAND,
   SPLAT_STAR,
-  ARGUMENT_LIST_LEFT_PAREN,
-  INFIX_SCOPE_COLONS,
-  KEYWORD_COLON,
   UNARY_MINUS,
   BINARY_MINUS,
   BINARY_STAR,
@@ -724,47 +720,6 @@ struct Scanner {
   bool scan(TSLexer *lexer, const bool *valid_symbols) {
     has_leading_whitespace = false;
 
-    // Operators that must not be preceded by whitespace
-    switch (lexer->lookahead) {
-      case '[':
-        if (valid_symbols[ELEMENT_REFERENCE_LEFT_BRACKET]) {
-          advance(lexer);
-          lexer->result_symbol = ELEMENT_REFERENCE_LEFT_BRACKET;
-          return true;
-        }
-        break;
-
-      case ':':
-        if (valid_symbols[KEYWORD_COLON] || valid_symbols[INFIX_SCOPE_COLONS]) {
-          advance(lexer);
-
-          if (valid_symbols[INFIX_SCOPE_COLONS] && lexer->lookahead == ':') {
-            advance(lexer);
-            if (!iswspace(lexer->lookahead)) {
-              lexer->result_symbol = INFIX_SCOPE_COLONS;
-              return true;
-            }
-          } else if (valid_symbols[KEYWORD_COLON]) {
-            lexer->result_symbol = KEYWORD_COLON;
-            return true;
-          }
-
-          return false;
-        }
-        break;
-
-      case '(':
-        if (valid_symbols[ARGUMENT_LIST_LEFT_PAREN]) {
-          advance(lexer);
-          lexer->result_symbol = ARGUMENT_LIST_LEFT_PAREN;
-          return true;
-        }
-        break;
-
-      default:
-        break;
-    }
-
     // Contents of literals, which match any character except for some close delimiter
     if (!valid_symbols[STRING_START]) {
       if (valid_symbols[STRING_CONTENT] && !literal_stack.empty()) {
@@ -780,7 +735,6 @@ struct Scanner {
     if (!scan_whitespace(lexer, valid_symbols)) return false;
     if (lexer->result_symbol != NONE) return true;
 
-    // Operators which can be preceded by whitespace
     switch (lexer->lookahead) {
       case '&':
         if (valid_symbols[BLOCK_AMPERSAND]) {


### PR DESCRIPTION
This new API means we don't have to use the external scanner for tokens like `(`, `[`, `::`, and `:`, which sometimes have different meaning when not preceded by leading whitespace.

https://github.com/tree-sitter/tree-sitter/pull/190