### PR TITLE
Avoid potential use-after-free in regex scanner

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -664,12 +664,11 @@ struct Scanner {
           if (has_content) {
             lexer->result_symbol = STRING_CONTENT;
           } else {
-            bool is_regex_start = literal.type == REGEX_START;
-            literal_stack.pop_back();
             advance(lexer);
-            if (is_regex_start) {
+            if (literal.type == REGEX_START) {
               while (iswlower(lexer->lookahead)) advance(lexer);
             }
+            literal_stack.pop_back();
             lexer->result_symbol = STRING_END;
             lexer->mark_end(lexer);
           }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -664,9 +664,10 @@ struct Scanner {
           if (has_content) {
             lexer->result_symbol = STRING_CONTENT;
           } else {
+            bool is_regex_start = literal.type == REGEX_START;
             literal_stack.pop_back();
             advance(lexer);
-            if (literal.type == REGEX_START) {
+            if (is_regex_start) {
               while (iswlower(lexer->lookahead)) advance(lexer);
             }
             lexer->result_symbol = STRING_END;


### PR DESCRIPTION
`literal` is a reference to the last element so it is invalidated after we call
`literal.pop_back()`. Use a temporary so we don't use `literal` after it has
been popped:

```
==14==ERROR: AddressSanitizer: container-overflow on address 0x603000000160 at pc 0x00000051bfe2 bp 0x7ffca8ec7980 sp 0x7ffca8ec7978
READ of size 4 at 0x603000000160 thread T0
SCARINESS: 17 (4-byte-read-container-overflow)
    #0 0x51bfe1 in (anonymous namespace)::Scanner::scan_literal_content(TSLexer*) /src/octofuzz/tree-sitter/test/fixtures/grammars/ruby/src/scanner.cc:669:25
    #1 0x51884f in (anonymous namespace)::Scanner::scan(TSLexer*, bool const*) /src/octofuzz/tree-sitter/test/fixtures/grammars/ruby/src/scanner.cc:726:16
    #2 0x66cda7 in ts_parser__lex /src/octofuzz/tree-sitter/src/runtime/parser.c:324:11
```