### PR TITLE
Use explicit `then` node to wrap statements inside if/case/rescue/when

### DIFF
--- a/corpus/control-flow.txt
+++ b/corpus/control-flow.txt
@@ -74,13 +74,18 @@ if foo then
 else
 end
 
-if true then ; 123; end
+if true then ;; 123; end
 
 ---
 
 (program
-  (if (identifier) (else))
-  (if (true) (integer)))
+  (if
+    (identifier)
+    (then)
+    (else))
+  (if
+    (true)
+    (then (empty_statement) (empty_statement) (integer))))
 
 ==================================
 single-line if then else statement
@@ -90,7 +95,7 @@ if foo then bar else quux end
 
 ---
 
-(program (if (identifier) (identifier) (else (identifier))))
+(program (if (identifier) (then (identifier)) (else (identifier))))
 
 ========
 if elsif
@@ -105,8 +110,8 @@ end
 ---
 
 (program
-  (if (identifier) (identifier)
-  (elsif (identifier) (identifier))))
+  (if (identifier) (then (identifier))
+  (elsif (identifier) (then (identifier)))))
 
 =============
 if elsif else
@@ -123,8 +128,11 @@ end
 ---
 
 (program
-  (if (identifier) (identifier)
-    (elsif (identifier) (identifier)
+  (if (identifier)
+    (then (identifier))
+    (elsif
+      (identifier)
+      (then (identifier))
       (else (identifier)))))
 
 ======================
@@ -147,7 +155,7 @@ end
 
 ---
 
-(program (unless (identifier)))
+(program (unless (identifier) (then)))
 
 ================================
 empty unless statement with else
@@ -311,13 +319,12 @@ rescue
   bar
 end
 
-
 ---
 
 (program
   (begin (rescue))
-  (begin (rescue))
-  (begin (rescue (identifier))))
+  (begin (rescue (then)))
+  (begin (rescue (then (identifier)))))
 
 ===========================
 begin with rescue with args
@@ -359,12 +366,12 @@ end
 
 (program
   (begin (rescue (exceptions (identifier))))
-  (begin (rescue (exceptions (identifier))))
-  (begin (rescue (exceptions (identifier)) (identifier)))
-  (begin (rescue (exception_variable (identifier)) (identifier)))
-  (begin (rescue (exceptions (identifier) (identifier)) (identifier)))
+  (begin (rescue (exceptions (identifier)) (then)))
+  (begin (rescue (exceptions (identifier)) (then (identifier))))
+  (begin (rescue (exception_variable (identifier)) (then (identifier))))
+  (begin (rescue (exceptions (identifier) (identifier)) (then (identifier))))
   (begin (rescue (exceptions (constant)) (exception_variable (identifier))))
-  (begin (rescue (exceptions (constant)) (exception_variable (identifier)) (identifier))))
+  (begin (rescue (exceptions (constant)) (exception_variable (identifier)) (then (identifier)))))
 
 ===========================
 begin with rescue with splat args
@@ -416,7 +423,7 @@ end
 
 (program
   (begin (identifier)
-    (rescue (exceptions (identifier)) (retry))
+    (rescue (exceptions (identifier)) (then (retry)))
     (else (identifier))
     (ensure (identifier))))
 
@@ -473,10 +480,12 @@ end
 (program
   (case
     (identifier)
-    (when (pattern (identifier)) (else)))
+    (when (pattern (identifier)))
+    (else))
   (case
     (identifier)
-    (when (pattern (identifier)) (else (identifier)))))
+    (when (pattern (identifier)))
+    (else (identifier))))
 
 ==============================
 case with multiple when blocks
@@ -495,9 +504,9 @@ end
 
 (program
   (case (identifier)
-    (when (pattern (identifier)) (identifier)
-      (when (pattern (identifier)) (identifier)
-        (else (identifier))))))
+    (when (pattern (identifier)) (then (identifier)))
+    (when (pattern (identifier)) (then (identifier)))
+    (else (identifier))))
 
 ==============================
 case with splat parameter in when
@@ -510,7 +519,12 @@ end
 
 ---
 
-(program (case (identifier) (when (pattern (splat_argument (identifier))) (identifier))))
+(program
+  (case
+    (identifier)
+    (when
+      (pattern (splat_argument (identifier)))
+      (then (identifier)))))
 
 ==============
 case with assignment
@@ -525,8 +539,8 @@ end
 
 (program (assignment (identifier)
   (case (identifier)
-    (when (pattern (identifier))
-      (else)))))
+    (when (pattern (identifier)))
+    (else))))
 
 ==============
 case with expression
@@ -541,5 +555,5 @@ end
 
 (program (assignment (identifier)
   (case (assignment (identifier) (binary (identifier) (identifier)))
-    (when (pattern (identifier))
-      (else)))))
+    (when (pattern (identifier)))
+    (else))))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -669,9 +669,9 @@ heredoc content
   (heredoc_beginning) (heredoc_body (heredoc_end))
   (heredoc_beginning) (heredoc_body (heredoc_end))
   (heredoc_beginning) (heredoc_body (heredoc_end))
-  (if (identifier)
+  (if (identifier) (then
     (heredoc_beginning) (heredoc_body (heredoc_end))
-    (heredoc_beginning) (heredoc_body (heredoc_end)))
+    (heredoc_beginning) (heredoc_body (heredoc_end))))
   (heredoc_beginning) (heredoc_body (heredoc_end)))
 
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -49,61 +49,53 @@
       "value": "(.|\\s)*"
     },
     "_statements": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_top_level_statement"
-            },
-            {
-              "type": "REPEAT",
+              "type": "REPEAT1",
               "content": {
-                "type": "SEQ",
+                "type": "CHOICE",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "_terminator"
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_statement"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "_terminator"
+                      }
+                    ]
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "_top_level_statement"
+                    "name": "empty_statement"
                   }
                 ]
               }
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statement"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             }
           ]
         },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_terminator"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
-    },
-    "_top_level_statement": {
-      "type": "CHOICE",
-      "members": [
         {
           "type": "SYMBOL",
           "name": "_statement"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "begin_block"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "end_block"
         }
       ]
     },
@@ -198,7 +190,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "empty_statement"
+          "name": "begin_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "end_block"
         },
         {
           "type": "SYMBOL",
@@ -1308,8 +1304,23 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "when"
+          "type": "REPEAT",
+          "content": {
+            "type": "SYMBOL",
+            "name": "when"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "else"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "STRING",
@@ -1350,39 +1361,15 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_then"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "else"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
+              "name": "_terminator"
             },
             {
               "type": "SYMBOL",
-              "name": "when"
+              "name": "then"
             }
           ]
         }
@@ -1413,10 +1400,6 @@
           "name": "_statement"
         },
         {
-          "type": "SYMBOL",
-          "name": "_then"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
@@ -1424,7 +1407,8 @@
               "name": "_terminator"
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "then"
             }
           ]
         },
@@ -1432,20 +1416,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_if_tail"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "elsif"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1470,18 +1451,15 @@
           "name": "_statement"
         },
         {
-          "type": "SYMBOL",
-          "name": "_then"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_statements"
+              "name": "_terminator"
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "then"
             }
           ]
         },
@@ -1515,18 +1493,15 @@
           "name": "_statement"
         },
         {
-          "type": "SYMBOL",
-          "name": "_then"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_statements"
+              "name": "_terminator"
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "then"
             }
           ]
         },
@@ -1534,8 +1509,17 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "_if_tail"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "else"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "elsif"
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1577,17 +1561,9 @@
         }
       ]
     },
-    "_then": {
+    "then": {
       "type": "CHOICE",
       "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_terminator"
-        },
-        {
-          "type": "STRING",
-          "value": "then"
-        },
         {
           "type": "SEQ",
           "members": [
@@ -1596,23 +1572,43 @@
               "name": "_terminator"
             },
             {
-              "type": "STRING",
-              "value": "then"
+              "type": "SYMBOL",
+              "name": "_statements"
             }
           ]
-        }
-      ]
-    },
-    "_if_tail": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "else"
         },
         {
-          "type": "SYMBOL",
-          "name": "elsif"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_terminator"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "then"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -1694,18 +1690,15 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_then"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_statements"
+              "name": "_terminator"
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "then"
             }
           ]
         },


### PR DESCRIPTION
Refs https://github.com/atom/language-ruby/issues/237

Previously, specifying the folding behavior for `if`, `elsif`, and `rescue` blocks in Atom was pretty tricky. There wasn't an explicit node to differentiate the 'body' of these nodes from their condition, and from any nested `elsif` or `else` clauses.

Now, the body of these nodes is always wrapped in a `then` node, whether or not there is an explicit "then" token.

I also made a few other minor changes:

* Parse empty statements (redundant `;` tokens) correctly regardless of where they occur
* Remove a couple of wrapper nodes that increase the size of the parse tree unnecessarily: `_if_tail` and `_top_level_statement`.

/cc @tclem - This will affect Ruby assignment in your app, though I imagine it would simplify it, because it's much easier to grab the body of an `if`, `unless`, `rescue`, `when` block?