### PR TITLE
Prebuild against electron v3 and v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tree-sitter generate && node-gyp build --debug",
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild -r electron -t 1.6.0 -t 1.7.0 -t 1.8.0 -t 2.0.0 --strip --verbose",
+    "prebuild": "prebuild -r electron -t 1.6.0 -t 1.7.0 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip --verbose",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"


### PR DESCRIPTION
Electron v3 and v4 use node-abi v64. VSCode will be moving to v3 at some point so adding it here to build against.

`node-abi` [has these versions available](https://github.com/lgeiger/node-abi/blob/master/index.js#L68-L69) already