### PR TITLE
Prebuilt for Electron and Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 sudo: false
 
 node_js:
-- node
+- 10
 
 os:
 - linux

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild -r electron -t 1.6.0 -t 1.7.0 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip && prebuild -t 8.16.0 -t 9.11.2 -t 10.12.0 --strip",
+    "prebuild": "prebuild -r electron -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip && prebuild -t 8.16.0 -t 10.12.0 --strip",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild --all --strip --verbose",
+    "prebuild": "prebuild -r electron -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip && prebuild -t 8.16.0 -t 9.11.2 -t 10.12.0 --strip",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild -r electron -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip && prebuild -t 8.16.0 -t 9.11.2 -t 10.12.0 --strip",
+    "prebuild": "prebuild -r electron -t 1.6.0 -t 1.7.0 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip && prebuild -t 8.16.0 -t 9.11.2 -t 10.12.0 --strip",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild -r electron -t 1.6.0 -t 1.7.0 -t 1.8.0 -t 2.0.0 -t 3.0.0 -t 4.0.0 --strip --verbose",
+    "prebuild": "prebuild --all --strip --verbose",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"


### PR DESCRIPTION
[node-tree-sitter](https://github.com/tree-sitter/node-tree-sitter/blob/master/package.json#L30) is built against all ABI versions, we may want to do the something for languages otherwise we don't have rebuilds for pure Nodejs.