### PR TITLE
Add Electron 3 back to the list of prebuild targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "install": "prebuild-install || node-gyp rebuild",
-    "prebuild": "prebuild -r electron -t 4.0.0 -t 4.0.4 -t 5.0.0 --strip && prebuild -t 8.16.0 -t 10.12.0 --strip",
+    "prebuild": "prebuild -r electron -t 3.0.0 -t 4.0.0 -t 4.0.4 -t 5.0.0 --strip && prebuild -t 8.16.0 -t 10.12.0 --strip",
     "prebuild:upload": "prebuild --upload-all",
     "test": "tree-sitter test && script/parse-examples",
     "test-windows": "tree-sitter test"


### PR DESCRIPTION
It looks like #108 removed Electron 3 from the list of prebuild targets, which seems to be causing problems with the `language-ruby` Atom package on Atom 1.39.1, which uses Electron 3. Locking the `language-ruby` dependency to `tree-sitter-ruby@0.15.0` makes the build pass on Travis, so I'm hopeful that adding  the 3.0 Electron target back resolves this. I'm not sure why we aren't successfully falling back to a manual build in this case.