### PR TITLE
Make string content and heredoc content visible

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -812,7 +812,7 @@ module.exports = grammar({
     heredoc_body: $ => seq(
       $._heredoc_body_start,
       repeat(choice(
-        $._heredoc_content,
+        alias($._heredoc_content, $.heredoc_content),
         $.interpolation,
         $.escape_sequence
       )),
@@ -820,7 +820,7 @@ module.exports = grammar({
     ),
 
     _literal_contents: $ => repeat1(choice(
-      $._string_content,
+      alias($._string_content, $.string_content),
       $.interpolation,
       $.escape_sequence
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5487,8 +5487,13 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_heredoc_content"
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_heredoc_content"
+                },
+                "named": true,
+                "value": "heredoc_content"
               },
               {
                 "type": "SYMBOL",
@@ -5513,8 +5518,13 @@
         "type": "CHOICE",
         "members": [
           {
-            "type": "SYMBOL",
-            "name": "_string_content"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_string_content"
+            },
+            "named": true,
+            "value": "string_content"
           },
           {
             "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -587,7 +587,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "escape_sequence",
@@ -595,6 +595,10 @@
         },
         {
           "type": "interpolation",
+          "named": true
+        },
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -606,7 +610,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "escape_sequence",
@@ -614,6 +618,10 @@
         },
         {
           "type": "interpolation",
+          "named": true
+        },
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -1566,6 +1574,10 @@
           "named": true
         },
         {
+          "type": "heredoc_content",
+          "named": true
+        },
+        {
           "type": "heredoc_end",
           "named": true
         },
@@ -2250,6 +2262,10 @@
         {
           "type": "interpolation",
           "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
         }
       ]
     }
@@ -2603,6 +2619,10 @@
         {
           "type": "interpolation",
           "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
         }
       ]
     }
@@ -2636,6 +2656,10 @@
         },
         {
           "type": "interpolation",
+          "named": true
+        },
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -2694,6 +2718,10 @@
         },
         {
           "type": "interpolation",
+          "named": true
+        },
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -3431,6 +3459,10 @@
     "named": true
   },
   {
+    "type": "heredoc_content",
+    "named": true
+  },
+  {
     "type": "heredoc_end",
     "named": true
   },
@@ -3496,6 +3528,10 @@
   },
   {
     "type": "self",
+    "named": true
+  },
+  {
+    "type": "string_content",
     "named": true
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -64,7 +64,7 @@ end
 ---
 
 (program
-  (method (operator) (method_parameters (identifier)) (string))
+  (method (operator) (method_parameters (identifier)) (string (string_content)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
@@ -85,7 +85,7 @@ end
 ---
 
 (program
-  (method_call (identifier) (argument_list (regex)))
+  (method_call (identifier) (argument_list (regex (string_content))))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier))))
 

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -48,7 +48,7 @@ foo["bar"]
 
 ---
 
-(program (element_reference (identifier) (string)))
+(program (element_reference (identifier) (string (string_content))))
 
 ============
 element reference with symbol
@@ -199,9 +199,9 @@ NIL = "nil"
 (program
   (assignment (identifier) (identifier))
   (assignment (identifier) (splat_argument (identifier)))
-  (assignment (false) (string))
-  (assignment (true) (string))
-  (assignment (nil) (string)))
+  (assignment (false) (string (string_content)))
+  (assignment (true) (string (string_content)))
+  (assignment (nil) (string (string_content))))
 
 =====================
 multiple assignment
@@ -296,7 +296,7 @@ puts "/hi"
   (operator_assignment (identifier) (identifier))
   (operator_assignment (identifier) (identifier))
   (operator_assignment (identifier) (identifier))
-  (method_call (identifier) (argument_list (string))))
+  (method_call (identifier) (argument_list (string (string_content)))))
 
 ==========
 operator assignment
@@ -351,7 +351,7 @@ conditional and character literal ambiguity
 true ?")":"c"
 
 ---
-(program (conditional (true) (string) (string)))
+(program (conditional (true) (string (string_content)) (string (string_content))))
 
 ===========================================
 conditional with reserved identifiers
@@ -583,10 +583,10 @@ print("hello")
     arguments: (argument_list))
   (method_call
     method: (identifier)
-    arguments: (argument_list (string)))
+    arguments: (argument_list (string (string_content))))
   (method_call
     method: (identifier)
-    arguments: (argument_list (string))))
+    arguments: (argument_list (string (string_content)))))
 
 ====================================
 nested unparenthesized method calls
@@ -668,22 +668,22 @@ foo.bar("hi", 2)
     method: (call
       receiver: (identifier)
       method: (identifier))
-    arguments: (argument_list (string)))
+    arguments: (argument_list (string (string_content))))
   (method_call
     method: (call
       receiver: (identifier)
       method: (identifier))
-    arguments: (argument_list (string) (integer)))
+    arguments: (argument_list (string (string_content)) (integer)))
   (method_call
     method: (call
       receiver: (identifier)
       method: (identifier))
-    arguments: (argument_list (string)))
+    arguments: (argument_list (string (string_content))))
   (method_call
     method: (call
       receiver: (identifier)
       method: (identifier))
-    arguments: (argument_list (string) (integer))))
+    arguments: (argument_list (string (string_content)) (integer))))
 
 ===============================
 implicit call
@@ -921,7 +921,7 @@ foo *(bar.baz)
 (program
   (method_call (identifier) (argument_list (splat_argument (identifier))))
   (method_call (identifier) (argument_list (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (string_array (bare_string) (bare_string)))))
+  (method_call (identifier) (argument_list (splat_argument (string_array (bare_string (string_content)) (bare_string (string_content))))))
   (method_call (identifier) (argument_list (splat_argument (parenthesized_statements (call (identifier) (identifier)))))))
 
 ===============================
@@ -1365,10 +1365,10 @@ foo \
   (method_call
     (identifier)
     (argument_list (identifier) (identifier)))
-  (string (escape_sequence))
+  (string (string_content) (escape_sequence) (string_content))
   (method_call
     (identifier)
-    (argument_list (string))))
+    (argument_list (string (string_content)))))
 
 ===============================
 basic division
@@ -1408,7 +1408,7 @@ foo /bar/
 ---
 
 (program
-  (method_call (identifier) (argument_list (regex))))
+  (method_call (identifier) (argument_list (regex (string_content)))))
 
 ===============================
 regex with opening space
@@ -1419,7 +1419,7 @@ foo
 
 ---
 
-(program (identifier) (regex))
+(program (identifier) (regex (string_content)))
 
 ===============================
 forward slash operator as method
@@ -1430,7 +1430,7 @@ Foo / "bar"
 
 ---
 
-(program (binary (constant) (string)) (string))
+(program (binary (constant) (string (string_content))) (string (string_content)))
 
 ===============================
 multiline regex
@@ -1441,4 +1441,4 @@ multiline regex
 
 ---
 
-(program (regex))
+(program (regex (string_content)))

--- a/test/corpus/line-endings.txt
+++ b/test/corpus/line-endings.txt
@@ -8,7 +8,7 @@ x = foo()
 ---
 
 (program
-  (method_call (identifier) (argument_list (string)))
+  (method_call (identifier) (argument_list (string (string_content))))
   (assignment (identifier) (method_call (identifier) (argument_list))))
 
 =======================

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -100,8 +100,8 @@ single quoted symbol
 ---
 
 (program
-  (symbol)
-  (symbol))
+  (symbol (string_content))
+  (symbol (string_content)))
 
 ====================
 double quoted symbol
@@ -112,7 +112,7 @@ double quoted symbol
 
 ---
 
-(program (symbol) (symbol))
+(program (symbol (string_content)) (symbol (string_content)))
 
 =======================================
 double quoted symbol with interpolation
@@ -122,7 +122,7 @@ double quoted symbol with interpolation
 
 ---
 
-(program (symbol (interpolation (identifier))))
+(program (symbol (string_content) (interpolation (identifier))))
 
 =========================================
 percent symbol with unbalanced delimiters
@@ -134,7 +134,7 @@ percent symbol with unbalanced delimiters
 
 ---
 
-(program (symbol) (symbol) (symbol))
+(program (symbol (string_content)) (symbol (string_content)) (symbol (string_content)))
 
 =======================================
 percent symbol with balanced delimiters
@@ -147,7 +147,7 @@ percent symbol with balanced delimiters
 
 ---
 
-(program (symbol) (symbol) (symbol) (symbol))
+(program (symbol (string_content)) (symbol (string_content)) (symbol (string_content)) (symbol (string_content)))
 
 =======================================
 global variables
@@ -385,7 +385,7 @@ single-quoted string
 
 ---
 
-(program (string) (string) (string))
+(program (string) (string (string_content)) (string (string_content)))
 
 ==============================================
 single-quoted strings with backslashes
@@ -398,9 +398,9 @@ single-quoted strings with backslashes
 ---
 
 (program
-  (string)
-  (string)
-  (string))
+  (string (string_content))
+  (string (string_content))
+  (string (string_content)))
 
 =================================================
 single-quoted string with pound and curly brace
@@ -410,7 +410,7 @@ single-quoted string with pound and curly brace
 
 ---
 
-(program (string))
+(program (string (string_content)))
 
 ====================
 double-quoted string
@@ -422,7 +422,7 @@ double-quoted string
 
 ---
 
-(program (string) (string) (string))
+(program (string) (string (string_content)) (string (string_content)))
 
 ==============================================
 double-quoted strings with escape sequences
@@ -439,7 +439,7 @@ double-quoted strings with escape sequences
   (string (escape_sequence))
   (string (escape_sequence))
   (string (escape_sequence))
-  (string (escape_sequence)))
+  (string (escape_sequence) (string_content)))
 
 =================================
 double-quoted string with just pound
@@ -449,7 +449,7 @@ double-quoted string with just pound
 
 ---
 
-(program (string))
+(program (string (string_content)))
 
 =============
 interpolation
@@ -462,7 +462,7 @@ interpolation
 
 (program
   (string (interpolation (identifier)))
-  (string (interpolation (unless_modifier (string) (identifier)))))
+  (string (interpolation (unless_modifier (string (string_content)) (identifier)))))
 
 ===========================================
 percent q string with unbalanced delimiters
@@ -474,7 +474,7 @@ percent q string with unbalanced delimiters
 
 ---
 
-(program (string) (string) (string))
+(program (string (string_content)) (string (string_content)) (string (string_content)))
 
 =========================================
 percent q string with balanced delimiters
@@ -487,7 +487,7 @@ percent q string with balanced delimiters
 
 ---
 
-(program (string) (string) (string) (string))
+(program (string (string_content)) (string (string_content)) (string (string_content)) (string (string_content)))
 
 =========================================
 percent string with unbalanced delimiters
@@ -499,7 +499,7 @@ percent string with unbalanced delimiters
 
 ---
 
-(program (string) (string) (string))
+(program (string (string_content)) (string (string_content)) (string (string_content)))
 
 =========================================
 percent string with balanced delimiters
@@ -512,7 +512,7 @@ percent string with balanced delimiters
 
 ---
 
-(program (string) (string) (string) (string))
+(program (string (string_content)) (string (string_content)) (string (string_content)) (string (string_content)))
 
 ===========================================
 percent Q string with unbalanced delimiters
@@ -524,7 +524,7 @@ percent Q string with unbalanced delimiters
 
 ---
 
-(program (string) (string) (string))
+(program (string (string_content)) (string (string_content)) (string (string_content)))
 
 =========================================
 percent Q string with balanced delimiters
@@ -537,7 +537,7 @@ percent Q string with balanced delimiters
 
 ---
 
-(program (string) (string) (string) (string))
+(program (string (string_content)) (string (string_content)) (string (string_content)) (string (string_content)))
 
 ===============
 string chaining
@@ -549,8 +549,8 @@ string chaining
 ---
 
 (program
-  (chained_string (string) (string) (string))
-  (chained_string (string) (string)))
+  (chained_string (string (string_content)) (string (string_content)) (string (string_content)))
+  (chained_string (string (string_content)) (string (string_content))))
 
 ==========================
 newline-delimited strings
@@ -563,7 +563,7 @@ flash[:notice] = "Pattern addition failed for '%s' in '%s'", %
 
 (program (assignment
   (element_reference (identifier) (symbol))
-  (right_assignment_list (string) (string))))
+  (right_assignment_list (string (string_content)) (string (string_content)))))
 
 ==========================
 % formatting that looks like a newline-delimited strings
@@ -579,7 +579,7 @@ foo("%s '%s' " %
     (identifier)
     (argument_list
       (binary
-        (string)
+        (string (string_content))
         (array (identifier) (identifier))))))
 
 ========================================
@@ -627,7 +627,7 @@ nested strings with different delimiters
 ---
 
 (program
-  (string (interpolation (regex (interpolation (subshell))))))
+  (string (string_content) (interpolation (regex (string_content) (interpolation (subshell (string_content))) (string_content))) (string_content)))
 
 ========================================
 basic heredocs
@@ -669,15 +669,15 @@ heredoc content
 ---
 
 (program
-  (heredoc_beginning) (heredoc_body (escape_sequence) (heredoc_end))
-  (heredoc_beginning) (heredoc_body (heredoc_end))
-  (heredoc_beginning) (heredoc_body (heredoc_end))
-  (heredoc_beginning) (heredoc_body (heredoc_end))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (escape_sequence) (heredoc_content) (heredoc_end))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))
   (if (identifier) (then
-    (heredoc_beginning) (heredoc_body (heredoc_end))
-    (heredoc_beginning) (heredoc_body (heredoc_end))
-    (heredoc_beginning) (heredoc_body (heredoc_end))))
-  (heredoc_beginning) (heredoc_body (heredoc_end)))
+    (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))
+    (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))
+    (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
 
 
 ========================================
@@ -690,7 +690,7 @@ eos
 
 ---
 
-(program (heredoc_beginning) (heredoc_body (heredoc_end)))
+(program (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
 
 ========================================
 heredoc with end word in content
@@ -709,8 +709,8 @@ a
 ---
 
 (program
-  (heredoc_beginning) (heredoc_body (heredoc_end))
-  (heredoc_beginning) (heredoc_body (heredoc_end)))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end))
+  (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
 
 ========================================
 heredocs in context starting with dot
@@ -726,7 +726,7 @@ end
 
 (program (method (identifier)
   (method_call (identifier) (argument_list (heredoc_beginning)))
-  (heredoc_body (heredoc_end))))
+  (heredoc_body (heredoc_content) (heredoc_end))))
 
 ========================================
 heredocs with method continuation
@@ -744,7 +744,7 @@ SQL
     (method_call
       (identifier)
       (argument_list (heredoc_beginning)))
-    (heredoc_body (heredoc_end))
+    (heredoc_body (heredoc_content) (heredoc_end))
     (identifier))
   (argument_list)))
 
@@ -763,9 +763,9 @@ where("a")
   (method_call
     (call
       (method_call (identifier) (argument_list (heredoc_beginning)))
-      (heredoc_body (heredoc_end))
+      (heredoc_body (heredoc_content) (heredoc_end))
       (identifier))
-    (argument_list (string))))
+    (argument_list (string (string_content)))))
 
 ========================================
 multiple heredocs with method continuation
@@ -786,8 +786,8 @@ group("b")
       (method_call
         (call (method_call (identifier) (argument_list (heredoc_beginning))) (identifier))
         (argument_list (heredoc_beginning)))
-      (heredoc_body (heredoc_end)) (heredoc_body (heredoc_end)) (identifier))
-    (argument_list (string))))
+      (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_body (heredoc_content) (heredoc_end)) (identifier))
+    (argument_list (string (string_content)))))
 
 ========================================
 heredocs with interpolation
@@ -808,13 +808,13 @@ return
 
 (program
   (heredoc_beginning)
-  (heredoc_body
-    (interpolation (array (integer) (string (interpolation (integer))) (integer)))
-    (interpolation (integer))
+  (heredoc_body (heredoc_content)
+    (interpolation (array (integer) (string (string_content) (interpolation (integer)) (string_content)) (integer)))
+    (heredoc_content) (interpolation (integer)) (heredoc_content)
     (interpolation (call (identifier) (identifier)))
-    (interpolation (if_modifier (identifier) (identifier)))
+    (heredoc_content) (interpolation (if_modifier (identifier) (identifier))) (heredoc_content)
     (interpolation (call (method_call (identifier) (argument_list (integer) (identifier))) (identifier)))
-    (heredoc_end))
+    (heredoc_content) (heredoc_end))
   (return))
 
 ========================================
@@ -861,17 +861,17 @@ foo[
     (call (identifier) (identifier))
     (argument_list
       (pair (symbol) (heredoc_beginning))
-      (heredoc_body (heredoc_end))
+      (heredoc_body (heredoc_content) (heredoc_end))
       (pair (symbol) (heredoc_beginning))
-      (heredoc_body (heredoc_end))))
+      (heredoc_body (heredoc_content) (heredoc_end))))
   (hash
     (pair (symbol) (heredoc_beginning))
-    (heredoc_body (heredoc_end))
+    (heredoc_body (heredoc_content) (heredoc_end))
     (pair (symbol) (heredoc_beginning))
-    (heredoc_body (heredoc_end)))
-  (array (heredoc_beginning) (heredoc_body (heredoc_end)) (heredoc_beginning) (heredoc_body (heredoc_end)))
+    (heredoc_body (heredoc_content) (heredoc_end)))
+  (array (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
   (assignment
-    (element_reference (identifier) (integer) (heredoc_beginning) (heredoc_body (heredoc_end)))
+    (element_reference (identifier) (integer) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
     (integer)))
 
 ==============================================================
@@ -892,9 +892,9 @@ foo(<<-STR.strip_heredoc.tr()
       (method_call
         (call (call (heredoc_beginning) (identifier)) (identifier))
         (argument_list))
-      (heredoc_body
+      (heredoc_body (heredoc_content)
         (interpolation (call (method_call (identifier) (argument_list)) (identifier)))
-        (heredoc_end)))))
+        (heredoc_content) (heredoc_end)))))
 
 ========================================
 multiple heredocs
@@ -914,8 +914,8 @@ TWO
     (argument_list
       (call (heredoc_beginning) (identifier))
       (call (heredoc_beginning) (identifier))))
-  (heredoc_body (heredoc_end))
-  (heredoc_body (heredoc_end)))
+  (heredoc_body (heredoc_content) (heredoc_end))
+  (heredoc_body (heredoc_content) (heredoc_end)))
 
 ========================================
 heredoc content that starts with a dot
@@ -934,7 +934,7 @@ heredoc content that starts with a dot
     (method_call
       (identifier)
       (argument_list (heredoc_beginning)))
-    (heredoc_body (heredoc_end)))))
+    (heredoc_body (heredoc_content) (heredoc_end)))))
 
 ========================================
 un-terminated heredocs
@@ -946,7 +946,7 @@ un-terminated heredocs
 
 (program
   (heredoc_beginning)
-  (heredoc_body (heredoc_end)))
+  (heredoc_body (heredoc_content) (heredoc_end)))
 
 ==================
 backticks subshell
@@ -956,7 +956,7 @@ backticks subshell
 
 ---
 
-(program (subshell))
+(program (subshell (string_content)))
 
 ==============================
 backticks subshell with escape
@@ -967,8 +967,8 @@ backticks subshell with escape
 ---
 
 (program (subshell
-  (escape_sequence)
-  (escape_sequence)))
+  (string_content) (escape_sequence)
+  (string_content) (escape_sequence)))
 
 ===========
 empty array
@@ -1038,7 +1038,7 @@ unbalanced percent w array
 
 ---
 
-(program (string_array (bare_string) (bare_string)))
+(program (string_array (bare_string (string_content)) (bare_string (string_content))))
 
 ===============
 percent w array
@@ -1048,7 +1048,7 @@ percent w array
 
 ---
 
-(program (string_array (bare_string) (bare_string)))
+(program (string_array (bare_string (string_content)) (bare_string (string_content))))
 
 ===================================
 percent W array with interpolations
@@ -1059,9 +1059,9 @@ percent W array with interpolations
 ---
 
 (program (string_array
-  (bare_string)
+  (bare_string (string_content))
   (bare_string (interpolation (identifier)))
-  (bare_string)))
+  (bare_string (string_content))))
 
 =====================
 empty percent i array
@@ -1081,7 +1081,7 @@ unbalanced percent i array
 
 ---
 
-(program (symbol_array (bare_symbol) (bare_symbol)))
+(program (symbol_array (bare_symbol (string_content)) (bare_symbol (string_content))))
 
 ===============
 percent i array
@@ -1091,7 +1091,7 @@ percent i array
 
 ---
 
-(program (symbol_array (bare_symbol) (bare_symbol)))
+(program (symbol_array (bare_symbol (string_content)) (bare_symbol (string_content))))
 
 ====================================
 percent I array with interpolations
@@ -1102,9 +1102,9 @@ percent I array with interpolations
 ---
 
 (program (symbol_array
-  (bare_symbol)
+  (bare_symbol (string_content))
   (bare_symbol (interpolation (identifier)))
-  (bare_symbol)))
+  (bare_symbol (string_content))))
 
 ====================================
 percent i array with spaces
@@ -1119,9 +1119,9 @@ percent i array with spaces
 ---
 
 (program (symbol_array
-  (bare_symbol)
-  (bare_symbol (interpolation (identifier)))
-  (bare_symbol)))
+  (bare_symbol (string_content))
+  (bare_symbol (string_content) (interpolation (identifier)) (string_content))
+  (bare_symbol (string_content))))
 
 ==========
 empty hash
@@ -1141,7 +1141,7 @@ hash with no spaces
 
 ---
 
-(program (hash (pair (symbol) (string))))
+(program (hash (pair (symbol) (string (string_content)))))
 
 =========================
 hash with expression keys
@@ -1154,7 +1154,7 @@ hash with expression keys
 ---
 
 (program
-	(hash (pair (string) (integer)) (pair (string) (integer)))
+	(hash (pair (string (string_content)) (integer)) (pair (string (string_content)) (integer)))
 	(hash (pair (array) (integer)))
 	(hash (pair (identifier) (integer))))
 
@@ -1254,11 +1254,11 @@ hash with keyword keys
   (hash
     (pair (symbol) (integer))
     (pair (symbol) (integer))
-    (pair (string) (integer)))
+    (pair (string (string_content)) (integer)))
   (hash
     (pair (symbol) (integer))
     (pair (symbol) (integer))
-    (pair (string) (integer))))
+    (pair (string (string_content)) (integer))))
 
 ========================
 hash with trailing comma
@@ -1309,7 +1309,7 @@ regular expression
 
 ---
 
-(program (regex))
+(program (regex (string_content)))
 
 =====================================
 regular expression with interpolation
@@ -1322,9 +1322,9 @@ regular expression with interpolation
 ---
 
 (program
-  (regex (interpolation (identifier)))
-  (regex)
-  (regex))
+  (regex (string_content) (interpolation (identifier)) (string_content))
+  (regex (string_content))
+  (regex (string_content)))
 
 =======================================================
 percent r regular expression with unbalanced delimiters
@@ -1336,7 +1336,7 @@ percent r regular expression with unbalanced delimiters
 
 ---
 
-(program (regex) (regex) (regex))
+(program (regex (string_content)) (regex (string_content)) (regex (string_content)))
 
 
 =====================================================
@@ -1351,7 +1351,7 @@ percent r regular expression with balanced delimiters
 
 ---
 
-(program (regex) (regex) (regex) (regex) (regex))
+(program (regex (string_content)) (regex (string_content)) (regex (string_content)) (regex (string_content)) (regex (string_content)))
 
 =========================================================================
 percent r regular expression with unbalanced delimiters and interpolation
@@ -1361,7 +1361,7 @@ percent r regular expression with unbalanced delimiters and interpolation
 
 ---
 
-(program (regex (interpolation (identifier))))
+(program (regex (string_content) (interpolation (identifier)) (string_content)))
 
 =======================================================================
 percent r regular expression with balanced delimiters and interpolation
@@ -1371,7 +1371,7 @@ percent r regular expression with balanced delimiters and interpolation
 
 ---
 
-(program (regex (interpolation (identifier))))
+(program (regex (string_content) (interpolation (identifier)) (string_content)))
 
 ==============
 empty function

--- a/test/corpus/single-cr-as-whitespace.rb
+++ b/test/corpus/single-cr-as-whitespace.rb
@@ -6,4 +6,4 @@ puts"hi"
 
 ---
 
-(program (method_call (identifier) (argument_list (string))))
+(program (method_call (identifier) (argument_list (string (string_content)))))


### PR DESCRIPTION
The contents of string literals and heredocs used to be hidden because the rule names for them start with an `_`.

@dcreager 