### PR TITLE
Correct field for when.pattern

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -314,7 +314,7 @@ module.exports = grammar({
 
     when: $ => seq(
       'when',
-      field('pattern', commaSep1($.pattern)),
+      commaSep1(field('pattern', $.pattern)),
       choice($._terminator, field('body', $.then))
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1494,33 +1494,37 @@
           "value": "when"
         },
         {
-          "type": "FIELD",
-          "name": "pattern",
-          "content": {
-            "type": "SEQ",
-            "members": [
-              {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "FIELD",
+              "name": "pattern",
+              "content": {
                 "type": "SYMBOL",
                 "name": "pattern"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "STRING",
-                      "value": ","
-                    },
-                    {
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "pattern",
+                    "content": {
                       "type": "SYMBOL",
                       "name": "pattern"
                     }
-                  ]
-                }
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3047,10 +3047,6 @@
         "required": true,
         "types": [
           {
-            "type": ",",
-            "named": false
-          },
-          {
             "type": "pattern",
             "named": true
           }


### PR DESCRIPTION
This fixes the `pattern` field of the `when` rule. Having the field defined outside the `commaSep` call causes the commas to be treated as patterns too.

@maxbrunsfeld 