### PR TITLE
Fix range of characters supported in keyword argument

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -844,8 +844,11 @@ struct Scanner {
     }
 
     // Open delimiters for literals
-    if (valid_symbols[IDENTIFIER_HASH_KEY] && iswalpha(lexer->lookahead)) {
-      while (iswalpha(lexer->lookahead)) advance(lexer);
+    if (valid_symbols[IDENTIFIER_HASH_KEY]
+        && (iswalnum(lexer->lookahead) || lexer->lookahead == '_')) {
+      while (iswalnum(lexer->lookahead) || lexer->lookahead == '_') {
+        advance(lexer);
+      }
       lexer->mark_end(lexer);
 
       if (lexer->lookahead == ':') {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -845,7 +845,7 @@ struct Scanner {
 
     // Open delimiters for literals
     if (valid_symbols[IDENTIFIER_HASH_KEY]
-        && (iswalnum(lexer->lookahead) || lexer->lookahead == '_')) {
+        && (iswalpha(lexer->lookahead) || lexer->lookahead == '_')) {
       while (iswalnum(lexer->lookahead) || lexer->lookahead == '_') {
         advance(lexer);
       }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -642,6 +642,25 @@ foo(bar(a),)
   (method_call (identifier) (argument_list (identifier) (identifier)))
   (method_call (identifier) (argument_list (method_call (identifier) (argument_list (identifier))))))
 
+==============================================
+keyword arguments, no space, trailing comma
+==============================================
+
+foo(a:b)
+foo(a_:b)
+foo(a2:b)
+foo(a_:b,)
+foo(a2:b,)
+
+---
+
+(program
+  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
+  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
+  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
+  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
+  (method_call (identifier) (argument_list (pair (symbol) (identifier)))))
+
 ===============================
 method call with receiver
 ===============================


### PR DESCRIPTION
This fixes https://github.com/tree-sitter/tree-sitter-ruby/issues/136

Original bug report for our application: https://github.com/returntocorp/semgrep/issues/2157
