### PR TITLE
Unify call and method_call

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -42,8 +42,6 @@
 
 (call
   method: [(identifier) (constant)] @function.method)
-(method_call
-  method: [(identifier) (constant)] @function.method)
 
 ; Function definitions
 

--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -55,15 +55,6 @@
 
 ; Calls
 
-(method_call
-  method: (call method: (identifier) @name)) @reference.call
-
-(
-  (method_call
-    method: (identifier) @name) @reference.call
-  (#not-match? @name "^(lambda|load|require|require_relative|__FILE__|__LINE__)$")
-)
-
 (call method: (identifier) @name) @reference.call
 
 (

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2074,7 +2074,7 @@
             "name": "command_call"
           },
           "named": true,
-          "value": "method_call"
+          "value": "call"
         },
         {
           "type": "ALIAS",
@@ -2083,7 +2083,7 @@
             "name": "command_call_with_block"
           },
           "named": true,
-          "value": "method_call"
+          "value": "call"
         },
         {
           "type": "PREC_LEFT",
@@ -2092,7 +2092,7 @@
             "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "chained_command_call"
+              "name": "_chained_command_call"
             },
             "named": true,
             "value": "call"
@@ -2460,7 +2460,7 @@
         ]
       }
     },
-    "call": {
+    "_call": {
       "type": "PREC_LEFT",
       "value": 56,
       "content": {
@@ -2519,34 +2519,34 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "FIELD",
-          "name": "method",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_variable"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "scope_resolution"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "call"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "chained_command_call"
-                },
-                "named": true,
-                "value": "call"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_call"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_chained_command_call"
+            },
+            {
+              "type": "FIELD",
+              "name": "method",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_variable"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "scope_resolution"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         },
         {
           "type": "FIELD",
@@ -2570,25 +2570,30 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "FIELD",
-              "name": "method",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_variable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scope_resolution"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "call"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_call"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "method",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_variable"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "scope_resolution"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             },
             {
               "type": "PREC",
@@ -2626,25 +2631,30 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "FIELD",
-              "name": "method",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_variable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scope_resolution"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "call"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_call"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "method",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_variable"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "scope_resolution"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             },
             {
               "type": "PREC",
@@ -2680,7 +2690,7 @@
         }
       ]
     },
-    "chained_command_call": {
+    "_chained_command_call": {
       "type": "SEQ",
       "members": [
         {
@@ -2693,7 +2703,7 @@
               "name": "command_call_with_block"
             },
             "named": true,
-            "value": "method_call"
+            "value": "call"
           }
         },
         {
@@ -2736,32 +2746,37 @@
         }
       ]
     },
-    "method_call": {
+    "call": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SEQ",
           "members": [
             {
-              "type": "FIELD",
-              "name": "method",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_variable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scope_resolution"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "call"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_call"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "method",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_variable"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "scope_resolution"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             },
             {
               "type": "FIELD",
@@ -2777,25 +2792,30 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "FIELD",
-              "name": "method",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_variable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scope_resolution"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "call"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_call"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "method",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_variable"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "scope_resolution"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             },
             {
               "type": "PREC",
@@ -2828,25 +2848,30 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "FIELD",
-              "name": "method",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_variable"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "scope_resolution"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "call"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_call"
+                },
+                {
+                  "type": "FIELD",
+                  "name": "method",
+                  "content": {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_variable"
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "scope_resolution"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             },
             {
               "type": "PREC",
@@ -2882,25 +2907,30 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "FIELD",
-                "name": "method",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_variable"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "scope_resolution"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "call"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_call"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "method",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_variable"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "scope_resolution"
+                        }
+                      ]
                     }
-                  ]
-                }
+                  }
+                ]
               },
               {
                 "type": "FIELD",
@@ -2920,25 +2950,30 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "FIELD",
-                "name": "method",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "_variable"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "scope_resolution"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "call"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_call"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "method",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_variable"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "scope_resolution"
+                        }
+                      ]
                     }
-                  ]
-                }
+                  }
+                ]
               },
               {
                 "type": "FIELD",
@@ -4705,12 +4740,17 @@
             "name": "element_reference"
           },
           {
-            "type": "SYMBOL",
-            "name": "call"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_call"
+            },
+            "named": true,
+            "value": "call"
           },
           {
             "type": "SYMBOL",
-            "name": "method_call"
+            "name": "call"
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -54,10 +54,6 @@
         "named": true
       },
       {
-        "type": "method_call",
-        "named": true
-      },
-      {
         "type": "nil",
         "named": true
       },
@@ -304,10 +300,6 @@
         "named": true
       },
       {
-        "type": "method_call",
-        "named": true
-      },
-      {
         "type": "next",
         "named": true
       },
@@ -438,10 +430,6 @@
           "named": true
         },
         {
-          "type": "method_call",
-          "named": true
-        },
-        {
           "type": "next",
           "named": true
         },
@@ -490,10 +478,6 @@
         },
         {
           "type": "hash_splat_argument",
-          "named": true
-        },
-        {
-          "type": "method_call",
           "named": true
         },
         {
@@ -551,10 +535,6 @@
           },
           {
             "type": "call",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {
@@ -698,10 +678,6 @@
             "named": true
           },
           {
-            "type": "method_call",
-            "named": true
-          },
-          {
             "type": "next",
             "named": true
           },
@@ -835,10 +811,6 @@
           },
           {
             "type": "call",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {
@@ -976,38 +948,62 @@
     "type": "call",
     "named": true,
     "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "argument_list",
+            "named": true
+          }
+        ]
+      },
+      "block": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          },
+          {
+            "type": "do_block",
+            "named": true
+          }
+        ]
+      },
       "method": {
         "multiple": false,
         "required": true,
         "types": [
           {
+            "type": "_variable",
+            "named": true
+          },
+          {
             "type": "argument_list",
             "named": true
           },
           {
-            "type": "constant",
-            "named": true
-          },
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
             "type": "operator",
+            "named": true
+          },
+          {
+            "type": "scope_resolution",
             "named": true
           }
         ]
       },
       "receiver": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "_primary",
             "named": true
           },
           {
-            "type": "method_call",
+            "type": "call",
             "named": true
           }
         ]
@@ -1305,10 +1301,6 @@
         },
         {
           "type": "hash_splat_argument",
-          "named": true
-        },
-        {
-          "type": "method_call",
           "named": true
         },
         {
@@ -1662,10 +1654,6 @@
             "named": true
           },
           {
-            "type": "method_call",
-            "named": true
-          },
-          {
             "type": "next",
             "named": true
           },
@@ -1882,54 +1870,6 @@
     }
   },
   {
-    "type": "method_call",
-    "named": true,
-    "fields": {
-      "arguments": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "argument_list",
-            "named": true
-          }
-        ]
-      },
-      "block": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "block",
-            "named": true
-          },
-          {
-            "type": "do_block",
-            "named": true
-          }
-        ]
-      },
-      "method": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "_variable",
-            "named": true
-          },
-          {
-            "type": "call",
-            "named": true
-          },
-          {
-            "type": "scope_resolution",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
     "type": "method_parameters",
     "named": true,
     "fields": {},
@@ -2120,10 +2060,6 @@
           },
           {
             "type": "call",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {
@@ -2399,10 +2335,6 @@
           },
           {
             "type": "call",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {
@@ -2752,10 +2684,6 @@
           "named": true
         },
         {
-          "type": "method_call",
-          "named": true
-        },
-        {
           "type": "next",
           "named": true
         },
@@ -2853,10 +2781,6 @@
           },
           {
             "type": "integer",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {
@@ -2995,10 +2919,6 @@
             "named": true
           },
           {
-            "type": "method_call",
-            "named": true
-          },
-          {
             "type": "next",
             "named": true
           },
@@ -3068,10 +2988,6 @@
           },
           {
             "type": "call",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {
@@ -3170,10 +3086,6 @@
           },
           {
             "type": "call",
-            "named": true
-          },
-          {
-            "type": "method_call",
             "named": true
           },
           {

--- a/test/corpus/control-flow.txt
+++ b/test/corpus/control-flow.txt
@@ -48,7 +48,7 @@ end
 ---
 
 (program (until
-  condition: (method_call
+  condition: (call
     method: (identifier)
     arguments: (argument_list (identifier)))
   body: (do)))

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -85,7 +85,7 @@ end
 ---
 
 (program
-  (method_call (identifier) (argument_list (regex (string_content))))
+  (call (identifier) (argument_list (regex (string_content))))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier))))
 
@@ -112,10 +112,10 @@ end
   (method (identifier) (super))
   (method
     (identifier)
-    (method_call (call (identifier) (identifier)) (block (super))))
+    (call (identifier) (identifier) (block (super))))
   (method
     (identifier)
-    (method_call (call (super) (identifier)) (argument_list (identifier) (identifier)))))
+    (call (super) (identifier) (argument_list (identifier) (identifier)))))
 
 ===========================
 method with args
@@ -363,7 +363,7 @@ end
     (superclass (scope_resolution (constant))))
   (class
     (constant)
-    (superclass (method_call (call (scope_resolution (constant) (constant)) (identifier)) (argument_list (identifier))))))
+    (superclass (call (scope_resolution (constant) (constant)) (identifier) (argument_list (identifier))))))
 
 =======================================
 unparenthesized call as superclass
@@ -378,10 +378,9 @@ end
 
 (program (class
   name: (constant)
-  (superclass (method_call
-    method: (call
-      receiver: (constant)
-      method: (identifier))
+  (superclass (call
+    receiver: (constant)
+    method: (identifier)
     arguments: (argument_list
       (symbol)
       (symbol))))))
@@ -408,7 +407,7 @@ end
 
 ---
 
-(program (class (scope_resolution (method_call (identifier) (argument_list)) (constant))))
+(program (class (scope_resolution (call (identifier) (argument_list)) (constant))))
 
 ===============
 singleton class
@@ -513,14 +512,14 @@ end
 
 (program (module (constant)
   (class (constant) (superclass (constant))
-    (method_call (identifier) (argument_list
+    (call (identifier) (argument_list
       (call
         (call
           (scope_resolution (constant) (constant))
           (identifier))
         (identifier))))
 
-    (method_call (identifier) (argument_list (symbol)))
+    (call (identifier) (argument_list (symbol)))
 
     (comment)
     (method (identifier) (identifier))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -15,7 +15,7 @@ puts ::Foo::Bar
     name: (identifier))
   (scope_resolution
     name: (constant))
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list
       (scope_resolution
@@ -173,16 +173,15 @@ defined?(@äö).should be_true
 ---
 
 (program
-  (unary (identifier))
-  (unary (call (constant) (identifier)))
-  (unary (parenthesized_statements (identifier)))
-  (unary (parenthesized_statements (global_variable)))
-  (unary (parenthesized_statements (instance_variable)))
-  (method_call
-    (call
-      (unary (parenthesized_statements (instance_variable)))
-      (identifier))
-    (argument_list (identifier))))
+  (unary operand: (identifier))
+  (unary operand: (call receiver: (constant) method: (identifier)))
+  (unary operand: (parenthesized_statements (identifier)))
+  (unary operand: (parenthesized_statements (global_variable)))
+  (unary operand: (parenthesized_statements (instance_variable)))
+  (call
+    receiver: (unary operand: (parenthesized_statements (instance_variable)))
+    method: (identifier)
+    arguments: (argument_list (identifier))))
 
 ==========
 assignment
@@ -271,10 +270,10 @@ x = foo a, :b => 1, :c => 2
 
 (program
   (assignment (identifier)
-    (method_call (identifier)
+    (call (identifier)
       (argument_list (identifier) (identifier))))
   (assignment (identifier)
-    (method_call (identifier)
+    (call (identifier)
       (argument_list (identifier) (pair (symbol) (integer)) (pair (symbol) (integer))))))
 
 ==========
@@ -296,7 +295,7 @@ puts "/hi"
   (operator_assignment (identifier) (identifier))
   (operator_assignment (identifier) (identifier))
   (operator_assignment (identifier) (identifier))
-  (method_call (identifier) (argument_list (string (string_content)))))
+  (call (identifier) (argument_list (string (string_content)))))
 
 ==========
 operator assignment
@@ -529,8 +528,8 @@ foo(-a, bar)
 
 (program
   (unary (identifier))
-  (method_call (identifier) (argument_list (unary (identifier)) (identifier)))
-  (method_call (identifier) (argument_list (unary (identifier)) (identifier))))
+  (call (identifier) (argument_list (unary (identifier)) (identifier)))
+  (call (identifier) (argument_list (unary (identifier)) (identifier))))
 
 ===========
 binary minus
@@ -578,13 +577,13 @@ print("hello")
 
 (program
   (identifier)
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list))
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list (string (string_content))))
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list (string (string_content)))))
 
@@ -598,18 +597,18 @@ puts(get_name self, true)
 ---
 
 (program
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list
-      (method_call
+      (call
         method: (identifier)
         arguments: (argument_list
           (self)
           (true)))))
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list
-      (method_call
+      (call
         method: (identifier)
         arguments: (argument_list
           (self)
@@ -625,7 +624,7 @@ foo a,
 ---
 
 (program
-  (method_call
+  (call
     method: (identifier)
     arguments: (argument_list (identifier) (identifier) (identifier))))
 
@@ -639,8 +638,8 @@ foo(bar(a),)
 ---
 
 (program
-  (method_call (identifier) (argument_list (identifier) (identifier)))
-  (method_call (identifier) (argument_list (method_call (identifier) (argument_list (identifier))))))
+  (call (identifier) (argument_list (identifier) (identifier)))
+  (call (identifier) (argument_list (call (identifier) (argument_list (identifier))))))
 
 ==============================================
 keyword arguments, no space, trailing comma
@@ -655,11 +654,11 @@ foo(a2:b,)
 ---
 
 (program
-  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
-  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
-  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
-  (method_call (identifier) (argument_list (pair (symbol) (identifier))))
-  (method_call (identifier) (argument_list (pair (symbol) (identifier)))))
+  (call (identifier) (argument_list (pair (symbol) (identifier))))
+  (call (identifier) (argument_list (pair (symbol) (identifier))))
+  (call (identifier) (argument_list (pair (symbol) (identifier))))
+  (call (identifier) (argument_list (pair (symbol) (identifier))))
+  (call (identifier) (argument_list (pair (symbol) (identifier)))))
 
 ===============================
 method call with receiver
@@ -678,30 +677,25 @@ foo.bar("hi", 2)
   (call
     receiver: (identifier)
     method: (identifier))
-  (method_call
-    method: (call
-      receiver: (identifier)
-      method: (identifier))
+  (call
+    receiver: (identifier)
+    method: (identifier)
     arguments: (argument_list))
-  (method_call
-    method: (call
-      receiver: (identifier)
-      method: (identifier))
+  (call
+    receiver: (identifier)
+    method: (identifier)
     arguments: (argument_list (string (string_content))))
-  (method_call
-    method: (call
-      receiver: (identifier)
-      method: (identifier))
+  (call
+    receiver: (identifier)
+    method: (identifier)
     arguments: (argument_list (string (string_content)) (integer)))
-  (method_call
-    method: (call
-      receiver: (identifier)
-      method: (identifier))
+  (call
+    receiver: (identifier)
+    method: (identifier)
     arguments: (argument_list (string (string_content))))
-  (method_call
-    method: (call
-      receiver: (identifier)
-      method: (identifier))
+  (call
+    receiver: (identifier)
+    method: (identifier)
     arguments: (argument_list (string (string_content)) (integer))))
 
 ===============================
@@ -714,8 +708,12 @@ foo.(1, 2)
 ---
 
 (program
-  (call (element_reference (identifier) (identifier)) (argument_list))
-  (call (identifier) (argument_list (integer) (integer))))
+  (call
+    receiver: (element_reference object: (identifier) (identifier))
+    method: (argument_list))
+  (call
+    receiver: (identifier)
+    method: (argument_list (integer) (integer))))
 
 ===============================
 implicit call with block
@@ -729,16 +727,14 @@ end
 ---
 
 (program
-  (method_call
-    (call
-      (identifier)
-      (argument_list))
-    (block))
-  (method_call
-    (call
-      (identifier)
-      (argument_list (pair (symbol) (identifier))))
-    (do_block (identifier))))
+  (call
+    receiver: (identifier)
+    method: (argument_list)
+    block: (block))
+  (call
+    receiver: (identifier)
+    method: (argument_list (pair key: (symbol) value: (identifier)))
+    block: (do_block (identifier))))
 
 ===============================
 call with operator method name
@@ -748,7 +744,11 @@ foo.[]()
 
 ---
 
-(program (method_call (call (identifier) (operator)) (argument_list)))
+(program
+  (call
+    receiver: (identifier)
+    method: (operator)
+    arguments: (argument_list)))
 
 ===============================
 method call with safe navigation operator
@@ -770,17 +770,18 @@ calls to methods on negated literals
 ---
 
 (program
-  (method_call
-    (call
-      (call (unary (integer)) (identifier))
-      (identifier))
-    (argument_list
-      (method_call
-        (identifier)
-        (argument_list (constant)))))
   (call
-    (unary (float))
-    (identifier)))
+    receiver: (call
+      receiver: (unary operand: (integer))
+      method: (identifier))
+    method: (identifier)
+    arguments: (argument_list
+  (call
+    method: (identifier)
+    arguments: (argument_list (constant)))))
+  (call
+    receiver: (unary operand: (float))
+    method: (identifier)))
 
 ===============================
 method call with hash args
@@ -794,10 +795,10 @@ foo :a => true, :c => 1
 ---
 
 (program
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (array) (integer))))
-  (method_call (identifier) (argument_list (pair (identifier) (integer))))
-  (method_call (identifier) (argument_list (pair (symbol) (true)) (pair (symbol) (integer)))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (array) (integer))))
+  (call (identifier) (argument_list (pair (identifier) (integer))))
+  (call (identifier) (argument_list (pair (symbol) (true)) (pair (symbol) (integer)))))
 
 ===============================
 method call with keyword args
@@ -810,9 +811,9 @@ foo B: true
 ---
 
 (program
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true)))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true)))))
 
 ===============================
 method call with reserved keyword args
@@ -859,43 +860,43 @@ foo yield: true
 ---
 
 (program
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true))))
-  (method_call (identifier) (argument_list (pair (symbol) (true)))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (symbol) (true)))))
 
 ===============================
 method call with paren args
@@ -905,7 +906,7 @@ foo (b), a
 
 ---
 
-(program (method_call (identifier) (argument_list (parenthesized_statements (identifier)) (identifier))))
+(program (call (identifier) (argument_list (parenthesized_statements (identifier)) (identifier))))
 
 ===============================
 method call with block argument
@@ -920,11 +921,11 @@ foo &bar, 1
 ---
 
 (program
-  (method_call (identifier) (argument_list (block_argument (symbol))))
-  (method_call (identifier) (argument_list (block_argument (identifier))))
-  (method_call (identifier) (argument_list (block_argument (identifier)) (integer)))
-  (method_call (identifier) (argument_list (block_argument (identifier))))
-  (method_call (identifier) (argument_list (block_argument (identifier)) (integer))))
+  (call (identifier) (argument_list (block_argument (symbol))))
+  (call (identifier) (argument_list (block_argument (identifier))))
+  (call (identifier) (argument_list (block_argument (identifier)) (integer)))
+  (call (identifier) (argument_list (block_argument (identifier))))
+  (call (identifier) (argument_list (block_argument (identifier)) (integer))))
 
 ===============================
 method call with splat argument
@@ -938,10 +939,10 @@ foo *(bar.baz)
 ---
 
 (program
-  (method_call (identifier) (argument_list (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (string_array (bare_string (string_content)) (bare_string (string_content))))))
-  (method_call (identifier) (argument_list (splat_argument (parenthesized_statements (call (identifier) (identifier)))))))
+  (call (identifier) (argument_list (splat_argument (identifier))))
+  (call (identifier) (argument_list (splat_argument (identifier))))
+  (call (identifier) (argument_list (splat_argument (string_array (bare_string (string_content)) (bare_string (string_content))))))
+  (call (identifier) (argument_list (splat_argument (parenthesized_statements (call (identifier) (identifier)))))))
 
 ===============================
 method call lambda argument
@@ -953,16 +954,16 @@ foo :bar, -> (a) { where(:c => b) }
 ---
 
 (program
-  (method_call (identifier)
+  (call (identifier)
     (argument_list
       (symbol)
       (lambda (lambda_parameters (identifier)) (block (integer)))))
-  (method_call (identifier)
+  (call (identifier)
     (argument_list
       (symbol)
       (lambda
         (lambda_parameters (identifier))
-        (block (method_call (identifier) (argument_list (pair (symbol) (identifier)))))))))
+        (block (call (identifier) (argument_list (pair (symbol) (identifier)))))))))
 
 ===============================
 method call lambda argument and do block
@@ -974,7 +975,7 @@ end
 ---
 
 (program
-  (method_call (identifier)
+  (call (identifier)
     (argument_list (symbol) (lambda (lambda_parameters (identifier)) (block (integer))))
     (do_block)))
 
@@ -993,28 +994,25 @@ end
 ---
 
 (program
-  (method_call
-    method: (call
-      receiver: (method_call
-        method: (call
-          receiver: (identifier)
-          method: (identifier))
-        arguments: (argument_list
-          (identifier)
-          (splat_argument (identifier)))
-        block: (do_block
-          parameters: (block_parameters (identifier))
-          (identifier)))
-      method: (identifier))
+  (call
+    receiver: (call
+      receiver: (identifier)
+      method: (identifier)
+      arguments: (argument_list
+        (identifier)
+        (splat_argument (identifier)))
+      block: (do_block
+        parameters: (block_parameters (identifier))
+        (identifier)))
+    method: (identifier)
     arguments: (argument_list
-      (method_call
-        method: (call
-          receiver: (method_call
-            method: (identifier)
-            block: (block
-              parameters: (block_parameters (identifier))
-              (identifier)))
-          method: (identifier))
+      (call
+        receiver: (call
+          method: (identifier)
+          block: (block
+            parameters: (block_parameters (identifier))
+            (identifier)))
+        method: (identifier)
         block: (do_block (identifier))))))
 
 ===============================
@@ -1030,13 +1028,13 @@ one two or
 (program
   (binary
     left: (binary
-      left: (method_call
+      left: (call
         method: (identifier)
         arguments: (argument_list (identifier)))
-      right: (method_call
+      right: (call
         method: (identifier)
         arguments: (argument_list (identifier) (identifier))))
-    right: (method_call
+    right: (call
       method: (identifier)
       arguments: (argument_list (identifier) (identifier) (identifier)))))
 
@@ -1050,10 +1048,9 @@ method calls in unary expression
 
 (program
   (unary
-    operand: (method_call
-      method: (call
-        receiver: (identifier)
-        method: (identifier))
+    operand: (call
+      receiver: (identifier)
+      method: (identifier)
       arguments: (argument_list (identifier)))))
 
 ===============================
@@ -1069,11 +1066,11 @@ foo(**baz)
 ---
 
 (program
-  (method_call (identifier) (argument_list (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (call (array (identifier) (identifier)) (identifier)))))
-  (method_call (identifier) (argument_list (identifier) (splat_argument (identifier))))
-  (method_call (identifier) (argument_list (splat_argument (call (identifier) (identifier)))))
-  (method_call (identifier) (argument_list (hash_splat_argument (identifier)))))
+  (call (identifier) (argument_list (splat_argument (identifier))))
+  (call (identifier) (argument_list (splat_argument (call (array (identifier) (identifier)) (identifier)))))
+  (call (identifier) (argument_list (identifier) (splat_argument (identifier))))
+  (call (identifier) (argument_list (splat_argument (call (identifier) (identifier)))))
+  (call (identifier) (argument_list (hash_splat_argument (identifier)))))
 
 ============================
 method call without parens
@@ -1083,7 +1080,7 @@ include D::E.f
 
 ---
 
-(program (method_call (identifier) (argument_list (call (scope_resolution (constant) (constant)) (identifier)))))
+(program (call (identifier) (argument_list (call (scope_resolution (constant) (constant)) (identifier)))))
 
 ============================
 method call with line break
@@ -1139,31 +1136,44 @@ end
 ---
 
 (program
-  (method_call
+  (call
+    method: (identifier)
+    block: (do_block
+      parameters: (block_parameters (identifier))
     (identifier)
-    (do_block
-      (block_parameters (identifier))
-        (identifier)
-      (rescue (exceptions (constant)) (then
-        (identifier)))
+      (rescue
+        exceptions: (exceptions (constant))
+        body: (then (identifier)))
       (ensure
         (identifier))))
-  (method_call
-    (identifier)
-    (do_block (block_parameters (identifier)) (identifier)))
-  (method_call (identifier) (do_block))
-  (method_call
-    (identifier)
-    (argument_list (identifier))
-    (do_block (block_parameters (identifier)) (identifier)))
-  (method_call
-    (call (identifier) (identifier))
-    (argument_list (identifier))
-    (do_block (block_parameters (identifier)) (identifier)))
-  (method_call
-    (identifier)
-    (argument_list (identifier))
-    (do_block (block_parameters (keyword_parameter (identifier) (identifier)) (splat_parameter (identifier))))))
+  (call
+    method: (identifier)
+    block: (do_block
+      parameters: (block_parameters (identifier))
+      (identifier)))
+  (call method: (identifier) block: (do_block))
+  (call
+    method: (identifier)
+    arguments: (argument_list (identifier))
+    block: (do_block
+      parameters: (block_parameters (identifier))
+      (identifier)))
+  (call
+    receiver: (identifier)
+    method: (identifier)
+    arguments: (argument_list (identifier))
+    block: (do_block
+      parameters: (block_parameters (identifier))
+      (identifier)))
+  (call
+    method: (identifier)
+    arguments: (argument_list (identifier))
+    block: (do_block
+      parameters: (block_parameters
+        (keyword_parameter
+          name: (identifier)
+          value: (identifier))
+        (splat_parameter name: (identifier))))))
 
 ===============================
 method call with block argument curly
@@ -1176,15 +1186,23 @@ foo(bar, baz) { quux }
 ---
 
 (program
-  (method_call (identifier) (block (block_parameters (identifier)) (identifier)))
-  (method_call (identifier) (argument_list (method_call
-    (call (identifier) (identifier))
-    (block (block_parameters (identifier)) (binary (identifier) (integer))))))
-
-  (method_call
-    (identifier)
-    (argument_list (identifier) (identifier))
-    (block (identifier))))
+  (call
+    method: (identifier)
+    block: (block
+      parameters: (block_parameters (identifier))
+      (identifier)))
+  (call
+    method: (identifier)
+    arguments: (argument_list (call
+      receiver: (identifier)
+      method: (identifier)
+      block: (block
+        parameters: (block_parameters (identifier))
+        (binary left: (identifier) right: (integer))))))
+  (call
+    method: (identifier)
+    arguments: (argument_list (identifier) (identifier))
+    block: (block (identifier))))
 
 ===============================
 method call with block shadow arguments
@@ -1194,7 +1212,7 @@ foo { |; i, j| }
 
 ---
 
-(program (method_call (identifier) (block (block_parameters (identifier) (identifier)))))
+(program (call (identifier) (block (block_parameters (identifier) (identifier)))))
 
 ===============================
 method call with capitalized name
@@ -1231,7 +1249,7 @@ end
     (method_parameters (identifier) (splat_parameter (identifier)) (destructured_parameter (identifier) (identifier))))
   (method (identifier)
     (method_parameters (identifier) (splat_parameter (identifier)) (destructured_parameter (identifier) (identifier))))
-  (method_call (identifier) (do_block
+  (call (identifier) (do_block
     (block_parameters
       (identifier)
       (destructured_parameter (identifier) (identifier) (splat_parameter (identifier)) (destructured_parameter (identifier) (identifier)))
@@ -1248,8 +1266,8 @@ foo[1]
 ---
 
 (program
-  (method_call (identifier) (argument_list (array)))
-  (method_call (identifier) (argument_list (array (integer))))
+  (call (identifier) (argument_list (array)))
+  (call (identifier) (argument_list (array (integer))))
   (element_reference (identifier) (integer)))
 
 ==============
@@ -1260,7 +1278,7 @@ lambda {}
 
 ---
 
-(program (method_call (identifier) (block)))
+(program (call (identifier) (block)))
 
 ==================
 lambda expressions
@@ -1273,9 +1291,9 @@ lambda(&lambda{})
 ---
 
 (program
-  (method_call (identifier) (block (identifier)))
-  (method_call (identifier) (argument_list (block_argument (identifier))) (block (identifier)))
-  (method_call (identifier) (argument_list (block_argument (method_call (identifier) (block))))))
+  (call (identifier) (block (identifier)))
+  (call (identifier) (argument_list (block_argument (identifier))) (block (identifier)))
+  (call (identifier) (argument_list (block_argument (call (identifier) (block))))))
 
 ====================
 lambda expression with an arg
@@ -1285,7 +1303,7 @@ lambda { |foo| 1 }
 
 ---
 
-(program (method_call (identifier) (block (block_parameters (identifier)) (integer))))
+(program (call (identifier) (block (block_parameters (identifier)) (integer))))
 
 ===========================
 lambda expression with multiple args
@@ -1298,7 +1316,7 @@ lambda { |a, b, c|
 
 ---
 
-(program (method_call (identifier) (block (block_parameters (identifier) (identifier) (identifier)) (integer) (integer))))
+(program (call (identifier) (block (block_parameters (identifier) (identifier) (identifier)) (integer) (integer))))
 
 ===========================
 lambda expression with trailing comma
@@ -1310,7 +1328,7 @@ lambda { |a, b,|
 
 ---
 
-(program (method_call (identifier) (block (block_parameters (identifier) (identifier)) (integer))))
+(program (call (identifier) (block (block_parameters (identifier) (identifier)) (integer))))
 
 ===========================
 lambda expression with optional arg
@@ -1322,7 +1340,7 @@ lambda { |a, b=nil|
 
 ---
 
-(program (method_call (identifier) (block (block_parameters (identifier) (optional_parameter (identifier) (nil))) (integer))))
+(program (call (identifier) (block (block_parameters (identifier) (optional_parameter (identifier) (nil))) (integer))))
 
 ===========================
 lambda expression with keyword arg
@@ -1334,7 +1352,7 @@ lambda { |a, b: nil|
 
 ---
 
-(program (method_call
+(program (call
   (identifier)
   (block (block_parameters (identifier) (keyword_parameter (identifier) (nil))) (integer))))
 
@@ -1348,7 +1366,7 @@ end
 
 ---
 
-(program (method_call (identifier) (do_block (block_parameters (identifier)) (integer))))
+(program (call (identifier) (do_block (block_parameters (identifier)) (integer))))
 
 ============================
 lambda and proc as variables
@@ -1362,8 +1380,8 @@ proc = proc {}
 
 (program
   (assignment (identifier) (call (constant) (identifier)))
-  (assignment (identifier) (method_call (identifier) (block)))
-  (assignment (identifier) (method_call (identifier) (block))))
+  (assignment (identifier) (call (identifier) (block)))
+  (assignment (identifier) (call (identifier) (block))))
 
 ===============================
 backslash-newline as line continuation
@@ -1381,11 +1399,11 @@ foo \
 ---
 
 (program
-  (method_call
+  (call
     (identifier)
     (argument_list (identifier) (identifier)))
   (string (string_content) (escape_sequence) (string_content))
-  (method_call
+  (call
     (identifier)
     (argument_list (string (string_content)))))
 
@@ -1412,10 +1430,12 @@ Time.at(timestamp/1000)
 ---
 
 (program
-  (binary (identifier) (identifier)) (string (interpolation (identifier)))
-  (method_call
-    (call (constant) (identifier))
-    (argument_list (binary (identifier) (integer))))
+  (binary left: (identifier) right: (identifier))
+  (string (interpolation (identifier)))
+  (call
+    receiver: (constant)
+    method: (identifier)
+    arguments: (argument_list (binary left: (identifier) right: (integer))))
   (string (interpolation (identifier))))
 
 ===============================
@@ -1427,7 +1447,7 @@ foo /bar/
 ---
 
 (program
-  (method_call (identifier) (argument_list (regex (string_content)))))
+  (call (identifier) (argument_list (regex (string_content)))))
 
 ===============================
 regex with opening space

--- a/test/corpus/line-endings.txt
+++ b/test/corpus/line-endings.txt
@@ -8,8 +8,8 @@ x = foo()
 ---
 
 (program
-  (method_call (identifier) (argument_list (string (string_content))))
-  (assignment (identifier) (method_call (identifier) (argument_list))))
+  (call (identifier) (argument_list (string (string_content))))
+  (assignment (identifier) (call (identifier) (argument_list))))
 
 =======================
 CRLF multiline comments

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -586,7 +586,7 @@ foo("%s '%s' " %
 ----
 
 (program
-  (method_call
+  (call
     (identifier)
     (argument_list
       (binary
@@ -622,7 +622,7 @@ foo(?/)
   (character)
   (character)
   (character)
-  (method_call (identifier) (argument_list (character))))
+  (call (identifier) (argument_list (character))))
 
 ========================================
 nested strings with different delimiters
@@ -736,7 +736,7 @@ end
 ---
 
 (program (method (identifier)
-  (method_call (identifier) (argument_list (heredoc_beginning)))
+  (call (identifier) (argument_list (heredoc_beginning)))
   (heredoc_body (heredoc_content) (heredoc_end))))
 
 ========================================
@@ -750,14 +750,13 @@ SQL
 
 ---
 
-(program (method_call
-  (call
-    (method_call
-      (identifier)
-      (argument_list (heredoc_beginning)))
+(program (call
+  receiver: (call
+    method: (identifier)
+    arguments: (argument_list (heredoc_beginning)))
     (heredoc_body (heredoc_content) (heredoc_end))
-    (identifier))
-  (argument_list)))
+  method: (identifier)
+  arguments: (argument_list)))
 
 ========================================
 heredocs with suffix dot method continuation
@@ -771,12 +770,13 @@ where("a")
 ---
 
 (program
-  (method_call
-    (call
-      (method_call (identifier) (argument_list (heredoc_beginning)))
-      (heredoc_body (heredoc_content) (heredoc_end))
-      (identifier))
-    (argument_list (string (string_content)))))
+  (call
+    receiver: (call
+      method: (identifier)
+      arguments: (argument_list (heredoc_beginning)))
+    (heredoc_body (heredoc_content) (heredoc_end))
+    method: (identifier)
+    arguments: (argument_list (string (string_content)))))
 
 ========================================
 multiple heredocs with method continuation
@@ -792,13 +792,16 @@ group("b")
 ---
 
 (program
-  (method_call
-    (call
-      (method_call
-        (call (method_call (identifier) (argument_list (heredoc_beginning))) (identifier))
-        (argument_list (heredoc_beginning)))
-      (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_body (heredoc_content) (heredoc_end)) (identifier))
-    (argument_list (string (string_content)))))
+  (call
+    receiver: (call
+      receiver: (call
+        method: (identifier)
+        arguments: (argument_list (heredoc_beginning)))
+      method: (identifier)
+      arguments: (argument_list (heredoc_beginning)))
+      (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_body (heredoc_content) (heredoc_end))
+    method: (identifier)
+    arguments: (argument_list (string (string_content)))))
 
 ========================================
 heredocs with interpolation
@@ -832,7 +835,7 @@ return
     (heredoc_content) (interpolation (if_modifier (identifier) (identifier))) (heredoc_content)
     (interpolation
       (comment)
-      (call (method_call (identifier) (argument_list (integer) (identifier))) (identifier)))
+      (call (call (identifier) (argument_list (integer) (identifier))) (identifier)))
     (heredoc_content) (heredoc_end))
   (return))
 
@@ -876,22 +879,23 @@ foo[
 ---
 
 (program
-  (method_call
-    (call (identifier) (identifier))
-    (argument_list
-      (pair (symbol) (heredoc_beginning))
+  (call
+    receiver: (identifier)
+    method: (identifier)
+    arguments: (argument_list
+      (pair key: (symbol) value: (heredoc_beginning))
       (heredoc_body (heredoc_content) (heredoc_end))
-      (pair (symbol) (heredoc_beginning))
+      (pair key: (symbol) value: (heredoc_beginning))
       (heredoc_body (heredoc_content) (heredoc_end))))
   (hash
-    (pair (symbol) (heredoc_beginning))
+    (pair key: (symbol) value: (heredoc_beginning))
     (heredoc_body (heredoc_content) (heredoc_end))
-    (pair (symbol) (heredoc_beginning))
+    (pair key: (symbol) value: (heredoc_beginning))
     (heredoc_body (heredoc_content) (heredoc_end)))
   (array (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
   (assignment
-    (element_reference (identifier) (integer) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
-    (integer)))
+    left: (element_reference object: (identifier) (integer) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
+    right: (integer)))
 
 ==============================================================
 heredocs with method calls and interpolation with method calls
@@ -905,14 +909,19 @@ foo(<<-STR.strip_heredoc.tr()
 ---
 
 (program
-  (method_call
-    (identifier)
-    (argument_list
-      (method_call
-        (call (call (heredoc_beginning) (identifier)) (identifier))
-        (argument_list))
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (call
+        receiver: (call receiver: (heredoc_beginning) method: (identifier))
+        method: (identifier)
+        arguments: (argument_list))
       (heredoc_body (heredoc_content)
-        (interpolation (call (method_call (identifier) (argument_list)) (identifier)))
+        (interpolation (call
+          receiver: (call
+            method: (identifier)
+            arguments: (argument_list))
+          method: (identifier)))
         (heredoc_content) (heredoc_end)))))
 
 ========================================
@@ -928,7 +937,7 @@ TWO
 ---
 
 (program
-  (method_call
+  (call
     (identifier)
     (argument_list
       (call (heredoc_beginning) (identifier))
@@ -950,7 +959,7 @@ heredoc content that starts with a dot
 
 (program
   (lambda (block
-    (method_call
+    (call
       (identifier)
       (argument_list (heredoc_beginning)))
     (heredoc_body (heredoc_content) (heredoc_end)))))
@@ -1026,8 +1035,12 @@ array as object
 
 ---
 (program
-  (method_call (call (array (integer) (integer)) (identifier))
-    (block (block_parameters (identifier)) (binary (identifier) (integer)))))
+  (call
+    receiver: (array (integer) (integer))
+    method: (identifier)
+    block: (block
+      parameters: (block_parameters (identifier))
+      (binary left: (identifier) right: (integer)))))
 
 =========================
 array with trailing comma

--- a/test/corpus/single-cr-as-whitespace.rb
+++ b/test/corpus/single-cr-as-whitespace.rb
@@ -6,4 +6,4 @@ puts"hi"
 
 ---
 
-(program (method_call (identifier) (argument_list (string (string_content)))))
+(program (call (identifier) (argument_list (string (string_content)))))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -18,7 +18,7 @@ return nil if foo
     (false))
   (if_modifier
     (return (argument_list (true)))
-    (method_call (identifier) (argument_list (identifier))))
+    (call (identifier) (argument_list (identifier))))
   (if_modifier
     (return (argument_list (nil)))
     (identifier)))


### PR DESCRIPTION
For example, given the following two expressions, the resulting parse trees are much more similar now.
```ruby
foo.bar
foo.bar()
```

Before these changes:
```bash
(program [0, 0] - [2, 0]
  (call [0, 0] - [0, 7]
    receiver: (identifier [0, 0] - [0, 3])
    method: (identifier [0, 4] - [0, 7]))
  (method_call [1, 0] - [1, 9]
    method: (call [1, 0] - [1, 7]
      receiver: (identifier [1, 0] - [1, 3])
      method: (identifier [1, 4] - [1, 7]))
    arguments: (argument_list [1, 7] - [1, 9])))
```

After these changes:
```bash
(program [0, 0] - [2, 0]
  (call [0, 0] - [0, 7]
    receiver: (identifier [0, 0] - [0, 3])
    method: (identifier [0, 4] - [0, 7]))
  (call [1, 0] - [1, 9]
    receiver: (identifier [1, 0] - [1, 3])
    method: (identifier [1, 4] - [1, 7])
    arguments: (argument_list [1, 7] - [1, 9])))
```

I noticed while making these changes that the `method` field on `_call` and `_chained_command_call` can be an `argument_list`. I'm not convinced that's right, and you can see it gives strange results in the tests for implicit calls, but the behaviour wasn't introduced by this PR.
https://github.com/nickrolfe/tree-sitter-ruby/blob/9bb2b6ab5b6e015c61a0c205843795d15c7f535f/test/corpus/expressions.txt#L711-L713