### PR TITLE
for-loop pattern improvements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -287,11 +287,7 @@ module.exports = grammar({
 
     for: $ => seq(
       'for',
-      commaSep1(field('pattern', choice(
-        $._lhs,
-        $.rest_assignment,
-        $.destructured_left_assignment
-      ))),
+      field('pattern', choice($._lhs, $.left_assignment_list)),
       field('value', $.in),
       field('body', $.do)
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1303,63 +1303,21 @@
           "value": "for"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "pattern",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_lhs"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "rest_assignment"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "destructured_left_assignment"
-                  }
-                ]
+          "type": "FIELD",
+          "name": "pattern",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_lhs"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "left_assignment_list"
               }
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "pattern",
-                    "content": {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "SYMBOL",
-                          "name": "_lhs"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "rest_assignment"
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "destructured_left_assignment"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
-            }
-          ]
+            ]
+          }
         },
         {
           "type": "FIELD",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1477,7 +1477,7 @@
         ]
       },
       "pattern": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
@@ -1485,11 +1485,7 @@
             "named": true
           },
           {
-            "type": "destructured_left_assignment",
-            "named": true
-          },
-          {
-            "type": "rest_assignment",
+            "type": "left_assignment_list",
             "named": true
           }
         ]

--- a/test/corpus/control-flow.txt
+++ b/test/corpus/control-flow.txt
@@ -201,7 +201,15 @@ for x in y do
 	f
 end
 
+for x, in y
+	f
+end
+
 for x, *y in z do
+	f
+end
+
+for (k, v) in y do
 	f
 end
 
@@ -213,8 +221,21 @@ end
     value: (in (identifier))
     body: (do (identifier)))
   (for
-    pattern: (identifier)
-    pattern: (rest_assignment (identifier))
+    pattern: (left_assignment_list
+      (identifier))
+    value: (in (identifier))
+    body: (do (identifier)))
+  (for
+    pattern: (left_assignment_list
+      (identifier)
+      (rest_assignment (identifier)))
+    value: (in (identifier))
+    body: (do (identifier)))
+  (for
+    pattern: (left_assignment_list
+      (destructured_left_assignment
+        (identifier)
+        (identifier)))
     value: (in (identifier))
     body: (do (identifier))))
 


### PR DESCRIPTION
Trailing commas (accepted by MRI) no longer cause parser errors, e.g. in:
```rb
  for x, in 1..10 do
    puts x
  end
```
For the following example, with multiple identifiers *not* surrounded by parentheses, it was awkward (for my needs, anyway) to have multiple pattern nodes without an overall node for the entire `key, value` pattern. Now, there is one.
```rb
  for key, value in my_hash do
  end
```