### PR TITLE
Fix error parsing hash splat arg followed by another arg

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -60,7 +60,9 @@ module.exports = grammar({
     $._binary_minus,
     $._binary_star,
     $._singleton_class_left_angle_left_langle,
-    $._identifier_hash_key
+    $._identifier_hash_key,
+    $._hash_splat_star_star,
+    $._binary_star_star
   ],
 
   extras: $ => [
@@ -559,7 +561,7 @@ module.exports = grammar({
     )),
 
     splat_argument: $ => seq(alias($._splat_star, '*'), $._arg),
-    hash_splat_argument: $ => seq('**', $._arg),
+    hash_splat_argument: $ => seq(alias($._hash_splat_star_star, '**'), $._arg),
     block_argument: $ => seq(alias($._block_ampersand, '&'), $._arg),
 
     do_block: $ => seq(
@@ -638,7 +640,7 @@ module.exports = grammar({
         [prec.left, PREC.ADDITIVE, choice('+', alias($._binary_minus, '-'))],
         [prec.left, PREC.MULTIPLICATIVE, choice('/', '%', alias($._binary_star, '*'))],
         [prec.right, PREC.RELATIONAL, choice('==', '!=', '===', '<=>', '=~', '!~')],
-        [prec.right, PREC.EXPONENTIAL, '**'],
+        [prec.right, PREC.EXPONENTIAL, alias($._binary_star_star, '**')],
       ];
 
       return choice(...operators.map(([fn, precedence, operator]) => fn(precedence, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3104,7 +3104,12 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_hash_splat_star_star"
+          },
+          "named": false,
           "value": "**"
         },
         {
@@ -4101,7 +4106,12 @@
                 "type": "FIELD",
                 "name": "operator",
                 "content": {
-                  "type": "STRING",
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_binary_star_star"
+                  },
+                  "named": false,
                   "value": "**"
                 }
               },
@@ -6062,6 +6072,14 @@
     {
       "type": "SYMBOL",
       "name": "_identifier_hash_key"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_hash_splat_star_star"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_binary_star_star"
     }
   ],
   "inline": [],

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -36,6 +36,8 @@ enum TokenType {
   BINARY_STAR,
   SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE,
   IDENTIFIER_HASH_KEY,
+  HASH_SPLAT_STAR_STAR,
+  BINARY_STAR_STAR,
 
   NONE
 };
@@ -773,20 +775,42 @@ struct Scanner {
         break;
 
       case '*':
-        if (valid_symbols[SPLAT_STAR] || valid_symbols[BINARY_STAR]) {
+        if (valid_symbols[SPLAT_STAR] || valid_symbols[BINARY_STAR] ||
+            valid_symbols[HASH_SPLAT_STAR_STAR] || valid_symbols[BINARY_STAR_STAR]) {
           advance(lexer);
-          if (lexer->lookahead == '*' || lexer->lookahead == '=') return false;
-          if (valid_symbols[SPLAT_STAR] && !iswspace(lexer->lookahead)) {
-            lexer->result_symbol = SPLAT_STAR;
-            return true;
-          } else if (valid_symbols[BINARY_STAR]) {
-            lexer->result_symbol = BINARY_STAR;
-            return true;
-          } else if (valid_symbols[SPLAT_STAR]) {
-            lexer->result_symbol = SPLAT_STAR;
-            return true;
+          if (lexer->lookahead == '=') return false;
+          if (lexer->lookahead == '*') {
+            if (valid_symbols[HASH_SPLAT_STAR_STAR] || valid_symbols[BINARY_STAR_STAR]) {
+              advance(lexer);
+              if (lexer->lookahead == '=') return false;
+              if (valid_symbols[HASH_SPLAT_STAR_STAR] && !iswspace(lexer->lookahead)) {
+                lexer->result_symbol = HASH_SPLAT_STAR_STAR;
+                return true;
+              } else if (valid_symbols[BINARY_STAR_STAR]) {
+                lexer->result_symbol = BINARY_STAR_STAR;
+                return true;
+              } else if (valid_symbols[HASH_SPLAT_STAR_STAR]) {
+                lexer->result_symbol = HASH_SPLAT_STAR_STAR;
+                return true;
+              } else  {
+                return false;
+              }
+            } else {
+              return false;
+            }
           } else {
-            return false;
+            if (valid_symbols[SPLAT_STAR] && !iswspace(lexer->lookahead)) {
+              lexer->result_symbol = SPLAT_STAR;
+              return true;
+            } else if (valid_symbols[BINARY_STAR]) {
+              lexer->result_symbol = BINARY_STAR;
+              return true;
+            } else if (valid_symbols[SPLAT_STAR]) {
+              lexer->result_symbol = SPLAT_STAR;
+              return true;
+            } else {
+              return false;
+            }
           }
         }
         break;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1062,6 +1062,7 @@ foo(*[bar, baz].quoz)
 foo(x, *bar)
 foo(*bar.baz)
 foo(**baz)
+foo **bar, baz
 
 ---
 
@@ -1070,7 +1071,8 @@ foo(**baz)
   (call (identifier) (argument_list (splat_argument (call (array (identifier) (identifier)) (identifier)))))
   (call (identifier) (argument_list (identifier) (splat_argument (identifier))))
   (call (identifier) (argument_list (splat_argument (call (identifier) (identifier)))))
-  (call (identifier) (argument_list (hash_splat_argument (identifier)))))
+  (call (identifier) (argument_list (hash_splat_argument (identifier))))
+  (call (identifier) (argument_list (hash_splat_argument (identifier)) (identifier))))
 
 ============================
 method call without parens


### PR DESCRIPTION
```rb
foo **bar, baz
```

This example (now added as a test case) was being incorrectly parsed as a binary `**` operation, followed by some junk, causing errors:

```
(program [0, 0] - [1, 0]
  (binary [0, 0] - [0, 9]
    left: (identifier [0, 0] - [0, 3])
    right: (identifier [0, 6] - [0, 9]))
  (ERROR [0, 9] - [0, 14]
    (identifier [0, 11] - [0, 14])))
```

I mirrored the way regular splat arguments are handled, and now it parses correctly:

```
(program [0, 0] - [1, 0]
  (call [0, 0] - [0, 14]
    method: (identifier [0, 0] - [0, 3])
    arguments: (argument_list [0, 4] - [0, 14]
      (hash_splat_argument [0, 4] - [0, 9]
        (identifier [0, 6] - [0, 9]))
      (identifier [0, 11] - [0, 14]))))
```
