### PR TITLE
Separate symbol aliases into distinct types

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -432,7 +432,7 @@ module.exports = grammar({
       $.hash,
       $.subshell,
       $.simple_symbol,
-      $.string_symbol,
+      $.delimited_symbol,
       $.integer,
       $.float,
       $.complex,
@@ -735,7 +735,7 @@ module.exports = grammar({
       $.constant,
       $.setter,
       $.simple_symbol,
-      $.string_symbol,
+      $.delimited_symbol,
       $.operator,
       $.instance_variable,
       $.class_variable,
@@ -818,7 +818,7 @@ module.exports = grammar({
       alias($._string_end, ')')
     ),
 
-    string_symbol: $ => seq(
+    delimited_symbol: $ => seq(
       alias($._symbol_start, ':"'),
       optional($._literal_contents),
       alias($._string_end, '"')

--- a/grammar.js
+++ b/grammar.js
@@ -38,7 +38,7 @@ module.exports = grammar({
     $._line_break,
 
     // Delimited literals
-    $._simple_symbol,
+    $.simple_symbol,
     $._string_start,
     $._symbol_start,
     $._subshell_start,
@@ -60,7 +60,7 @@ module.exports = grammar({
     $._binary_minus,
     $._binary_star,
     $._singleton_class_left_angle_left_langle,
-    $._identifier_hash_key,
+    $.identifier_hash_key_symbol,
     $._hash_splat_star_star,
     $._binary_star_star
   ],
@@ -431,7 +431,8 @@ module.exports = grammar({
       $.symbol_array,
       $.hash,
       $.subshell,
-      $.symbol,
+      $.simple_symbol,
+      $.string_symbol,
       $.integer,
       $.float,
       $.complex,
@@ -733,7 +734,8 @@ module.exports = grammar({
       $.identifier,
       $.constant,
       $.setter,
-      $.symbol,
+      $.simple_symbol,
+      $.string_symbol,
       $.operator,
       $.instance_variable,
       $.class_variable,
@@ -816,11 +818,11 @@ module.exports = grammar({
       alias($._string_end, ')')
     ),
 
-    symbol: $ => choice($._simple_symbol, seq(
+    string_symbol: $ => seq(
       alias($._symbol_start, ':"'),
       optional($._literal_contents),
       alias($._string_end, '"')
-    )),
+    ),
 
     regex: $ => seq(
       alias($._regex_start, '/'),
@@ -879,9 +881,9 @@ module.exports = grammar({
       ),
       seq(
         field('key', choice(
-          alias($._identifier_hash_key, $.symbol),
-          alias($.identifier, $.symbol),
-          alias($.constant, $.symbol),
+          $.identifier_hash_key_symbol,
+          alias($.identifier, $.identifier_hash_key_symbol),
+          alias($.constant, $.identifier_hash_key_symbol),
           $.string
         )),
         token.immediate(':'),

--- a/grammar.js
+++ b/grammar.js
@@ -60,7 +60,7 @@ module.exports = grammar({
     $._binary_minus,
     $._binary_star,
     $._singleton_class_left_angle_left_langle,
-    $.identifier_hash_key_symbol,
+    $.hash_key_symbol,
     $._hash_splat_star_star,
     $._binary_star_star
   ],
@@ -881,9 +881,9 @@ module.exports = grammar({
       ),
       seq(
         field('key', choice(
-          $.identifier_hash_key_symbol,
-          alias($.identifier, $.identifier_hash_key_symbol),
-          alias($.constant, $.identifier_hash_key_symbol),
+          $.hash_key_symbol,
+          alias($.identifier, $.hash_key_symbol),
+          alias($.constant, $.hash_key_symbol),
           $.string
         )),
         token.immediate(':'),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -95,7 +95,7 @@
 
 [
   (simple_symbol)
-  (string_symbol)
+  (delimited_symbol)
   (identifier_hash_key_symbol)
   (bare_symbol)
 ] @string.special.symbol

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -96,7 +96,7 @@
 [
   (simple_symbol)
   (delimited_symbol)
-  (identifier_hash_key_symbol)
+  (hash_key_symbol)
   (bare_symbol)
 ] @string.special.symbol
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -94,7 +94,9 @@
 ] @string
 
 [
-  (symbol)
+  (simple_symbol)
+  (string_symbol)
+  (identifier_hash_key_symbol)
   (bare_symbol)
 ] @string.special.symbol
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2164,7 +2164,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "symbol"
+          "name": "simple_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_symbol"
         },
         {
           "type": "SYMBOL",
@@ -4894,7 +4898,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "symbol"
+          "name": "simple_symbol"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_symbol"
         },
         {
           "type": "SYMBOL",
@@ -5521,47 +5529,38 @@
         }
       ]
     },
-    "symbol": {
-      "type": "CHOICE",
+    "string_symbol": {
+      "type": "SEQ",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "_simple_symbol"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_symbol_start"
+          },
+          "named": false,
+          "value": ":\""
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_symbol_start"
-              },
-              "named": false,
-              "value": ":\""
+              "type": "SYMBOL",
+              "name": "_literal_contents"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_literal_contents"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "ALIAS",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_string_end"
-              },
-              "named": false,
-              "value": "\""
+              "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_string_end"
+          },
+          "named": false,
+          "value": "\""
         }
       ]
     },
@@ -5834,13 +5833,8 @@
                 "type": "CHOICE",
                 "members": [
                   {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "_identifier_hash_key"
-                    },
-                    "named": true,
-                    "value": "symbol"
+                    "type": "SYMBOL",
+                    "name": "identifier_hash_key_symbol"
                   },
                   {
                     "type": "ALIAS",
@@ -5849,7 +5843,7 @@
                       "name": "identifier"
                     },
                     "named": true,
-                    "value": "symbol"
+                    "value": "identifier_hash_key_symbol"
                   },
                   {
                     "type": "ALIAS",
@@ -5858,7 +5852,7 @@
                       "name": "constant"
                     },
                     "named": true,
-                    "value": "symbol"
+                    "value": "identifier_hash_key_symbol"
                   },
                   {
                     "type": "SYMBOL",
@@ -5991,7 +5985,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_simple_symbol"
+      "name": "simple_symbol"
     },
     {
       "type": "SYMBOL",
@@ -6071,7 +6065,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_identifier_hash_key"
+      "name": "identifier_hash_key_symbol"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5834,7 +5834,7 @@
                 "members": [
                   {
                     "type": "SYMBOL",
-                    "name": "identifier_hash_key_symbol"
+                    "name": "hash_key_symbol"
                   },
                   {
                     "type": "ALIAS",
@@ -5843,7 +5843,7 @@
                       "name": "identifier"
                     },
                     "named": true,
-                    "value": "identifier_hash_key_symbol"
+                    "value": "hash_key_symbol"
                   },
                   {
                     "type": "ALIAS",
@@ -5852,7 +5852,7 @@
                       "name": "constant"
                     },
                     "named": true,
-                    "value": "identifier_hash_key_symbol"
+                    "value": "hash_key_symbol"
                   },
                   {
                     "type": "SYMBOL",
@@ -6065,7 +6065,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "identifier_hash_key_symbol"
+      "name": "hash_key_symbol"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2168,7 +2168,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "string_symbol"
+          "name": "delimited_symbol"
         },
         {
           "type": "SYMBOL",
@@ -4902,7 +4902,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "string_symbol"
+          "name": "delimited_symbol"
         },
         {
           "type": "SYMBOL",
@@ -5529,7 +5529,7 @@
         }
       ]
     },
-    "string_symbol": {
+    "delimited_symbol": {
       "type": "SEQ",
       "members": [
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -80,6 +80,10 @@
         "named": true
       },
       {
+        "type": "delimited_symbol",
+        "named": true
+      },
+      {
         "type": "global_variable",
         "named": true
       },
@@ -101,10 +105,6 @@
       },
       {
         "type": "simple_symbol",
-        "named": true
-      },
-      {
-        "type": "string_symbol",
         "named": true
       }
     ]
@@ -147,6 +147,10 @@
       },
       {
         "type": "complex",
+        "named": true
+      },
+      {
+        "type": "delimited_symbol",
         "named": true
       },
       {
@@ -231,10 +235,6 @@
       },
       {
         "type": "string_array",
-        "named": true
-      },
-      {
-        "type": "string_symbol",
         "named": true
       },
       {
@@ -1147,6 +1147,29 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "delimited_symbol",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "interpolation",
+          "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -2639,29 +2662,6 @@
       "types": [
         {
           "type": "bare_string",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "string_symbol",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "interpolation",
-          "named": true
-        },
-        {
-          "type": "string_content",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2144,7 +2144,7 @@
             "named": true
           },
           {
-            "type": "identifier_hash_key_symbol",
+            "type": "hash_key_symbol",
             "named": true
           },
           {
@@ -3464,6 +3464,10 @@
     "named": true
   },
   {
+    "type": "hash_key_symbol",
+    "named": true
+  },
+  {
     "type": "heredoc_beginning",
     "named": true
   },
@@ -3477,10 +3481,6 @@
   },
   {
     "type": "identifier",
-    "named": true
-  },
-  {
-    "type": "identifier_hash_key_symbol",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -100,7 +100,11 @@
         "named": true
       },
       {
-        "type": "symbol",
+        "type": "simple_symbol",
+        "named": true
+      },
+      {
+        "type": "string_symbol",
         "named": true
       }
     ]
@@ -210,6 +214,10 @@
         "named": true
       },
       {
+        "type": "simple_symbol",
+        "named": true
+      },
+      {
         "type": "singleton_class",
         "named": true
       },
@@ -226,11 +234,11 @@
         "named": true
       },
       {
-        "type": "subshell",
+        "type": "string_symbol",
         "named": true
       },
       {
-        "type": "symbol",
+        "type": "subshell",
         "named": true
       },
       {
@@ -2113,11 +2121,11 @@
             "named": true
           },
           {
-            "type": "string",
+            "type": "identifier_hash_key_symbol",
             "named": true
           },
           {
-            "type": "symbol",
+            "type": "string",
             "named": true
           }
         ]
@@ -2637,6 +2645,29 @@
     }
   },
   {
+    "type": "string_symbol",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        },
+        {
+          "type": "interpolation",
+          "named": true
+        },
+        {
+          "type": "string_content",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "subshell",
     "named": true,
     "fields": {},
@@ -2689,29 +2720,6 @@
         },
         {
           "type": "yield",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "symbol",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": false,
-      "types": [
-        {
-          "type": "escape_sequence",
-          "named": true
-        },
-        {
-          "type": "interpolation",
-          "named": true
-        },
-        {
-          "type": "string_content",
           "named": true
         }
       ]
@@ -3472,6 +3480,10 @@
     "named": true
   },
   {
+    "type": "identifier_hash_key_symbol",
+    "named": true
+  },
+  {
     "type": "if",
     "named": false
   },
@@ -3529,6 +3541,10 @@
   },
   {
     "type": "self",
+    "named": true
+  },
+  {
+    "type": "simple_symbol",
     "named": true
   },
   {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -35,7 +35,7 @@ enum TokenType {
   BINARY_MINUS,
   BINARY_STAR,
   SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE,
-  IDENTIFIER_HASH_KEY,
+  IDENTIFIER_HASH_KEY_SYMBOL,
   HASH_SPLAT_STAR_STAR,
   BINARY_STAR_STAR,
 
@@ -875,7 +875,7 @@ struct Scanner {
     }
 
     // Open delimiters for literals
-    if (valid_symbols[IDENTIFIER_HASH_KEY]
+    if (valid_symbols[IDENTIFIER_HASH_KEY_SYMBOL]
         && (iswalpha(lexer->lookahead) || lexer->lookahead == '_')) {
       while (iswalnum(lexer->lookahead) || lexer->lookahead == '_') {
         advance(lexer);
@@ -885,7 +885,7 @@ struct Scanner {
       if (lexer->lookahead == ':') {
         advance(lexer);
         if (lexer->lookahead != ':') {
-          lexer->result_symbol = IDENTIFIER_HASH_KEY;
+          lexer->result_symbol = IDENTIFIER_HASH_KEY_SYMBOL;
           return true;
         }
       }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -35,7 +35,7 @@ enum TokenType {
   BINARY_MINUS,
   BINARY_STAR,
   SINGLETON_CLASS_LEFT_ANGLE_LEFT_ANGLE,
-  IDENTIFIER_HASH_KEY_SYMBOL,
+  HASH_KEY_SYMBOL,
   HASH_SPLAT_STAR_STAR,
   BINARY_STAR_STAR,
 
@@ -875,7 +875,7 @@ struct Scanner {
     }
 
     // Open delimiters for literals
-    if (valid_symbols[IDENTIFIER_HASH_KEY_SYMBOL]
+    if (valid_symbols[HASH_KEY_SYMBOL]
         && (iswalpha(lexer->lookahead) || lexer->lookahead == '_')) {
       while (iswalnum(lexer->lookahead) || lexer->lookahead == '_') {
         advance(lexer);
@@ -885,7 +885,7 @@ struct Scanner {
       if (lexer->lookahead == ':') {
         advance(lexer);
         if (lexer->lookahead != ':') {
-          lexer->result_symbol = IDENTIFIER_HASH_KEY_SYMBOL;
+          lexer->result_symbol = HASH_KEY_SYMBOL;
           return true;
         }
       }

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -382,8 +382,8 @@ end
     receiver: (constant)
     method: (identifier)
     arguments: (argument_list
-      (symbol)
-      (symbol))))))
+      (simple_symbol)
+      (simple_symbol))))))
 
 ===============
 class with body
@@ -519,7 +519,7 @@ end
           (identifier))
         (identifier))))
 
-    (call (identifier) (argument_list (symbol)))
+    (call (identifier) (argument_list (simple_symbol)))
 
     (comment)
     (method (identifier) (identifier))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -654,11 +654,11 @@ foo(a2:b,)
 ---
 
 (program
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier)))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (identifier)))))
 
 ===============================
 method call with receiver
@@ -733,7 +733,7 @@ end
     block: (block))
   (call
     receiver: (identifier)
-    method: (argument_list (pair key: (identifier_hash_key_symbol) value: (identifier)))
+    method: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
     block: (do_block (identifier))))
 
 ===============================
@@ -811,9 +811,9 @@ foo B: true
 ---
 
 (program
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true)))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true)))))
 
 ===============================
 method call with reserved keyword args
@@ -860,43 +860,43 @@ foo yield: true
 ---
 
 (program
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true)))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true)))))
 
 ===============================
 method call with paren args

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -58,7 +58,7 @@ foo[:bar]
 
 ---
 
-(program (element_reference (identifier) (symbol)))
+(program (element_reference (identifier) (simple_symbol)))
 
 ============
 element assignment
@@ -274,7 +274,7 @@ x = foo a, :b => 1, :c => 2
       (argument_list (identifier) (identifier))))
   (assignment (identifier)
     (call (identifier)
-      (argument_list (identifier) (pair (symbol) (integer)) (pair (symbol) (integer))))))
+      (argument_list (identifier) (pair (simple_symbol) (integer)) (pair (simple_symbol) (integer))))))
 
 ==========
 math assignment
@@ -654,11 +654,11 @@ foo(a2:b,)
 ---
 
 (program
-  (call (identifier) (argument_list (pair (symbol) (identifier))))
-  (call (identifier) (argument_list (pair (symbol) (identifier))))
-  (call (identifier) (argument_list (pair (symbol) (identifier))))
-  (call (identifier) (argument_list (pair (symbol) (identifier))))
-  (call (identifier) (argument_list (pair (symbol) (identifier)))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (identifier)))))
 
 ===============================
 method call with receiver
@@ -733,7 +733,7 @@ end
     block: (block))
   (call
     receiver: (identifier)
-    method: (argument_list (pair key: (symbol) value: (identifier)))
+    method: (argument_list (pair key: (identifier_hash_key_symbol) value: (identifier)))
     block: (do_block (identifier))))
 
 ===============================
@@ -795,10 +795,10 @@ foo :a => true, :c => 1
 ---
 
 (program
-  (call (identifier) (argument_list (pair (symbol) (true))))
+  (call (identifier) (argument_list (pair (simple_symbol) (true))))
   (call (identifier) (argument_list (pair (array) (integer))))
   (call (identifier) (argument_list (pair (identifier) (integer))))
-  (call (identifier) (argument_list (pair (symbol) (true)) (pair (symbol) (integer)))))
+  (call (identifier) (argument_list (pair (simple_symbol) (true)) (pair (simple_symbol) (integer)))))
 
 ===============================
 method call with keyword args
@@ -811,9 +811,9 @@ foo B: true
 ---
 
 (program
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true)))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true)))))
 
 ===============================
 method call with reserved keyword args
@@ -860,43 +860,43 @@ foo yield: true
 ---
 
 (program
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true))))
-  (call (identifier) (argument_list (pair (symbol) (true)))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (identifier_hash_key_symbol) (true)))))
 
 ===============================
 method call with paren args
@@ -921,7 +921,7 @@ foo &bar, 1
 ---
 
 (program
-  (call (identifier) (argument_list (block_argument (symbol))))
+  (call (identifier) (argument_list (block_argument (simple_symbol))))
   (call (identifier) (argument_list (block_argument (identifier))))
   (call (identifier) (argument_list (block_argument (identifier)) (integer)))
   (call (identifier) (argument_list (block_argument (identifier))))
@@ -956,14 +956,14 @@ foo :bar, -> (a) { where(:c => b) }
 (program
   (call (identifier)
     (argument_list
-      (symbol)
+      (simple_symbol)
       (lambda (lambda_parameters (identifier)) (block (integer)))))
   (call (identifier)
     (argument_list
-      (symbol)
+      (simple_symbol)
       (lambda
         (lambda_parameters (identifier))
-        (block (call (identifier) (argument_list (pair (symbol) (identifier)))))))))
+        (block (call (identifier) (argument_list (pair (simple_symbol) (identifier)))))))))
 
 ===============================
 method call lambda argument and do block
@@ -976,7 +976,7 @@ end
 
 (program
   (call (identifier)
-    (argument_list (symbol) (lambda (lambda_parameters (identifier)) (block (integer))))
+    (argument_list (simple_symbol) (lambda (lambda_parameters (identifier)) (block (integer))))
     (do_block)))
 
 ===============================================

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -100,8 +100,8 @@ single quoted symbol
 ---
 
 (program
-  (string_symbol (string_content))
-  (string_symbol (string_content)))
+  (delimited_symbol (string_content))
+  (delimited_symbol (string_content)))
 
 ====================
 double quoted symbol
@@ -112,7 +112,7 @@ double quoted symbol
 
 ---
 
-(program (string_symbol (string_content)) (string_symbol (string_content)))
+(program (delimited_symbol (string_content)) (delimited_symbol (string_content)))
 
 =======================================
 double quoted symbol with interpolation
@@ -122,7 +122,7 @@ double quoted symbol with interpolation
 
 ---
 
-(program (string_symbol (string_content) (interpolation (identifier))))
+(program (delimited_symbol (string_content) (interpolation (identifier))))
 
 =======================================
 interpolation with no content
@@ -132,7 +132,7 @@ interpolation with no content
 
 ---
 
-(program (string_symbol (string_content) (interpolation)))
+(program (delimited_symbol (string_content) (interpolation)))
 
 =========================================
 percent symbol with unbalanced delimiters
@@ -144,7 +144,7 @@ percent symbol with unbalanced delimiters
 
 ---
 
-(program (string_symbol (string_content)) (string_symbol (string_content)) (string_symbol (string_content)))
+(program (delimited_symbol (string_content)) (delimited_symbol (string_content)) (delimited_symbol (string_content)))
 
 =======================================
 percent symbol with balanced delimiters
@@ -157,7 +157,7 @@ percent symbol with balanced delimiters
 
 ---
 
-(program (string_symbol (string_content)) (string_symbol (string_content)) (string_symbol (string_content)) (string_symbol (string_content)))
+(program (delimited_symbol (string_content)) (delimited_symbol (string_content)) (delimited_symbol (string_content)) (delimited_symbol (string_content)))
 
 =======================================
 global variables

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -903,14 +903,14 @@ foo[
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list
-      (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
+      (pair key: (hash_key_symbol) value: (heredoc_beginning))
       (heredoc_body (heredoc_content) (heredoc_end))
-      (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
+      (pair key: (hash_key_symbol) value: (heredoc_beginning))
       (heredoc_body (heredoc_content) (heredoc_end))))
   (hash
-    (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
+    (pair key: (hash_key_symbol) value: (heredoc_beginning))
     (heredoc_body (heredoc_content) (heredoc_end))
-    (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
+    (pair key: (hash_key_symbol) value: (heredoc_beginning))
     (heredoc_body (heredoc_content) (heredoc_end)))
   (array (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
   (assignment
@@ -1256,42 +1256,42 @@ hash with reserved word key
 ---
 
 (program (hash
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))
-  (pair (identifier_hash_key_symbol) (simple_symbol))))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol) (simple_symbol))))
 
 ======================
 hash with keyword keys
@@ -1304,12 +1304,12 @@ hash with keyword keys
 
 (program
   (hash
-    (pair (identifier_hash_key_symbol) (integer))
-    (pair (identifier_hash_key_symbol) (integer))
+    (pair (hash_key_symbol) (integer))
+    (pair (hash_key_symbol) (integer))
     (pair (string (string_content)) (integer)))
   (hash
-    (pair (identifier_hash_key_symbol) (integer))
-    (pair (identifier_hash_key_symbol) (integer))
+    (pair (hash_key_symbol) (integer))
+    (pair (hash_key_symbol) (integer))
     (pair (string (string_content)) (integer))))
 
 ========================
@@ -1320,7 +1320,7 @@ hash with trailing comma
 
 ---
 
-(program (hash (pair (identifier_hash_key_symbol) (integer))))
+(program (hash (pair (hash_key_symbol) (integer))))
 
 ========================
 hash initialization with hash splat
@@ -1331,8 +1331,8 @@ hash initialization with hash splat
 ---
 
 (program (hash
-  (pair (identifier_hash_key_symbol) (integer))
-  (hash_splat_argument (hash (pair (identifier_hash_key_symbol) (integer))))))
+  (pair (hash_key_symbol) (integer))
+  (hash_splat_argument (hash (pair (hash_key_symbol) (integer))))))
 
 ========================
 hash with line breaks and inline comments

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -17,17 +17,17 @@ symbol
 ---
 
 (program
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol))
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol))
 
 ======
 symbol operators
@@ -63,32 +63,32 @@ symbol operators
 ---
 
 (program
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol)
-  (symbol))
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol)
+  (simple_symbol))
 
 ====================
 single quoted symbol
@@ -100,8 +100,8 @@ single quoted symbol
 ---
 
 (program
-  (symbol (string_content))
-  (symbol (string_content)))
+  (string_symbol (string_content))
+  (string_symbol (string_content)))
 
 ====================
 double quoted symbol
@@ -112,7 +112,7 @@ double quoted symbol
 
 ---
 
-(program (symbol (string_content)) (symbol (string_content)))
+(program (string_symbol (string_content)) (string_symbol (string_content)))
 
 =======================================
 double quoted symbol with interpolation
@@ -122,7 +122,7 @@ double quoted symbol with interpolation
 
 ---
 
-(program (symbol (string_content) (interpolation (identifier))))
+(program (string_symbol (string_content) (interpolation (identifier))))
 
 =======================================
 interpolation with no content
@@ -132,7 +132,7 @@ interpolation with no content
 
 ---
 
-(program (symbol (string_content) (interpolation)))
+(program (string_symbol (string_content) (interpolation)))
 
 =========================================
 percent symbol with unbalanced delimiters
@@ -144,7 +144,7 @@ percent symbol with unbalanced delimiters
 
 ---
 
-(program (symbol (string_content)) (symbol (string_content)) (symbol (string_content)))
+(program (string_symbol (string_content)) (string_symbol (string_content)) (string_symbol (string_content)))
 
 =======================================
 percent symbol with balanced delimiters
@@ -157,7 +157,7 @@ percent symbol with balanced delimiters
 
 ---
 
-(program (symbol (string_content)) (symbol (string_content)) (symbol (string_content)) (symbol (string_content)))
+(program (string_symbol (string_content)) (string_symbol (string_content)) (string_symbol (string_content)) (string_symbol (string_content)))
 
 =======================================
 global variables
@@ -593,7 +593,7 @@ flash[:notice] = "Pattern addition failed for '%s' in '%s'", %
 ----
 
 (program (assignment
-  (element_reference (identifier) (symbol))
+  (element_reference (identifier) (simple_symbol))
   (right_assignment_list (string (string_content)) (string (string_content)))))
 
 ==========================
@@ -903,14 +903,14 @@ foo[
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list
-      (pair key: (symbol) value: (heredoc_beginning))
+      (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
       (heredoc_body (heredoc_content) (heredoc_end))
-      (pair key: (symbol) value: (heredoc_beginning))
+      (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
       (heredoc_body (heredoc_content) (heredoc_end))))
   (hash
-    (pair key: (symbol) value: (heredoc_beginning))
+    (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
     (heredoc_body (heredoc_content) (heredoc_end))
-    (pair key: (symbol) value: (heredoc_beginning))
+    (pair key: (identifier_hash_key_symbol) value: (heredoc_beginning))
     (heredoc_body (heredoc_content) (heredoc_end)))
   (array (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)) (heredoc_beginning) (heredoc_body (heredoc_content) (heredoc_end)))
   (assignment
@@ -1045,7 +1045,7 @@ array
   (array (identifier) (splat_argument (identifier)))
   (array (identifier) (splat_argument (instance_variable)))
   (array (identifier) (splat_argument (global_variable)))
-  (array (identifier) (pair (symbol) (integer))))
+  (array (identifier) (pair (simple_symbol) (integer))))
 
 =====
 array as object
@@ -1193,7 +1193,7 @@ hash with no spaces
 
 ---
 
-(program (hash (pair (symbol) (string (string_content)))))
+(program (hash (pair (simple_symbol) (string (string_content)))))
 
 =========================
 hash with expression keys
@@ -1256,42 +1256,42 @@ hash with reserved word key
 ---
 
 (program (hash
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))
-  (pair (symbol) (symbol))))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))
+  (pair (identifier_hash_key_symbol) (simple_symbol))))
 
 ======================
 hash with keyword keys
@@ -1304,12 +1304,12 @@ hash with keyword keys
 
 (program
   (hash
-    (pair (symbol) (integer))
-    (pair (symbol) (integer))
+    (pair (identifier_hash_key_symbol) (integer))
+    (pair (identifier_hash_key_symbol) (integer))
     (pair (string (string_content)) (integer)))
   (hash
-    (pair (symbol) (integer))
-    (pair (symbol) (integer))
+    (pair (identifier_hash_key_symbol) (integer))
+    (pair (identifier_hash_key_symbol) (integer))
     (pair (string (string_content)) (integer))))
 
 ========================
@@ -1320,7 +1320,7 @@ hash with trailing comma
 
 ---
 
-(program (hash (pair (symbol) (integer))))
+(program (hash (pair (identifier_hash_key_symbol) (integer))))
 
 ========================
 hash initialization with hash splat
@@ -1331,8 +1331,8 @@ hash initialization with hash splat
 ---
 
 (program (hash
-  (pair (symbol) (integer))
-  (hash_splat_argument (hash (pair (symbol) (integer))))))
+  (pair (identifier_hash_key_symbol) (integer))
+  (hash_splat_argument (hash (pair (identifier_hash_key_symbol) (integer))))))
 
 ========================
 hash with line breaks and inline comments
@@ -1349,9 +1349,9 @@ hash with line breaks and inline comments
 
 (program
   (hash
-    (pair (symbol) (identifier))
+    (pair (simple_symbol) (identifier))
     (comment)
-    (pair (symbol) (integer))))
+    (pair (simple_symbol) (integer))))
 
 ==================
 regular expression
@@ -1507,5 +1507,5 @@ Cß
   (constant)
   (instance_variable)
   (class_variable)
-  (symbol)
+  (simple_symbol)
   (identifier))

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -69,7 +69,7 @@ alias foo +
 ---
 
 (program
-  (alias (symbol) (symbol))
+  (alias (simple_symbol) (simple_symbol))
   (alias (identifier) (identifier))
   (alias (global_variable) (global_variable))
   (alias (identifier) (operator)))
@@ -86,7 +86,7 @@ undef :foo, :bar
 ---
 
 (program
-  (undef (symbol))
+  (undef (simple_symbol))
   (undef (identifier))
   (undef (operator))
-  (undef (symbol) (symbol)))
+  (undef (simple_symbol) (simple_symbol)))


### PR DESCRIPTION
I hope this change isn't too disruptive for anyone else, but it solves some issues we had with the current setup for symbols:

* since we treat leaf nodes specially for our use case, having `_simple_symbol` aliased to `symbol` meant that we couldn't handle it appropriately, since it appeared to be a non-leaf node in `node-types.json`.
* `_simple_symbol` nodes include the leading colon in the range (e.g. `:foo`), while `_identifier_hash_key` obviously don't have a leading colon (e.g. in `{ foo: 0 }` you get `foo`), so having them aliased to the same type made it difficult to get the symbol text/name in a consistent way.

Now there are four distinct node types that can represent symbols:
1. `bare_symbol` (unchanged; e.g. in `%i(foo bar baz)` symbol arrays)
2. `identifier_hash_key_symbol` (e.g. the key in `{ foo: bar }`)
3. `simple_symbol` (e.g. `:foo`)
4. `string_symbol` (e.g. `:"foo"`, `:'foo bar'`, `:"foo-#{i}"`)

Feel free to bike-shed the new names, even if you're otherwise happy with the change.