### PR TITLE
Support :!~ symbols, add symbol test cases

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -316,6 +316,9 @@ struct Scanner {
   }
 
   bool scan_symbol_identifier(TSLexer *lexer) {
+    // Specifically to support :!~
+    bool starts_with_bang = false;
+
     if (lexer->lookahead == '@') {
       advance(lexer);
       if (lexer->lookahead == '@') {
@@ -323,6 +326,10 @@ struct Scanner {
       }
     } else if (lexer->lookahead == '$') {
       advance(lexer);
+    }
+
+    if (lexer->lookahead == '!') {
+      starts_with_bang = true;
     }
 
     if (is_iden_char(lexer->lookahead)) {
@@ -336,6 +343,11 @@ struct Scanner {
     }
 
     if (lexer->lookahead == '?' || lexer->lookahead == '!') {
+      advance(lexer);
+    }
+
+    // Handles :!~
+    if (starts_with_bang && lexer->lookahead == '~') {
       advance(lexer);
     }
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -280,16 +280,21 @@ struct Scanner {
         }
         return false;
 
-      // &, ^, |, ~, /, %, !,`
+      // &, ^, |, ~, /, %`
       case '&':
       case '^':
       case '|':
       case '~':
       case '/':
       case '%':
-      case '!':
       case '`':
         advance(lexer);
+        return true;
+
+      // !, !=, !~
+      case '!':
+        advance(lexer);
+        if (lexer->lookahead == '=' || lexer->lookahead == '~') advance(lexer);
         return true;
 
       // *, **
@@ -316,8 +321,6 @@ struct Scanner {
   }
 
   bool scan_symbol_identifier(TSLexer *lexer) {
-    // Specifically to support :!~
-    bool starts_with_bang = false;
 
     if (lexer->lookahead == '@') {
       advance(lexer);
@@ -326,10 +329,6 @@ struct Scanner {
       }
     } else if (lexer->lookahead == '$') {
       advance(lexer);
-    }
-
-    if (lexer->lookahead == '!') {
-      starts_with_bang = true;
     }
 
     if (is_iden_char(lexer->lookahead)) {
@@ -343,11 +342,6 @@ struct Scanner {
     }
 
     if (lexer->lookahead == '?' || lexer->lookahead == '!') {
-      advance(lexer);
-    }
-
-    // Handles :!~
-    if (starts_with_bang && lexer->lookahead == '~') {
       advance(lexer);
     }
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -13,10 +13,12 @@ symbol
 :$0
 :_bar
 :åäö
+:_
 
 ---
 
 (program
+  (simple_symbol)
   (simple_symbol)
   (simple_symbol)
   (simple_symbol)
@@ -59,10 +61,14 @@ symbol operators
 :<=
 :<<
 :<=>
+:!=
+:!~
 
 ---
 
 (program
+  (simple_symbol)
+  (simple_symbol)
   (simple_symbol)
   (simple_symbol)
   (simple_symbol)
@@ -94,12 +100,14 @@ symbol operators
 single quoted symbol
 ====================
 
+:''
 :'foo bar'
 :'#{'
 
 ---
 
 (program
+  (delimited_symbol)
   (delimited_symbol (string_content))
   (delimited_symbol (string_content)))
 


### PR DESCRIPTION
This commit updates the lexer to specifically match the symbol :!~.

I also add test cases from
https://github.com/ruby/spec/blob/master/language/symbol_spec.rb:

- :_
- :!~
- :''

Fixes tree-sitter/tree-sitter-ruby#143.