### PR TITLE
Add support for hex character literals

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -784,7 +784,7 @@ module.exports = grammar({
 
     chained_string: $ => seq($.string, repeat1($.string)),
 
-    character: $ => /\?(\\\S({[0-9]*}|[0-9]*|-\S([MC]-\S)?)?|\S)/,
+    character: $ => /\?(\\\S({[0-9A-Fa-f]*}|[0-9A-Fa-f]*|-\S([MC]-\S)?)?|\S)/,
 
     interpolation: $ => seq(
       '#{', optional($._statement),'}'

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5252,7 +5252,7 @@
     },
     "character": {
       "type": "PATTERN",
-      "value": "\\?(\\\\\\S({[0-9]*}|[0-9]*|-\\S([MC]-\\S)?)?|\\S)"
+      "value": "\\?(\\\\\\S({[0-9A-Fa-f]*}|[0-9A-Fa-f]*|-\\S([MC]-\\S)?)?|\\S)"
     },
     "interpolation": {
       "type": "SEQ",

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -627,11 +627,17 @@ Single character string literals
 ?\C-a
 ?\M-\C-a
 ?あ
+?\u028f
+?\u{028f}
+?\xff
 foo(?/)
 
 ---
 
 (program
+  (character)
+  (character)
+  (character)
   (character)
   (character)
   (character)


### PR DESCRIPTION
Per irb:

    irb(main):016:0> ?\xff
    => "\xFF"
    irb(main):017:0> ?\u{024f}
    => "ɏ"
    irb(main):018:0> ?\u024f
    => "ɏ"

Add these test cases and update the character matching regex to enable.

Fixes tree-sitter/tree-sitter-ruby#145.