### PR TITLE
Allow expression to continue after a line-comment

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -222,7 +222,7 @@ struct Scanner {
           }
           break;
         default:
-          if (crossed_newline && lexer->lookahead != '.' && lexer->lookahead != '&') {
+          if (crossed_newline && lexer->lookahead != '.' && lexer->lookahead != '&' && lexer->lookahead != '#') {
             lexer->result_symbol = LINE_BREAK;
           }
           return true;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1097,12 +1097,18 @@ Foo \
   &.bar
   &.baz
 
+Foo
+  # a comment
+  .bar
+  .baz
+
 ---
 
 (program
   (call (call (constant) (identifier)) (identifier))
   (call (constant) (identifier))
-  (call (call (constant) (identifier)) (identifier)))
+  (call (call (constant) (identifier)) (identifier))
+  (call (call (constant) (comment) (identifier)) (identifier)))
 
 ======================================
 method call with block argument do end


### PR DESCRIPTION
@nickrolfe I think this should fix the parse error on
```ruby
foo
 # some comment
 .bar
```