### PR TITLE
Make superclass a field

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -210,7 +210,7 @@ module.exports = grammar({
     class: $ => seq(
       'class',
       field('name', choice($.constant, $.scope_resolution)),
-      optional($.superclass),
+      field('superclass', optional($.superclass)),
       $._terminator,
       $._body_statement
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -746,16 +746,20 @@
           }
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "superclass"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "FIELD",
+          "name": "superclass",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "superclass"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1080,6 +1080,16 @@
             "named": true
           }
         ]
+      },
+      "superclass": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "superclass",
+            "named": true
+          }
+        ]
       }
     },
     "children": {
@@ -1104,10 +1114,6 @@
         },
         {
           "type": "rescue",
-          "named": true
-        },
-        {
-          "type": "superclass",
           "named": true
         }
       ]

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -378,7 +378,7 @@ end
 
 (program (class
   name: (constant)
-  (superclass (call
+  superclass: (superclass (call
     receiver: (constant)
     method: (identifier)
     arguments: (argument_list


### PR DESCRIPTION
This makes `node-types.json` a little more precise - now the generic children of `class` are just the body statements.