### PR TITLE
Add field names to `range`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -623,11 +623,16 @@ module.exports = grammar({
       field('alternative', $._arg)
     )),
 
-    range: $ => prec.right(PREC.RANGE, choice(
-      seq($._arg, choice('..', '...'), $._arg),
-      seq(choice('..', '...'), $._arg),
-      seq($._arg, choice('..', '...')),
-    )),
+    range: $ => {
+      const begin = field('begin', $._arg);
+      const end = field('end', $._arg);
+      const operator = field('operator', choice('..', '...'));
+      return prec.right(PREC.RANGE, choice(
+        seq(begin, operator, end),
+        seq(operator, end),
+        seq(begin, operator)
+      ));
+    },
 
     binary: $ => {
       const operators = [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3571,25 +3571,37 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_arg"
+                "type": "FIELD",
+                "name": "begin",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ".."
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..."
-                  }
-                ]
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ".."
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "..."
+                    }
+                  ]
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "_arg"
+                "type": "FIELD",
+                "name": "end",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
               }
             ]
           },
@@ -3597,21 +3609,29 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ".."
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..."
-                  }
-                ]
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ".."
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "..."
+                    }
+                  ]
+                }
               },
               {
-                "type": "SYMBOL",
-                "name": "_arg"
+                "type": "FIELD",
+                "name": "end",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
               }
             ]
           },
@@ -3619,21 +3639,29 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_arg"
+                "type": "FIELD",
+                "name": "begin",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
               },
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ".."
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "..."
-                  }
-                ]
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ".."
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "..."
+                    }
+                  ]
+                }
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2235,16 +2235,41 @@
   {
     "type": "range",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_arg",
-          "named": true
-        }
-      ]
+    "fields": {
+      "begin": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_arg",
+            "named": true
+          }
+        ]
+      },
+      "end": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "_arg",
+            "named": true
+          }
+        ]
+      },
+      "operator": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "..",
+            "named": false
+          },
+          {
+            "type": "...",
+            "named": false
+          }
+        ]
+      }
     }
   },
   {


### PR DESCRIPTION
This improves the `node-types.json` output so we can handle beginless/endless ranges properly and distinguish inclusive and exclusive ranges.