### PR TITLE
Added `loop` construct to the grammar

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -282,6 +282,11 @@ module.exports = grammar({
       field('body', $.do)
     ),
 
+    loop: $ => seq(
+      'loop',
+      field('body', $.do)
+    ),
+
     until: $ => seq(
       'until',
       field('condition', $._statement),
@@ -450,6 +455,7 @@ module.exports = grammar({
       $.module,
       $.begin,
       $.while,
+      $.loop,
       $.until,
       $.if,
       $.unless,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -27,6 +27,7 @@
   "until"
   "when"
   "while"
+  "loop"
   "yield"
 ] @keyword
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1274,6 +1274,23 @@
         }
       ]
     },
+    "loop": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "loop"
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "do"
+          }
+        }
+      ]
+    },
     "until": {
       "type": "SEQ",
       "members": [
@@ -2237,6 +2254,10 @@
         {
           "type": "SYMBOL",
           "name": "while"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "loop"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -182,6 +182,10 @@
         "named": true
       },
       {
+        "type": "loop",
+        "named": true
+      },
+      {
         "type": "method",
         "named": true
       },
@@ -1852,6 +1856,22 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "loop",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "do",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3533,6 +3553,10 @@
   {
     "type": "integer",
     "named": true
+  },
+  {
+    "type": "loop",
+    "named": false
   },
   {
     "type": "module",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;

--- a/test/corpus/control-flow.txt
+++ b/test/corpus/control-flow.txt
@@ -634,3 +634,30 @@ end
   (case (assignment (identifier) (binary (identifier) (identifier)))
     (when (pattern (identifier)))
     (else))))
+
+=====================
+empty loop statement
+=====================
+
+loop do
+end
+
+---
+
+(program (loop
+  body: (do)))
+
+=========================
+loop statement with body
+=========================
+
+loop do
+  bar
+end
+
+---
+
+(program (loop
+  body: (do (identifier))))
+
+


### PR DESCRIPTION
Added the `loop` statement to the grammar together with tests for it. This solves part of the issue described in https://github.com/tree-sitter/tree-sitter-ruby/issues/180

Checklist:
- [X] All tests pass in CI.
- [X] There are sufficient tests for the new fix/feature.
- [X] Grammar rules have not been renamed unless absolutely necessary.
- [X] The conflicts section hasn't grown too much.
- [X] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
