### PR TITLE
Fix CRLF behavior mismatch during error recovery

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -69,7 +69,8 @@ module.exports = grammar({
   extras: $ => [
     $.comment,
     $.heredoc_body,
-    /\s|\\\r?\n/
+    /\s/,
+    /\\\r?\n/
   ],
 
   word: $ => $.identifier,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6008,7 +6008,11 @@
     },
     {
       "type": "PATTERN",
-      "value": "\\s|\\\\\\r?\\n"
+      "value": "\\s"
+    },
+    {
+      "type": "PATTERN",
+      "value": "\\\\\\r?\\n"
     }
   ],
   "conflicts": [],

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -197,14 +197,17 @@ struct Scanner {
         return true;
       }
 
-      bool seen_cr = false;
       switch (lexer->lookahead) {
         case ' ':
         case '\t':
           skip(lexer);
           break;
         case '\r':
-          if (!heredoc_body_start_is_valid) {
+          if (heredoc_body_start_is_valid) {
+            lexer->result_symbol = HEREDOC_BODY_START;
+            open_heredocs[0].started = true;
+            return true;
+          } else {
             skip(lexer);
             break;
           }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -197,12 +197,17 @@ struct Scanner {
         return true;
       }
 
+      bool seen_cr = false;
       switch (lexer->lookahead) {
         case ' ':
         case '\t':
-        case '\r':
           skip(lexer);
           break;
+        case '\r':
+          if (!heredoc_body_start_is_valid) {
+            skip(lexer);
+            break;
+          }
         case '\n':
           if (heredoc_body_start_is_valid) {
             lexer->result_symbol = HEREDOC_BODY_START;
@@ -557,7 +562,7 @@ struct Scanner {
       case '`':
         quote = lexer->lookahead;
         advance(lexer);
-        while (lexer->lookahead != quote && lexer->lookahead != 0) {
+        while (lexer->lookahead != quote && !lexer->eof(lexer)) {
           result += lexer->lookahead;
           advance(lexer);
         }
@@ -589,9 +594,8 @@ struct Scanner {
       if (position_in_word == heredoc.word.size()) {
         if (!has_content) lexer->mark_end(lexer);
         while (lexer->lookahead == ' ' ||
-               lexer->lookahead == '\t' ||
-               lexer->lookahead == '\r') advance(lexer);
-        if (lexer->lookahead == '\n') {
+               lexer->lookahead == '\t') advance(lexer);
+        if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
           if (has_content) {
             lexer->result_symbol = HEREDOC_CONTENT;
           } else {
@@ -605,7 +609,7 @@ struct Scanner {
         }
       }
 
-      if (lexer->lookahead == 0) {
+      if (lexer->eof(lexer)) {
         lexer->mark_end(lexer);
         if (has_content) {
           lexer->result_symbol = HEREDOC_CONTENT;
@@ -644,10 +648,17 @@ struct Scanner {
             }
           }
           lexer->mark_end(lexer);
-        } else if (lexer->lookahead == '\n') {
+        } else if (lexer->lookahead == '\r' || lexer->lookahead == '\n') {
+          if (lexer->lookahead == '\r') {
+            advance(lexer);
+            if (lexer->lookahead == '\n') {
+              advance(lexer);
+            }
+          } else {
+            advance(lexer);
+          }
           has_content = true;
           look_for_heredoc_end = true;
-          advance(lexer);
           while (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
             advance(lexer);
             if (!heredoc.end_word_indentation_allowed) look_for_heredoc_end = false;
@@ -723,7 +734,7 @@ struct Scanner {
           advance(lexer);
           advance(lexer);
         }
-      } else if (lexer->lookahead == 0) {
+      } else if (lexer->eof(lexer)) {
         advance(lexer);
         lexer->mark_end(lexer);
         return false;

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -1,0 +1,19 @@
+==========================
+Heredocs with errors
+==========================
+
+joins(<<~SQL(
+  b
+SQL
+c
+
+---
+
+(program
+  (call
+    method: (identifier)
+    (ERROR (heredoc_beginning))
+    arguments: (argument_list
+      (heredoc_body (heredoc_content) (heredoc_end))
+      (identifier)
+      (MISSING ")"))))

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -17,3 +17,26 @@ c
       (heredoc_body (heredoc_content) (heredoc_end))
       (identifier)
       (MISSING ")"))))
+
+====================================
+Heredocs
+====================================
+
+joins(<<-SQL
+b
+
+SQL
+
+)
+
+------------------------------------
+
+(program
+  (call
+    method: (identifier)
+    arguments: (argument_list
+      (heredoc_beginning)
+      (heredoc_body (heredoc_content) (heredoc_end))
+    )
+  )
+)


### PR DESCRIPTION
This is a bit more subtle than the previous fixes in https://github.com/tree-sitter/tree-sitter-ruby/pull/188
The [ruby error_corpus test](https://github.com/tree-sitter/tree-sitter/blob/master/test/fixtures/error_corpus/ruby_errors.txt) was failing in the main repo on Windows, generating a slightly different error-corrected parse tree. I suspect this is because of the additional `\r` characters consumed by the external scanner which led the parser to prefer one GLR branch over another. I changed the external scanner so its behavior matches as closely as possible in both cases by doing a line-by-line diff of the debug parse output. If I had to summarize the changes, they would be "treat a standalone `\r` as a newline, unless it's directly followed by a `\n`, in which case consume `\r\n` one right after the other". The same error-corrected parse tree is now output on all platforms. I've also added the test itself to this repo since it seems a bit fragile.