### PR TITLE
Disable C++ exceptions when compile for wasm32-wasi

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::Path;
 extern crate cc;
 
@@ -18,6 +19,11 @@ fn main() {
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
+
+    if env::var("TARGET").unwrap() == "wasm32-wasi" {
+        cpp_config.flag_if_supported("-fno-exceptions");
+    }
+
     cpp_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable");


### PR DESCRIPTION
Currently wasm32-wasi doesn't support exceptions

Checklist:
- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [ ] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
