### PR TITLE
One-line pattern matching

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -652,9 +652,12 @@ module.exports = grammar({
       alias($.yield_command, $.yield),
       alias($.break_command, $.break),
       alias($.next_command, $.next),
+      $.match_pattern,
       $.test_pattern,
       $._arg
     ),
+
+    match_pattern: $ => seq(field('value', $._arg), '=>', field('pattern', $._pattern_top_expr_body)),
 
     test_pattern: $ => prec(100, seq(field('value', $._arg), 'in', field('pattern', $._pattern_top_expr_body))),
 

--- a/grammar.js
+++ b/grammar.js
@@ -652,8 +652,11 @@ module.exports = grammar({
       alias($.yield_command, $.yield),
       alias($.break_command, $.break),
       alias($.next_command, $.next),
+      $.test_pattern,
       $._arg
     ),
+
+    test_pattern: $ => seq(field('value', $._arg), 'in', field('pattern', $._pattern_top_expr_body)),
 
     _arg: $ => choice(
       alias($._unary_minus_pow, $.unary),

--- a/grammar.js
+++ b/grammar.js
@@ -240,10 +240,10 @@ module.exports = grammar({
 
     forward_parameter: $ => '...',
 
-    splat_parameter: $ => seq(
+    splat_parameter: $ => prec.right(-2, seq(
       '*',
       field('name', optional($.identifier))
-    ),
+    )),
     hash_splat_parameter: $ => seq(
       '**',
       field('name', optional($.identifier))
@@ -441,11 +441,11 @@ module.exports = grammar({
       $._array_pattern_n,
     ),
 
-    array_pattern: $ => choice(
+    array_pattern: $ => prec.right(-1, choice(
       seq('[', optional($._array_pattern_body), ']'),
       seq(field('class', $._pattern_constant), token.immediate('['), optional($._array_pattern_body), ']'),
       seq(field('class', $._pattern_constant), token.immediate('('), optional($._array_pattern_body), ')')
-    ),
+    )),
 
     _find_pattern_body: $ => seq($.splat_parameter, repeat1(seq(',', $._pattern_expr)), ',', $.splat_parameter),
     find_pattern: $ => choice(
@@ -460,7 +460,7 @@ module.exports = grammar({
       $._hash_pattern_any_rest
     )),
 
-    keyword_pattern: $ => prec.right(seq(
+    keyword_pattern: $ => prec.right(-1, seq(
       field('key',
         choice(
           alias($.identifier, $.hash_key_symbol),
@@ -476,30 +476,30 @@ module.exports = grammar({
 
     _hash_pattern_any_rest: $ => choice($.hash_splat_parameter, $.hash_splat_nil),
 
-    hash_pattern: $ => choice(
+    hash_pattern: $ => prec.right(-1, choice(
       seq('{', optional($._hash_pattern_body), '}'),
       seq(field('class', $._pattern_constant), token.immediate('['), $._hash_pattern_body, ']'),
       seq(field('class', $._pattern_constant), token.immediate('('), $._hash_pattern_body, ')')
-    ),
+    )),
 
-    _pattern_expr_basic: $ => choice(
+    _pattern_expr_basic: $ => prec.right(-1, choice(
       $._pattern_value,
       $.identifier,
       $.array_pattern,
       $.find_pattern,
       $.hash_pattern,
       $.parenthesized_pattern,
-    ),
+    )),
 
     parenthesized_pattern: $ => seq('(', $._pattern_expr, ')'),
 
-    _pattern_value: $ => choice(
+    _pattern_value: $ => prec.right(-1, choice(
       $._pattern_primitive,
       alias($._pattern_range, $.range),
       $.variable_reference_pattern,
       $.expression_reference_pattern,
       $._pattern_constant
-    ),
+    )),
 
     _pattern_range: $ => {
       const begin = field('begin', $._pattern_primitive);
@@ -517,9 +517,9 @@ module.exports = grammar({
       $._pattern_lambda
     ),
 
-    _pattern_lambda: $ => $.lambda,
+    _pattern_lambda: $ => prec.right(-1, $.lambda),
 
-    _pattern_literal: $ => choice(
+    _pattern_literal: $ => prec.right(-1, choice(
       $._literal,
       $.string,
       $.subshell,
@@ -528,9 +528,9 @@ module.exports = grammar({
       $.string_array,
       $.symbol_array,
       $._keyword_variable
-    ),
+    )),
 
-    _keyword_variable: $ => choice(
+    _keyword_variable: $ => prec.right(-1, choice(
       $.nil,
       $.self,
       $.true,
@@ -538,7 +538,7 @@ module.exports = grammar({
       $.line,
       $.file,
       $.encoding,
-    ),
+    )),
 
     line: $ => '__LINE__',
     file: $ => '__FILE__',
@@ -548,10 +548,10 @@ module.exports = grammar({
 
     expression_reference_pattern: $ => seq('^', '(', field('value', $._expression), ')'),
 
-    _pattern_constant: $ => choice(
+    _pattern_constant: $ => prec.right(-1, choice(
       $.constant,
       alias($._pattern_constant_resolution, $.scope_resolution)
-    ),
+    )),
 
     _pattern_constant_resolution: $ => seq(
       optional(field('scope', $._pattern_constant)),
@@ -657,7 +657,7 @@ module.exports = grammar({
       $._arg
     ),
 
-    match_pattern: $ => seq(field('value', $._arg), '=>', field('pattern', $._pattern_top_expr_body)),
+    match_pattern: $ => prec(100, seq(field('value', $._arg), '=>', field('pattern', $._pattern_top_expr_body))),
 
     test_pattern: $ => prec(100, seq(field('value', $._arg), 'in', field('pattern', $._pattern_top_expr_body))),
 

--- a/grammar.js
+++ b/grammar.js
@@ -409,18 +409,18 @@ module.exports = grammar({
       field('condition', $._expression)
     ),
 
-    _pattern_top_expr_body: $ => choice(
+    _pattern_top_expr_body: $ => prec(-1, choice(
       $._pattern_expr,
       alias($._array_pattern_n, $.array_pattern),
       alias($._find_pattern_body, $.find_pattern),
       alias($._hash_pattern_body, $.hash_pattern),
-    ),
+    )),
 
-    _array_pattern_n: $ => choice(
+    _array_pattern_n: $ => prec.right(choice(
       seq($._pattern_expr, alias(',', $.splat_parameter)),
       seq($._pattern_expr, ',', choice($._pattern_expr, $._array_pattern_n)),
       seq($.splat_parameter, repeat(seq(',', $._pattern_expr))),
-    ),
+    )),
 
     _pattern_expr: $ => choice(
       $.as_pattern,
@@ -454,13 +454,13 @@ module.exports = grammar({
       seq(field('class', $._pattern_constant), token.immediate('('), $._find_pattern_body, ')')
     ),
 
-    _hash_pattern_body: $ => choice(
+    _hash_pattern_body: $ => prec.right(choice(
       seq(commaSep1($.keyword_pattern), optional(',')),
       seq(commaSep1($.keyword_pattern), ',', $._hash_pattern_any_rest),
       $._hash_pattern_any_rest
-    ),
+    )),
 
-    keyword_pattern: $ => seq(
+    keyword_pattern: $ => prec.right(seq(
       field('key',
         choice(
           alias($.identifier, $.hash_key_symbol),
@@ -472,7 +472,7 @@ module.exports = grammar({
       ),
       token.immediate(':'),
       optional(field('value', $._pattern_expr))
-    ),
+    )),
 
     _hash_pattern_any_rest: $ => choice($.hash_splat_parameter, $.hash_splat_nil),
 
@@ -656,7 +656,7 @@ module.exports = grammar({
       $._arg
     ),
 
-    test_pattern: $ => seq(field('value', $._arg), 'in', field('pattern', $._pattern_top_expr_body)),
+    test_pattern: $ => prec(100, seq(field('value', $._arg), 'in', field('pattern', $._pattern_top_expr_body))),
 
     _arg: $ => choice(
       alias($._unary_minus_pow, $.unary),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -772,29 +772,33 @@
       "value": "..."
     },
     "splat_parameter": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "*"
-        },
-        {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "identifier"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+      "type": "PREC_RIGHT",
+      "value": -2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "*"
+          },
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
           }
-        }
-      ]
+        ]
+      }
     },
     "hash_splat_parameter": {
       "type": "SEQ",
@@ -1941,114 +1945,122 @@
       ]
     },
     "_pattern_top_expr_body": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_pattern_expr"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SYMBOL",
-            "name": "_array_pattern_n"
+            "name": "_pattern_expr"
           },
-          "named": true,
-          "value": "array_pattern"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_find_pattern_body"
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_array_pattern_n"
+            },
+            "named": true,
+            "value": "array_pattern"
           },
-          "named": true,
-          "value": "find_pattern"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_hash_pattern_body"
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_find_pattern_body"
+            },
+            "named": true,
+            "value": "find_pattern"
           },
-          "named": true,
-          "value": "hash_pattern"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_hash_pattern_body"
+            },
+            "named": true,
+            "value": "hash_pattern"
+          }
+        ]
+      }
     },
     "_array_pattern_n": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_pattern_expr"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_pattern_expr"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "STRING",
+                  "value": ","
+                },
+                "named": true,
+                "value": "splat_parameter"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_pattern_expr"
+              },
+              {
                 "type": "STRING",
                 "value": ","
               },
-              "named": true,
-              "value": "splat_parameter"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_pattern_expr"
-            },
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_pattern_expr"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_array_pattern_n"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "splat_parameter"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "SEQ",
+              {
+                "type": "CHOICE",
                 "members": [
-                  {
-                    "type": "STRING",
-                    "value": ","
-                  },
                   {
                     "type": "SYMBOL",
                     "name": "_pattern_expr"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_array_pattern_n"
                   }
                 ]
               }
-            }
-          ]
-        }
-      ]
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "splat_parameter"
+              },
+              {
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_pattern_expr"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
     },
     "_pattern_expr": {
       "type": "CHOICE",
@@ -2148,106 +2160,110 @@
       ]
     },
     "array_pattern": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "["
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_array_pattern_body"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "]"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "class",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_pattern_constant"
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
                 "type": "STRING",
                 "value": "["
-              }
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_array_pattern_body"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "]"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "class",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_pattern_constant"
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_array_pattern_body"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
                 "type": "STRING",
-                "value": "("
+                "value": "]"
               }
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "class",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "_array_pattern_body"
-                },
-                {
-                  "type": "BLANK"
+                  "name": "_pattern_constant"
                 }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
-        }
-      ]
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "["
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_array_pattern_body"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "class",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_pattern_constant"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "("
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_array_pattern_body"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          }
+        ]
+      }
     },
     "_find_pattern_body": {
       "type": "SEQ",
@@ -2361,170 +2377,178 @@
       ]
     },
     "_hash_pattern_body": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "keyword_pattern"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "keyword_pattern"
-                      }
-                    ]
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "keyword_pattern"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_pattern"
+                        }
+                      ]
+                    }
                   }
-                }
-              ]
-            },
-            {
+                ]
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "keyword_pattern"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": ","
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "keyword_pattern"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_hash_pattern_any_rest"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_hash_pattern_any_rest"
+          }
+        ]
+      }
+    },
+    "keyword_pattern": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "key",
+            "content": {
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "STRING",
-                  "value": ","
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier"
+                  },
+                  "named": true,
+                  "value": "hash_key_symbol"
                 },
                 {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "constant"
+                  },
+                  "named": true,
+                  "value": "hash_key_symbol"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "identifier_suffix"
+                  },
+                  "named": true,
+                  "value": "hash_key_symbol"
+                },
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "constant_suffix"
+                  },
+                  "named": true,
+                  "value": "hash_key_symbol"
+                },
                 {
                   "type": "SYMBOL",
-                  "name": "keyword_pattern"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "keyword_pattern"
-                      }
-                    ]
-                  }
+                  "name": "string"
                 }
               ]
-            },
-            {
-              "type": "STRING",
-              "value": ","
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_hash_pattern_any_rest"
             }
-          ]
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_hash_pattern_any_rest"
-        }
-      ]
-    },
-    "keyword_pattern": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "FIELD",
-          "name": "key",
-          "content": {
+          },
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "STRING",
+              "value": ":"
+            }
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
-                "type": "ALIAS",
+                "type": "FIELD",
+                "name": "value",
                 "content": {
                   "type": "SYMBOL",
-                  "name": "identifier"
-                },
-                "named": true,
-                "value": "hash_key_symbol"
+                  "name": "_pattern_expr"
+                }
               },
               {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "constant"
-                },
-                "named": true,
-                "value": "hash_key_symbol"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "identifier_suffix"
-                },
-                "named": true,
-                "value": "hash_key_symbol"
-              },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "constant_suffix"
-                },
-                "named": true,
-                "value": "hash_key_symbol"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "string"
+                "type": "BLANK"
               }
             ]
           }
-        },
-        {
-          "type": "IMMEDIATE_TOKEN",
-          "content": {
-            "type": "STRING",
-            "value": ":"
-          }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "value",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_pattern_expr"
-              }
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+        ]
+      }
     },
     "_hash_pattern_any_rest": {
       "type": "CHOICE",
@@ -2540,119 +2564,127 @@
       ]
     },
     "hash_pattern": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "{"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_hash_pattern_body"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "class",
+                "content": {
                   "type": "SYMBOL",
-                  "name": "_hash_pattern_body"
-                },
-                {
-                  "type": "BLANK"
+                  "name": "_pattern_constant"
                 }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": "}"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "class",
-              "content": {
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "["
+                }
+              },
+              {
                 "type": "SYMBOL",
-                "name": "_pattern_constant"
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
+                "name": "_hash_pattern_body"
+              },
+              {
                 "type": "STRING",
-                "value": "["
+                "value": "]"
               }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_hash_pattern_body"
-            },
-            {
-              "type": "STRING",
-              "value": "]"
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "class",
-              "content": {
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "class",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_pattern_constant"
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": "("
+                }
+              },
+              {
                 "type": "SYMBOL",
-                "name": "_pattern_constant"
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
+                "name": "_hash_pattern_body"
+              },
+              {
                 "type": "STRING",
-                "value": "("
+                "value": ")"
               }
-            },
-            {
-              "type": "SYMBOL",
-              "name": "_hash_pattern_body"
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
-        }
-      ]
+            ]
+          }
+        ]
+      }
     },
     "_pattern_expr_basic": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_pattern_value"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "array_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "find_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "hash_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "parenthesized_pattern"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_pattern_value"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "identifier"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "array_pattern"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "find_pattern"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "hash_pattern"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "parenthesized_pattern"
+          }
+        ]
+      }
     },
     "parenthesized_pattern": {
       "type": "SEQ",
@@ -2672,34 +2704,38 @@
       ]
     },
     "_pattern_value": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_pattern_primitive"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SYMBOL",
-            "name": "_pattern_range"
+            "name": "_pattern_primitive"
           },
-          "named": true,
-          "value": "range"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "variable_reference_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "expression_reference_pattern"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_pattern_constant"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pattern_range"
+            },
+            "named": true,
+            "value": "range"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "variable_reference_pattern"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "expression_reference_pattern"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_pattern_constant"
+          }
+        ]
+      }
     },
     "_pattern_range": {
       "type": "CHOICE",
@@ -2818,78 +2854,90 @@
       ]
     },
     "_pattern_lambda": {
-      "type": "SYMBOL",
-      "name": "lambda"
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "SYMBOL",
+        "name": "lambda"
+      }
     },
     "_pattern_literal": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "subshell"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "heredoc_beginning"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "regex"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string_array"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "symbol_array"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_keyword_variable"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_literal"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "string"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "subshell"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "heredoc_beginning"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "regex"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "string_array"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "symbol_array"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_keyword_variable"
+          }
+        ]
+      }
     },
     "_keyword_variable": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "nil"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "self"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "true"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "false"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "line"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "file"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "encoding"
-        }
-      ]
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "nil"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "self"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "true"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "false"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "line"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "file"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "encoding"
+          }
+        ]
+      }
     },
     "line": {
       "type": "STRING",
@@ -2955,22 +3003,26 @@
       ]
     },
     "_pattern_constant": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "constant"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
+      "type": "PREC_RIGHT",
+      "value": -1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
             "type": "SYMBOL",
-            "name": "_pattern_constant_resolution"
+            "name": "constant"
           },
-          "named": true,
-          "value": "scope_resolution"
-        }
-      ]
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pattern_constant_resolution"
+            },
+            "named": true,
+            "value": "scope_resolution"
+          }
+        ]
+      }
     },
     "_pattern_constant_resolution": {
       "type": "SEQ",
@@ -3629,9 +3681,75 @@
         },
         {
           "type": "SYMBOL",
+          "name": "match_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "test_pattern"
+        },
+        {
+          "type": "SYMBOL",
           "name": "_arg"
         }
       ]
+    },
+    "match_pattern": {
+      "type": "PREC",
+      "value": 100,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_arg"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "=>"
+          },
+          {
+            "type": "FIELD",
+            "name": "pattern",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pattern_top_expr_body"
+            }
+          }
+        ]
+      }
+    },
+    "test_pattern": {
+      "type": "PREC",
+      "value": 100,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_arg"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "in"
+          },
+          {
+            "type": "FIELD",
+            "name": "pattern",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_pattern_top_expr_body"
+            }
+          }
+        ]
+      }
     },
     "_arg": {
       "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -76,6 +76,10 @@
         "named": true
       },
       {
+        "type": "match_pattern",
+        "named": true
+      },
+      {
         "type": "next",
         "named": true
       },
@@ -85,6 +89,10 @@
       },
       {
         "type": "return",
+        "named": true
+      },
+      {
+        "type": "test_pattern",
         "named": true
       },
       {
@@ -2339,6 +2347,32 @@
     }
   },
   {
+    "type": "match_pattern",
+    "named": true,
+    "fields": {
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_pattern_top_expr_body",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_arg",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "method",
     "named": true,
     "fields": {
@@ -3193,6 +3227,32 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "test_pattern",
+    "named": true,
+    "fields": {
+      "pattern": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_pattern_top_expr_body",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_arg",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -341,3 +341,35 @@ DOC
   (heredoc_body
     (heredoc_content)
     (heredoc_end)))
+
+=================
+one-line patterns
+=================
+
+x in Foo(y:)
+
+case foo in 5 in true then 1 end
+case foo in 5; in true then 1 end
+case (foo x) in 5; in true then 1 end
+
+-----------------
+
+(program
+  (test_pattern (identifier) (hash_pattern (constant) (keyword_pattern (hash_key_symbol))))
+
+  (case_match (test_pattern (identifier) (integer)) (in_clause (true) (then (integer))))
+  (case_match (test_pattern (identifier) (integer)) (in_clause (true) (then (integer))))
+  (case_match (test_pattern (parenthesized_statements (call (identifier) (argument_list (identifier)))) (integer))
+    (in_clause (true) (then (integer))))
+)
+
+=====================================
+one-line patterns: incorrectly parsed
+=====================================
+foo x in 5 # FIXME: should be parsed as `(foo x) in 5` instead of `foo (x in 5)`
+
+-----------------
+
+(program
+  (call (identifier) (argument_list (test_pattern (identifier) (integer)))) (comment)
+)

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -352,6 +352,9 @@ case foo in 5 in true then 1 end
 case foo in 5; in true then 1 end
 case (foo x) in 5; in true then 1 end
 
+x => 6 | 7
+return x => 6 | 7
+
 -----------------
 
 (program
@@ -361,6 +364,10 @@ case (foo x) in 5; in true then 1 end
   (case_match (test_pattern (identifier) (integer)) (in_clause (true) (then (integer))))
   (case_match (test_pattern (parenthesized_statements (call (identifier) (argument_list (identifier)))) (integer))
     (in_clause (true) (then (integer))))
+
+  (match_pattern (identifier) (alternative_pattern (integer) (integer)))
+  (return (argument_list (pair (identifier) (binary (integer) (integer)))))
+
 )
 
 =====================================


### PR DESCRIPTION
This pull request adds the one-line pattern matching syntax (`expr in pattern` and `expr => pattern`). 

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
