### PR TITLE
Add parenthesized_pattern

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -462,7 +462,10 @@ module.exports = grammar({
       $.array_pattern,
       $.find_pattern,
       $.hash_pattern,
+      $.parenthesized_pattern,
     ),
+
+    parenthesized_pattern: $ => seq('(', $._pattern_expr, ')'),
 
     _pattern_value: $ => choice(
       $._pattern_primitive,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2465,6 +2465,27 @@
         {
           "type": "SYMBOL",
           "name": "hash_pattern"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "parenthesized_pattern"
+        }
+      ]
+    },
+    "parenthesized_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_pattern_expr"
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -216,6 +216,10 @@
         "named": true
       },
       {
+        "type": "parenthesized_pattern",
+        "named": true
+      },
+      {
         "type": "range",
         "named": true
       },
@@ -2523,6 +2527,21 @@
     }
   },
   {
+    "type": "parenthesized_pattern",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "_pattern_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "parenthesized_statements",
     "named": true,
     "fields": {},
@@ -3831,11 +3850,11 @@
   },
   {
     "type": "nil",
-    "named": false
+    "named": true
   },
   {
     "type": "nil",
-    "named": true
+    "named": false
   },
   {
     "type": "not",

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -145,7 +145,7 @@ case expr
   in Foo
   in Foo::Bar
   in ::Foo::Bar
-  in nil | self | true | false | __LINE__ | __FILE__ | __ENCODING__
+  in (nil | self | true | false | __LINE__ | __FILE__ | __ENCODING__)
   in -> x { x == 10 }
   in :foo
   in :"foo bar"
@@ -179,14 +179,16 @@ end
      (in_clause (scope_resolution (constant) (constant)))
      (in_clause (scope_resolution (scope_resolution (constant)) (constant)))
      (in_clause 
-       (alternative_pattern 
-         (nil)
-         (self)
-         (true)
-         (false)
-         (line)
-         (file)
-         (encoding)
+       (parenthesized_pattern 
+         (alternative_pattern 
+           (nil)
+           (self)
+           (true)
+           (false)
+           (line)
+           (file)
+           (encoding)
+         )
        )
      )
      (in_clause (lambda (lambda_parameters (identifier)) (block (binary (identifier) (integer)))))


### PR DESCRIPTION
I forgot about the parenthesized patterns such as
```
case x
  in (1..10) then ...
  ...
```
Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
