### PR TITLE
Ruby 3.1 features

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -231,7 +231,7 @@ module.exports = grammar({
     hash_splat_nil: $ => seq('**', 'nil'),
     block_parameter: $ => seq(
       '&',
-      field('name', $.identifier)
+      field('name', optional($.identifier))
     ),
     keyword_parameter: $ => prec.right(PREC.BITWISE_OR + 1, seq(
       field('name', $.identifier),
@@ -771,7 +771,7 @@ module.exports = grammar({
     forward_argument: $ => '...',
     splat_argument: $ => seq(alias($._splat_star, '*'), $._arg),
     hash_splat_argument: $ => seq(alias($._hash_splat_star_star, '**'), $._arg),
-    block_argument: $ => seq(alias($._block_ampersand, '&'), $._arg),
+    block_argument: $ => prec.right(seq(alias($._block_ampersand, '&'), optional($._arg))),
 
     do_block: $ => seq(
       'do',

--- a/grammar.js
+++ b/grammar.js
@@ -1105,7 +1105,7 @@ module.exports = grammar({
       '}'
     ),
 
-    pair: $ => choice(
+    pair: $ => prec.right(choice(
       seq(
         field('key', $._arg),
         '=>',
@@ -1113,15 +1113,21 @@ module.exports = grammar({
       ),
       seq(
         field('key', choice(
-          $.hash_key_symbol,
-          alias($.identifier, $.hash_key_symbol),
-          alias($.constant, $.hash_key_symbol),
           $.string
         )),
         token.immediate(':'),
         field('value', $._arg)
+      ),
+      seq(
+        field('key', choice(
+          $.hash_key_symbol,
+          alias($.identifier, $.hash_key_symbol),
+          alias($.constant, $.hash_key_symbol)
+        )),
+        token.immediate(':'),
+        field('value', optional($._arg))
       )
-    ),
+    )),
 
     lambda: $ => seq(
       '->',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2464,6 +2464,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "identifier"
+        },
+        {
+          "type": "SYMBOL",
           "name": "array_pattern"
         },
         {
@@ -2515,11 +2519,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "identifier"
+          "name": "variable_reference_pattern"
         },
         {
           "type": "SYMBOL",
-          "name": "variable_reference_pattern"
+          "name": "expression_reference_pattern"
         },
         {
           "type": "SYMBOL",
@@ -2732,9 +2736,43 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_nonlocal_variable"
+              }
+            ]
           }
+        }
+      ]
+    },
+    "expression_reference_pattern": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "^"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "FIELD",
+          "name": "value",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_expression"
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
         }
       ]
     },
@@ -6088,15 +6126,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "instance_variable"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "class_variable"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "global_variable"
+            "name": "_nonlocal_variable"
           },
           {
             "type": "SYMBOL",
@@ -6253,6 +6283,15 @@
           "type": "SYMBOL",
           "name": "operator"
         },
+        {
+          "type": "SYMBOL",
+          "name": "_nonlocal_variable"
+        }
+      ]
+    },
+    "_nonlocal_variable": {
+      "type": "CHOICE",
+      "members": [
         {
           "type": "SYMBOL",
           "name": "instance_variable"
@@ -7484,6 +7523,7 @@
     "_primary",
     "_simple_numeric",
     "_lhs",
+    "_nonlocal_variable",
     "_pattern_top_expr_body",
     "_pattern_expr",
     "_pattern_expr_basic",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -749,8 +749,16 @@
           "type": "FIELD",
           "name": "name",
           "content": {
-            "type": "SYMBOL",
-            "name": "identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         }
       ]
@@ -4373,22 +4381,34 @@
       ]
     },
     "block_argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_block_ampersand"
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_block_ampersand"
+            },
+            "named": false,
+            "value": "&"
           },
-          "named": false,
-          "value": "&"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "do_block": {
       "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7124,89 +7124,130 @@
       ]
     },
     "pair": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "key",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_arg"
-              }
-            },
-            {
-              "type": "STRING",
-              "value": "=>"
-            },
-            {
-              "type": "FIELD",
-              "name": "value",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_arg"
-              }
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "FIELD",
-              "name": "key",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "hash_key_symbol"
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "identifier"
-                    },
-                    "named": true,
-                    "value": "hash_key_symbol"
-                  },
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "constant"
-                    },
-                    "named": true,
-                    "value": "hash_key_symbol"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "string"
-                  }
-                ]
-              }
-            },
-            {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "key",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
+              },
+              {
                 "type": "STRING",
-                "value": ":"
+                "value": "=>"
+              },
+              {
+                "type": "FIELD",
+                "name": "value",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
               }
-            },
-            {
-              "type": "FIELD",
-              "name": "value",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_arg"
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "key",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "string"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": ":"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "value",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_arg"
+                }
               }
-            }
-          ]
-        }
-      ]
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "key",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "hash_key_symbol"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "identifier"
+                      },
+                      "named": true,
+                      "value": "hash_key_symbol"
+                    },
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "constant"
+                      },
+                      "named": true,
+                      "value": "hash_key_symbol"
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "STRING",
+                  "value": ":"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "value",
+                "content": {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_arg"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
     },
     "lambda": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1043,7 +1043,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_arg",
@@ -1058,7 +1058,7 @@
     "fields": {
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "identifier",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2516,7 +2516,7 @@
       },
       "value": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "_arg",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -118,7 +118,7 @@
     "named": true,
     "subtypes": [
       {
-        "type": "class_variable",
+        "type": "_nonlocal_variable",
         "named": true
       },
       {
@@ -130,15 +130,7 @@
         "named": true
       },
       {
-        "type": "global_variable",
-        "named": true
-      },
-      {
         "type": "identifier",
-        "named": true
-      },
-      {
-        "type": "instance_variable",
         "named": true
       },
       {
@@ -151,6 +143,24 @@
       },
       {
         "type": "simple_symbol",
+        "named": true
+      }
+    ]
+  },
+  {
+    "type": "_nonlocal_variable",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "class_variable",
+        "named": true
+      },
+      {
+        "type": "global_variable",
+        "named": true
+      },
+      {
+        "type": "instance_variable",
         "named": true
       }
     ]
@@ -201,6 +211,10 @@
       },
       {
         "type": "array_pattern",
+        "named": true
+      },
+      {
+        "type": "expression_reference_pattern",
         "named": true
       },
       {
@@ -544,7 +558,7 @@
     "named": true,
     "subtypes": [
       {
-        "type": "class_variable",
+        "type": "_nonlocal_variable",
         "named": true
       },
       {
@@ -552,15 +566,7 @@
         "named": true
       },
       {
-        "type": "global_variable",
-        "named": true
-      },
-      {
         "type": "identifier",
-        "named": true
-      },
-      {
-        "type": "instance_variable",
         "named": true
       },
       {
@@ -1703,6 +1709,22 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "expression_reference_pattern",
+    "named": true,
+    "fields": {
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -3351,6 +3373,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "_nonlocal_variable",
+            "named": true
+          },
           {
             "type": "identifier",
             "named": true

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -252,6 +252,9 @@ end
 def foo(&block)
 end
 
+def foo(&)
+end
+
 def foo(...)
   super(...)
 end
@@ -270,6 +273,7 @@ end
   (method (identifier) (method_parameters (keyword_parameter (identifier)) (hash_splat_parameter)))
   (method (identifier) (method_parameters (identifier) (hash_splat_nil)))
   (method (identifier) (method_parameters (block_parameter (identifier))))
+  (method (identifier) (method_parameters (block_parameter)))
   (method (identifier) (method_parameters (forward_parameter))
     (call (super) (argument_list (forward_argument)))
   )  

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -807,13 +807,18 @@ method call with keyword args
 foo(a: true)
 foo a: true
 foo B: true
+foo a:
+foo B:
 
 ---
 
 (program
   (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
   (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (hash_key_symbol) (true)))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol))))
+  (call (identifier) (argument_list (pair (hash_key_symbol))))
+)
 
 ===============================
 method call with reserved keyword args
@@ -856,6 +861,7 @@ foo until: true
 foo when: true
 foo while: true
 foo yield: true
+foo yield:
 
 ---
 
@@ -896,7 +902,8 @@ foo yield: true
   (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
   (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
   (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
-  (call (identifier) (argument_list (pair (hash_key_symbol) (true)))))
+  (call (identifier) (argument_list (pair (hash_key_symbol) (true))))
+  (call (identifier) (argument_list (pair (hash_key_symbol)))))
 
 ===============================
 method call with paren args
@@ -1328,6 +1335,19 @@ end
     (do_block
       (call (identifier) (argument_list (integer))))))
 
+
+========================================================================
+call with normal and keyword argument with value that looks like a block
+========================================================================
+render "foo/bars/show", locals: { }
+render "foo/bars/show", locals: { display_text: dt, safe_text: "hello" }
+
+---
+
+(program 
+  (call (identifier) (argument_list (string (string_content)) (pair (hash_key_symbol) (hash))))
+  (call (identifier) (argument_list (string (string_content)) (pair (hash_key_symbol) (hash (pair (hash_key_symbol) (identifier)) (pair (hash_key_symbol) (string (string_content)))))))
+)
 
 ==============
 empty lambda expression

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -924,6 +924,10 @@ foo(&bar)
 foo(&bar, 1)
 foo &bar
 foo &bar, 1
+foo(&)
+foo(&, 1)
+foo &;
+foo 1, &;
 
 ---
 
@@ -932,7 +936,12 @@ foo &bar, 1
   (call (identifier) (argument_list (block_argument (identifier))))
   (call (identifier) (argument_list (block_argument (identifier)) (integer)))
   (call (identifier) (argument_list (block_argument (identifier))))
-  (call (identifier) (argument_list (block_argument (identifier)) (integer))))
+  (call (identifier) (argument_list (block_argument (identifier)) (integer)))
+  (call (identifier) (argument_list (block_argument)))
+  (call (identifier) (argument_list (block_argument) (integer)))
+  (call (identifier) (argument_list (block_argument)))
+  (call (identifier) (argument_list (integer) (block_argument)))
+)
 
 ===============================
 method call with splat argument

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1264,7 +1264,8 @@ hash with reserved word key
   if: :foo,
   unless: :foo,
   while: :foo,
-  until: :foo
+  until: :foo,
+  until:
 }
 
 ---
@@ -1305,14 +1306,16 @@ hash with reserved word key
   (pair (hash_key_symbol) (simple_symbol))
   (pair (hash_key_symbol) (simple_symbol))
   (pair (hash_key_symbol) (simple_symbol))
-  (pair (hash_key_symbol) (simple_symbol))))
+  (pair (hash_key_symbol) (simple_symbol))
+  (pair (hash_key_symbol))))
 
 ======================
 hash with keyword keys
 ======================
 
 { a: 1, b: 2, "c": 3 }
-{a:1, b:2, "c":3 }
+{a:1, B:2, "c":3 }
+{ a:, B: }
 
 ---
 
@@ -1324,7 +1327,12 @@ hash with keyword keys
   (hash
     (pair (hash_key_symbol) (integer))
     (pair (hash_key_symbol) (integer))
-    (pair (string (string_content)) (integer))))
+    (pair (string (string_content)) (integer)))
+  (hash
+    (pair (hash_key_symbol))
+    (pair (hash_key_symbol))
+  )
+)
 
 ========================
 hash with trailing comma

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -132,6 +132,12 @@ more pattern matching
 case expr 
   in 5
   in ^foo
+  in ^$foo
+  in ^@foo
+  in ^@@foo
+  in ^(1+1)
+  in ^(foo)
+  in ^(Foo::Bar)
   in var
   in "string"
   in %w(foo bar)
@@ -158,6 +164,12 @@ end
    (case_match (identifier)
      (in_clause (integer))
      (in_clause (variable_reference_pattern (identifier)))
+     (in_clause (variable_reference_pattern (global_variable)))
+     (in_clause (variable_reference_pattern (instance_variable)))
+     (in_clause (variable_reference_pattern (class_variable)))
+     (in_clause (expression_reference_pattern (binary (integer) (integer))))
+     (in_clause (expression_reference_pattern (identifier)))
+     (in_clause (expression_reference_pattern (scope_resolution (constant) (constant))))
      (in_clause (identifier))
      (in_clause (string (string_content)))
      (in_clause (string_array (bare_string (string_content)) (bare_string (string_content))))


### PR DESCRIPTION
This pull-request Implements the following items taken from https://rubyreferences.github.io/rubychanges/3.1.html
* Values in Hash literals and keyword arguments can be omitted
* Anonymous block argument
* Expressions and non-local variables allowed in pin operator `^`

The following items are *not* addressed by this pull request as did not yet find a good way to implement them without causing all sorts of grammar conflicts.
* One-line pattern matching (both versions) is no longer experimental
* Inside “endless” method definitions, method calls without parenthesis are allowed

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
