### PR TITLE
Update to Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm test
   test_windows:
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm run-script test-windows


### PR DESCRIPTION
This follows the change from https://github.com/tree-sitter/tree-sitter-java/pull/106 to try to get CI for windows working again. Thanks so much for the pointer!