### PR TITLE
Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = ">= 0.19, < 0.21"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -8,8 +8,8 @@ way.)
 
 ``` toml
 [dependencies]
-tree-sitter = "0.17"
-tree-sitter-ruby = "0.16"
+tree-sitter = "0.19"
+tree-sitter-ruby = "0.19"
 ```
 
 Typically, you will use the [language][language func] function to add this


### PR DESCRIPTION
Allow a range of tree-sitter in dependencies. (Akin to tree-sitter-go)