### PR TITLE
CI: use windows-2019 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: npm install
       - run: npm test
   test_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
@maxbrunsfeld This PR fixes the CI failures on windows but running the jobs on windows-2019. 

See also: https://github.blog/changelog/2021-11-16-github-actions-windows-server-2022-with-visual-studio-2022-is-now-generally-available-on-github-hosted-runners/

I think a better fix would be to upgrade node-gyp upstream to a version that works with Visual Studio 2022, but this should work for now.

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
