### PR TITLE
Add named rules for the various call operators

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -33,7 +33,7 @@ const ALPHA_CHAR = /[^\x00-\x1F\s0-9:;`"'@$#.,|^&<=>+\-*/\\%?!~()\[\]{}]/;
 
 module.exports = grammar({
   name: 'ruby',
-  inline: $ => [$._arg_rhs],
+  inline: $ => [$._arg_rhs, $._call_operator],
   externals: $ => [
     $._line_break,
 
@@ -79,6 +79,7 @@ module.exports = grammar({
   supertypes: $ => [
     $._statement,
     $._arg,
+    $._call_operator,
     $._method_name,
     $._expression,
     $._variable,
@@ -711,9 +712,10 @@ module.exports = grammar({
       field('name', $.constant)
     )),
 
+    _call_operator: $ => choice('.', '&.', token.immediate('::')),
     _call: $ => prec.left(PREC.CALL, seq(
       field('receiver', $._primary),
-      field('operator', choice('.', '&.', token.immediate('::'))),
+      field('operator', $._call_operator),
       field('method', choice($.identifier, $.operator, $.constant, $._function_identifier)),
     )),
 
@@ -745,7 +747,7 @@ module.exports = grammar({
 
     _chained_command_call: $ => seq(
       field('receiver', alias($.command_call_with_block, $.call)),
-      field('operator', choice('.', '&.', token.immediate('::'))),
+      field('operator', $._call_operator),
       field('method', choice($.identifier, $._function_identifier, $.operator, $.constant)),
     ),
 
@@ -764,7 +766,7 @@ module.exports = grammar({
             receiver,
             prec.left(PREC.CALL, seq(
               field('receiver', $._primary),
-              field('operator', choice('.', '&.', token.immediate('::')))
+              field('operator', $._call_operator)
             ))
           ),
           arguments

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3855,6 +3855,26 @@
         ]
       }
     },
+    "_call_operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "STRING",
+          "value": "&."
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "::"
+          }
+        }
+      ]
+    },
     "_call": {
       "type": "PREC_LEFT",
       "value": 56,
@@ -3873,24 +3893,8 @@
             "type": "FIELD",
             "name": "operator",
             "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "."
-                },
-                {
-                  "type": "STRING",
-                  "value": "&."
-                },
-                {
-                  "type": "IMMEDIATE_TOKEN",
-                  "content": {
-                    "type": "STRING",
-                    "value": "::"
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "_call_operator"
             }
           },
           {
@@ -4116,24 +4120,8 @@
           "type": "FIELD",
           "name": "operator",
           "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "."
-              },
-              {
-                "type": "STRING",
-                "value": "&."
-              },
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "::"
-                }
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "_call_operator"
           }
         },
         {
@@ -4216,24 +4204,8 @@
                         "type": "FIELD",
                         "name": "operator",
                         "content": {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "STRING",
-                              "value": "."
-                            },
-                            {
-                              "type": "STRING",
-                              "value": "&."
-                            },
-                            {
-                              "type": "IMMEDIATE_TOKEN",
-                              "content": {
-                                "type": "STRING",
-                                "value": "::"
-                              }
-                            }
-                          ]
+                          "type": "SYMBOL",
+                          "name": "_call_operator"
                         }
                       }
                     ]
@@ -4307,24 +4279,8 @@
                               "type": "FIELD",
                               "name": "operator",
                               "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "."
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "&."
-                                  },
-                                  {
-                                    "type": "IMMEDIATE_TOKEN",
-                                    "content": {
-                                      "type": "STRING",
-                                      "value": "::"
-                                    }
-                                  }
-                                ]
+                                "type": "SYMBOL",
+                                "name": "_call_operator"
                               }
                             }
                           ]
@@ -4409,24 +4365,8 @@
                               "type": "FIELD",
                               "name": "operator",
                               "content": {
-                                "type": "CHOICE",
-                                "members": [
-                                  {
-                                    "type": "STRING",
-                                    "value": "."
-                                  },
-                                  {
-                                    "type": "STRING",
-                                    "value": "&."
-                                  },
-                                  {
-                                    "type": "IMMEDIATE_TOKEN",
-                                    "content": {
-                                      "type": "STRING",
-                                      "value": "::"
-                                    }
-                                  }
-                                ]
+                                "type": "SYMBOL",
+                                "name": "_call_operator"
                               }
                             }
                           ]
@@ -7967,11 +7907,13 @@
     }
   ],
   "inline": [
-    "_arg_rhs"
+    "_arg_rhs",
+    "_call_operator"
   ],
   "supertypes": [
     "_statement",
     "_arg",
+    "_call_operator",
     "_method_name",
     "_expression",
     "_variable",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -34,6 +34,24 @@
     ]
   },
   {
+    "type": "_call_operator",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "&.",
+        "named": false
+      },
+      {
+        "type": ".",
+        "named": false
+      },
+      {
+        "type": "::",
+        "named": false
+      }
+    ]
+  },
+  {
     "type": "_expression",
     "named": true,
     "subtypes": [
@@ -1214,16 +1232,8 @@
         "required": false,
         "types": [
           {
-            "type": "&.",
-            "named": false
-          },
-          {
-            "type": ".",
-            "named": false
-          },
-          {
-            "type": "::",
-            "named": false
+            "type": "_call_operator",
+            "named": true
           }
         ]
       },

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -123,6 +123,7 @@ struct TSLanguage {
     unsigned (*serialize)(void *, char *);
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
+  const TSStateId *primary_state_ids;
 };
 
 /*


### PR DESCRIPTION
Having named operators helps the CodeQL dbscheme generator to produce better output.

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
