### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,20 @@ VERSION := 0.19.0
 # Repository
 SRC_DIR := src
 
-PARSER_REPO_URL ?= $(shell git -C $(SRC_DIR) remote get-url origin )
-# the # in the sed pattern has to be escaped or it will be interpreted as a comment
-PARSER_NAME ?= $(shell basename $(PARSER_REPO_URL) | cut -d '-' -f3 | sed 's\#.git\#\#')
+PARSER_REPO_URL := $(shell git -C $(SRC_DIR) remote get-url origin )
+
+ifeq (, $(PARSER_NAME))
+	PARSER_NAME := $(shell basename $(PARSER_REPO_URL))
+	PARSER_NAME := $(subst tree-sitter-,,$(PARSER_NAME))
+	PARSER_NAME := $(subst .git,,$(PARSER_NAME))
+endif
+
+ifeq (, $(PARSER_URL))
+	PARSER_URL := $(subst :,/,$(PARSER_REPO_URL))
+	PARSER_URL := $(subst git@,https://,$(PARSER_URL))
+	PARSER_URL := $(subst .git,,$(PARSER_URL))
+endif
+
 UPPER_PARSER_NAME := $(shell echo $(PARSER_NAME) | tr a-z A-Z )
 
 # install directory layout
@@ -61,7 +72,7 @@ ifneq (,$(filter $(shell uname),FreeBSD NetBSD DragonFly))
 	PCLIBDIR := $(PREFIX)/libdata/pkgconfig
 endif
 				
-all: libtree-sitter-$(PARSER_NAME).a libtree-sitter-$(PARSER_NAME).$(SOEXTVER) bindings/c/$(PARSER_NAME).h
+all: libtree-sitter-$(PARSER_NAME).a libtree-sitter-$(PARSER_NAME).$(SOEXTVER) bindings/c/$(PARSER_NAME).h bindings/c/tree-sitter-$(PARSER_NAME).pc
 
 libtree-sitter-$(PARSER_NAME).a: $(OBJ)
 	$(AR) rcs $@ $^
@@ -76,6 +87,15 @@ bindings/c/$(PARSER_NAME).h:
 		-e 's|@PARSERNAME@|$(PARSER_NAME)|' \
 		bindings/c/tree-sitter.h.in > $@
 
+bindings/c/tree-sitter-$(PARSER_NAME).pc:
+	sed -e 's|@LIBDIR@|$(LIBDIR)|;s|@INCLUDEDIR@|$(INCLUDEDIR)|;s|@VERSION@|$(VERSION)|' \
+		-e 's|=$(PREFIX)|=$${prefix}|' \
+		-e 's|@PREFIX@|$(PREFIX)|' \
+		-e 's|@ADDITIONALLIBS@|$(ADDITIONALLIBS)|' \
+		-e 's|@PARSERNAME@|$(PARSER_NAME)|' \
+		-e 's|@PARSERURL@|$(PARSER_URL)|' \
+		bindings/c/tree-sitter.pc.in > $@
+
 install: all
 	install -d '$(DESTDIR)$(LIBDIR)'
 	install -m755 libtree-sitter-$(PARSER_NAME).a '$(DESTDIR)$(LIBDIR)'/libtree-sitter-$(PARSER_NAME).a
@@ -85,15 +105,10 @@ install: all
 	install -d '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter
 	install -m644 bindings/c/$(PARSER_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/
 	install -d '$(DESTDIR)$(PCLIBDIR)'
-	sed -e 's|@LIBDIR@|$(LIBDIR)|;s|@INCLUDEDIR@|$(INCLUDEDIR)|;s|@VERSION@|$(VERSION)|' \
-	    -e 's|=$(PREFIX)|=$${prefix}|' \
-	    -e 's|@PREFIX@|$(PREFIX)|' \
-	    -e 's|@ADDITIONALLIBS@|$(ADDITIONALLIBS)|' \
-		-e 's|@PARSERNAME@|$(PARSER_NAME)|' \
-		-e 's|@PARSERREPOURL@|$(PARSER_REPO_URL)|' \
-	    bindings/c/tree-sitter.pc.in > '$(DESTDIR)$(PCLIBDIR)'/tree-sitter-$(PARSER_NAME).pc
+	install -m644 bindings/c/tree-sitter-$(PARSER_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/
 
 clean:
-	rm -f $(OBJ) libtree-sitter-$(PARSER_NAME).a libtree-sitter-$(PARSER_NAME).$(SOEXT) libtree-sitter-$(PARSER_NAME).$(SOEXTVER_MAJOR) libtree-sitter-$(PARSER_NAME).$(SOEXTVER) bindings/c/$(PARSER_NAME).h
+	rm -f $(OBJ) libtree-sitter-$(PARSER_NAME).a libtree-sitter-$(PARSER_NAME).$(SOEXT) libtree-sitter-$(PARSER_NAME).$(SOEXTVER_MAJOR) libtree-sitter-$(PARSER_NAME).$(SOEXTVER)
+	rm -f bindings/c/$(PARSER_NAME).h bindings/c/tree-sitter-$(PARSER_NAME).pc
 
 .PHONY: all install clean

--- a/bindings/c/tree-sitter.pc.in
+++ b/bindings/c/tree-sitter.pc.in
@@ -5,7 +5,7 @@ additionallibs=@ADDITIONALLIBS@
 
 Name: tree-sitter-@PARSERNAME@
 Description: A tree-sitter grammar for the @PARSERNAME@ programming language.
-URL: @PARSERREPOURL@
+URL: @PARSERURL@
 Version: @VERSION@
 Libs: -L${libdir} ${additionallibs} -ltree-sitter-@PARSERNAME@
 Cflags: -I${includedir}


### PR DESCRIPTION
Sorry for the churn here - timing worked out a little poorly compared to https://github.com/tree-sitter/tree-sitter-ruby/pull/199. This brings the Makefile and C bindings up to date with the latest version being used. I didn't want to leave it in an out-of-sync state.

It's a small number of changes, and is functionally-equivalent to what was there.

- improves the ability to detect the parser's URL and name
- treats the .h and .pc files as build targets
- fixes the URL in the .pc file