### PR TITLE
Fix parse error in 'foo! if condition'

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -975,7 +975,7 @@ module.exports = grammar({
     rest_assignment: $ => prec(-1, seq('*', optional($._lhs))),
 
     _function_identifier: $ => choice(alias($.identifier_suffix, $.identifier), alias($.constant_suffix, $.constant)),
-    _function_identifier_call: $ => prec.right(field('method', $._function_identifier)),
+    _function_identifier_call: $ => prec.left(field('method', $._function_identifier)),
     _lhs: $ => prec.left(choice(
       $._variable,
       $.true,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6383,7 +6383,7 @@
       ]
     },
     "_function_identifier_call": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "FIELD",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -705,7 +705,8 @@ exit!()
 include?
 include?("hello")
 include? "hello"
-
+exit! if done
+exit!() if done
 
 ---
 
@@ -732,7 +733,16 @@ include? "hello"
     arguments: (argument_list (string (string_content))))
   (call
     method: (identifier)
-    arguments: (argument_list (string (string_content)))))
+    arguments: (argument_list (string (string_content))))
+  (if_modifier
+    body: (call
+      method: (identifier))
+    condition: (identifier))
+  (if_modifier
+    body: (call
+      method: (identifier)
+      arguments: (argument_list))
+    condition: (identifier)))
 
 ====================================
 nested unparenthesized method calls


### PR DESCRIPTION

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
