### PR TITLE
Wrap class, module, method, and block bodies in a named node

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -159,7 +159,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional(field('method_body', $.body_statement)), 'end'),
+            seq(optional($._terminator), optional(field('body', $.body_statement)), 'end'),
             $._body_expr
           )
 
@@ -169,7 +169,7 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional(field('method_body', $.body_statement)),
+          optional(field('body', $.body_statement)),
           'end'
         ),
       ),
@@ -266,7 +266,7 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional(field('namespace_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 
@@ -282,7 +282,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional(field('namespace_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 
@@ -290,7 +290,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional(field('namespace_body', $.body_statement)), 'end'),
+        seq($._terminator, optional(field('body', $.body_statement)), 'end'),
         'end'
       )
     ),
@@ -830,7 +830,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional(field('do_block_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -159,7 +159,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional($.method_body), 'end'),
+            seq(optional($._terminator), optional(field("method_body", $.body)), 'end'),
             $._body_expr
           )
 
@@ -169,13 +169,11 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional($.method_body),
+          optional(field("method_body", $.body)),
           'end'
         ),
       ),
     ),
-
-    method_body: $ => $._body,
 
     rescue_modifier_arg: $ => prec(PREC.RESCUE,
       seq(
@@ -268,13 +266,11 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional($.namespace_body),
+      optional(field("namespace_body", $.body)),
       'end'
     ),
 
-    namespace_body: $ => $._body,
-
-    _body: $ => choice(
+    body: $ => choice(
       seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
       seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
     ),
@@ -286,7 +282,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional($.namespace_body),
+      optional(field("namespace_body", $.body)),
       'end'
     ),
 
@@ -294,7 +290,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional($.namespace_body), 'end'),
+        seq($._terminator, optional(field("namespace_body", $.body)), 'end'),
         'end'
       )
     ),
@@ -826,7 +822,6 @@ module.exports = grammar({
     splat_argument: $ => seq(alias($._splat_star, '*'), $._arg),
     hash_splat_argument: $ => seq(alias($._hash_splat_star_star, '**'), $._arg),
     block_argument: $ => prec.right(seq(alias($._block_ampersand, '&'), optional($._arg))),
-    do_block_body: $=> $._body,
 
     do_block: $ => seq(
       'do',
@@ -835,7 +830,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional($.do_block_body),
+      optional(field("do_block_body", $.body)),
       'end'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -159,7 +159,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional(field("method_body", $.body)), 'end'),
+            seq(optional($._terminator), optional(field("method_body", $.body_statement)), 'end'),
             $._body_expr
           )
 
@@ -169,7 +169,7 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional(field("method_body", $.body)),
+          optional(field("method_body", $.body_statement)),
           'end'
         ),
       ),
@@ -266,11 +266,11 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional(field("namespace_body", $.body)),
+      optional(field("namespace_body", $.body_statement)),
       'end'
     ),
 
-    body: $ => choice(
+    body_statement: $ => choice(
       seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
       seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
     ),
@@ -282,7 +282,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional(field("namespace_body", $.body)),
+      optional(field("namespace_body", $.body_statement)),
       'end'
     ),
 
@@ -290,7 +290,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional(field("namespace_body", $.body)), 'end'),
+        seq($._terminator, optional(field("namespace_body", $.body_statement)), 'end'),
         'end'
       )
     ),
@@ -830,7 +830,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional(field("do_block_body", $.body)),
+      optional(field("do_block_body", $.body_statement)),
       'end'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -837,7 +837,7 @@ module.exports = grammar({
     block: $ => prec(PREC.CURLY_BLOCK, seq(
       '{',
       field('parameters', optional($.block_parameters)),
-      optional($.block_body),
+      optional(field('body', $.block_body)),
       '}'
     )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -159,7 +159,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional(field('body', $.body_statement)), 'end'),
+            seq(optional($._terminator), optional(field('method_body', $.body_statement)), 'end'),
             $._body_expr
           )
 
@@ -169,7 +169,7 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional(field('body', $.body_statement)),
+          optional(field('method_body', $.body_statement)),
           'end'
         ),
       ),
@@ -266,7 +266,7 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional(field('body', $.body_statement)),
+      optional(field('namespace_body', $.body_statement)),
       'end'
     ),
 
@@ -277,7 +277,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional(field('body', $.body_statement)),
+      optional(field('namespace_body', $.body_statement)),
       'end'
     ),
 
@@ -285,7 +285,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional(field('body', $.body_statement)), 'end'),
+        seq($._terminator, optional(field('namespace_body', $.body_statement)), 'end'),
         'end'
       )
     ),
@@ -826,7 +826,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional(field('body', $.body_statement)),
+      optional(field('do_block_body', $.body_statement)),
       'end'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -270,11 +270,6 @@ module.exports = grammar({
       'end'
     ),
 
-    body_statement: $ => choice(
-      seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
-      seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
-    ),
-
     superclass: $ => seq('<', $._expression),
 
     singleton_class: $ => seq(
@@ -601,7 +596,7 @@ module.exports = grammar({
       )
     ),
 
-    begin: $ => seq('begin', optional($._terminator), $._body_statement),
+    begin: $ => seq('begin', optional($._terminator), optional($._body_statement), 'end'),
 
     ensure: $ => seq('ensure', optional($._statements)),
 
@@ -619,10 +614,11 @@ module.exports = grammar({
 
     exception_variable: $ => seq('=>', $._lhs),
 
-    _body_statement: $ => seq(
-      optional($._statements),
-      repeat(choice($.rescue, $.else, $.ensure)),
-      'end'
+    body_statement: $ => $._body_statement,
+
+    _body_statement: $ => choice(
+      seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
+      seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
     ),
 
     // Method calls without parentheses (aka "command calls") are only allowed

--- a/grammar.js
+++ b/grammar.js
@@ -266,7 +266,7 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional(field("body", $.namespace_body)),
+      optional($.namespace_body),
       'end'
     ),
 
@@ -287,7 +287,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional(field("body", $.namespace_body)),
+      optional($.namespace_body),
       'end'
     ),
 
@@ -295,7 +295,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional(field("body", $.namespace_body)), 'end'),
+        seq($._terminator, optional($.namespace_body), 'end'),
         'end'
       )
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -266,8 +266,13 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional($.body),
+      optional(field("body", $.namespace_body)),
       'end'
+    ),
+
+    namespace_body: $ => choice(
+      seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
+      seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
     ),
 
     body: $ => choice(
@@ -282,7 +287,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional($.body),
+      optional(field("body", $.namespace_body)),
       'end'
     ),
 
@@ -290,7 +295,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional($.body), 'end'),
+        seq($._terminator, optional(field("body", $.namespace_body)), 'end'),
         'end'
       )
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -159,7 +159,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional(field("method_body", $.body_statement)), 'end'),
+            seq(optional($._terminator), optional(field('method_body', $.body_statement)), 'end'),
             $._body_expr
           )
 
@@ -169,7 +169,7 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional(field("method_body", $.body_statement)),
+          optional(field('method_body', $.body_statement)),
           'end'
         ),
       ),
@@ -266,7 +266,7 @@ module.exports = grammar({
       field('name', choice($.constant, $.scope_resolution)),
       field('superclass', optional($.superclass)),
       $._terminator,
-      optional(field("namespace_body", $.body_statement)),
+      optional(field('namespace_body', $.body_statement)),
       'end'
     ),
 
@@ -282,7 +282,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional(field("namespace_body", $.body_statement)),
+      optional(field('namespace_body', $.body_statement)),
       'end'
     ),
 
@@ -290,7 +290,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       choice(
-        seq($._terminator, optional(field("namespace_body", $.body_statement)), 'end'),
+        seq($._terminator, optional(field('namespace_body', $.body_statement)), 'end'),
         'end'
       )
     ),
@@ -830,7 +830,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional(field("do_block_body", $.body_statement)),
+      optional(field('do_block_body', $.body_statement)),
       'end'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -160,7 +160,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional(field('method_body', $.body_statement)), 'end'),
+            seq(optional($._terminator), optional(field('body', $.body_statement)), 'end'),
             $._body_expr
           )
 
@@ -170,7 +170,7 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional(field('method_body', $.body_statement)),
+          optional(field('body', $.body_statement)),
           'end'
         ),
       ),
@@ -269,7 +269,7 @@ module.exports = grammar({
         seq(field('superclass', $.superclass), $._terminator),
         optional($._terminator)
       ),
-      optional(field('namespace_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 
@@ -280,7 +280,7 @@ module.exports = grammar({
       alias($._singleton_class_left_angle_left_langle, '<<'),
       field('value', $._arg),
       $._terminator,
-      optional(field('namespace_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 
@@ -288,7 +288,7 @@ module.exports = grammar({
       'module',
       field('name', choice($.constant, $.scope_resolution)),
       optional($._terminator),
-      optional(field('namespace_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 
@@ -828,7 +828,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional(field('do_block_body', $.body_statement)),
+      optional(field('body', $.body_statement)),
       'end'
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -159,7 +159,7 @@ module.exports = grammar({
         seq(
           field('parameters', alias($.parameters, $.method_parameters)),
           choice(
-            seq(optional($._terminator), optional($.body), 'end'),
+            seq(optional($._terminator), optional($.method_body), 'end'),
             $._body_expr
           )
 
@@ -169,11 +169,13 @@ module.exports = grammar({
             field('parameters', alias($.bare_parameters, $.method_parameters))
           ),
           $._terminator,
-          optional($.body),
+          optional($.method_body),
           'end'
         ),
       ),
     ),
+
+    method_body: $ => $._body,
 
     rescue_modifier_arg: $ => prec(PREC.RESCUE,
       seq(
@@ -270,12 +272,9 @@ module.exports = grammar({
       'end'
     ),
 
-    namespace_body: $ => choice(
-      seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
-      seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
-    ),
+    namespace_body: $ => $._body,
 
-    body: $ => choice(
+    _body: $ => choice(
       seq($._statements, repeat(choice($.rescue, $.else, $.ensure))),
       seq(optional($._statements), repeat1(choice($.rescue, $.else, $.ensure))),
     ),
@@ -827,6 +826,7 @@ module.exports = grammar({
     splat_argument: $ => seq(alias($._splat_star, '*'), $._arg),
     hash_splat_argument: $ => seq(alias($._hash_splat_star_star, '**'), $._arg),
     block_argument: $ => prec.right(seq(alias($._block_ampersand, '&'), optional($._arg))),
+    do_block_body: $=> $._body,
 
     do_block: $ => seq(
       'do',
@@ -835,7 +835,7 @@ module.exports = grammar({
         field('parameters', $.block_parameters),
         optional($._terminator)
       )),
-      optional($.body),
+      optional($.do_block_body),
       'end'
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -344,7 +344,7 @@
                               "name": "method_body",
                               "content": {
                                 "type": "SYMBOL",
-                                "name": "body"
+                                "name": "body_statement"
                               }
                             },
                             {
@@ -402,7 +402,7 @@
                       "name": "method_body",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "body"
+                        "name": "body_statement"
                       }
                     },
                     {
@@ -957,7 +957,7 @@
               "name": "namespace_body",
               "content": {
                 "type": "SYMBOL",
-                "name": "body"
+                "name": "body_statement"
               }
             },
             {
@@ -971,7 +971,7 @@
         }
       ]
     },
-    "body": {
+    "body_statement": {
       "type": "CHOICE",
       "members": [
         {
@@ -1091,7 +1091,7 @@
               "name": "namespace_body",
               "content": {
                 "type": "SYMBOL",
-                "name": "body"
+                "name": "body_statement"
               }
             },
             {
@@ -1147,7 +1147,7 @@
                       "name": "namespace_body",
                       "content": {
                         "type": "SYMBOL",
-                        "name": "body"
+                        "name": "body_statement"
                       }
                     },
                     {
@@ -4908,7 +4908,7 @@
               "name": "do_block_body",
               "content": {
                 "type": "SYMBOL",
-                "name": "body"
+                "name": "body_statement"
               }
             },
             {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -945,8 +945,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "body"
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "namespace_body"
+              }
             },
             {
               "type": "BLANK"
@@ -956,6 +960,77 @@
         {
           "type": "STRING",
           "value": "end"
+        }
+      ]
+    },
+    "namespace_body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "rescue"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "else"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ensure"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "rescue"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "else"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ensure"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -1075,8 +1150,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "body"
+              "type": "FIELD",
+              "name": "body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "namespace_body"
+              }
             },
             {
               "type": "BLANK"
@@ -1127,8 +1206,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "body"
+                      "type": "FIELD",
+                      "name": "body",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "namespace_body"
+                      }
                     },
                     {
                       "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -341,7 +341,7 @@
                           "members": [
                             {
                               "type": "SYMBOL",
-                              "name": "body"
+                              "name": "method_body"
                             },
                             {
                               "type": "BLANK"
@@ -395,7 +395,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "body"
+                      "name": "method_body"
                     },
                     {
                       "type": "BLANK"
@@ -411,6 +411,10 @@
           ]
         }
       ]
+    },
+    "method_body": {
+      "type": "SYMBOL",
+      "name": "_body"
     },
     "rescue_modifier_arg": {
       "type": "PREC",
@@ -960,77 +964,10 @@
       ]
     },
     "namespace_body": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "rescue"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "else"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ensure"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "REPEAT1",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "rescue"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "else"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ensure"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      ]
+      "type": "SYMBOL",
+      "name": "_body"
     },
-    "body": {
+    "_body": {
       "type": "CHOICE",
       "members": [
         {
@@ -4899,6 +4836,10 @@
         ]
       }
     },
+    "do_block_body": {
+      "type": "SYMBOL",
+      "name": "_body"
+    },
     "do_block": {
       "type": "SEQ",
       "members": [
@@ -4956,7 +4897,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "body"
+              "name": "do_block_body"
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -48,6 +48,10 @@
       "type": "PATTERN",
       "value": "(.|\\s)*"
     },
+    "block_body": {
+      "type": "SYMBOL",
+      "name": "_statements"
+    },
     "_statements": {
       "type": "CHOICE",
       "members": [
@@ -333,8 +337,20 @@
                           ]
                         },
                         {
-                          "type": "SYMBOL",
-                          "name": "_body_statement"
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "SYMBOL",
+                              "name": "body"
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "end"
                         }
                       ]
                     },
@@ -375,8 +391,20 @@
                   "name": "_terminator"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_body_statement"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "body"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "end"
                 }
               ]
             }
@@ -914,8 +942,91 @@
           "name": "_terminator"
         },
         {
-          "type": "SYMBOL",
-          "name": "_body_statement"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
+        }
+      ]
+    },
+    "body": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_statements"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "rescue"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "else"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ensure"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "rescue"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "else"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ensure"
+                  }
+                ]
+              }
+            }
+          ]
         }
       ]
     },
@@ -961,8 +1072,20 @@
           "name": "_terminator"
         },
         {
-          "type": "SYMBOL",
-          "name": "_body_statement"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
         }
       ]
     },
@@ -1001,8 +1124,20 @@
                   "name": "_terminator"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "_body_statement"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "body"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "STRING",
+                  "value": "end"
                 }
               ]
             },
@@ -4746,8 +4881,20 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_body_statement"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "body"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
         }
       ]
     },
@@ -4782,7 +4929,7 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_statements"
+                "name": "block_body"
               },
               {
                 "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4952,8 +4952,12 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "block_body"
+                "type": "FIELD",
+                "name": "body",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "block_body"
+                }
               },
               {
                 "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -340,8 +340,12 @@
                           "type": "CHOICE",
                           "members": [
                             {
-                              "type": "SYMBOL",
-                              "name": "method_body"
+                              "type": "FIELD",
+                              "name": "method_body",
+                              "content": {
+                                "type": "SYMBOL",
+                                "name": "body"
+                              }
                             },
                             {
                               "type": "BLANK"
@@ -394,8 +398,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "method_body"
+                      "type": "FIELD",
+                      "name": "method_body",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "body"
+                      }
                     },
                     {
                       "type": "BLANK"
@@ -411,10 +419,6 @@
           ]
         }
       ]
-    },
-    "method_body": {
-      "type": "SYMBOL",
-      "name": "_body"
     },
     "rescue_modifier_arg": {
       "type": "PREC",
@@ -949,8 +953,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "namespace_body"
+              "type": "FIELD",
+              "name": "namespace_body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "body"
+              }
             },
             {
               "type": "BLANK"
@@ -963,11 +971,7 @@
         }
       ]
     },
-    "namespace_body": {
-      "type": "SYMBOL",
-      "name": "_body"
-    },
-    "_body": {
+    "body": {
       "type": "CHOICE",
       "members": [
         {
@@ -1083,8 +1087,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "namespace_body"
+              "type": "FIELD",
+              "name": "namespace_body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "body"
+              }
             },
             {
               "type": "BLANK"
@@ -1135,8 +1143,12 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "SYMBOL",
-                      "name": "namespace_body"
+                      "type": "FIELD",
+                      "name": "namespace_body",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "body"
+                      }
                     },
                     {
                       "type": "BLANK"
@@ -4836,10 +4848,6 @@
         ]
       }
     },
-    "do_block_body": {
-      "type": "SYMBOL",
-      "name": "_body"
-    },
     "do_block": {
       "type": "SEQ",
       "members": [
@@ -4896,8 +4904,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "do_block_body"
+              "type": "FIELD",
+              "name": "do_block_body",
+              "content": {
+                "type": "SYMBOL",
+                "name": "body"
+              }
             },
             {
               "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -341,7 +341,7 @@
                           "members": [
                             {
                               "type": "FIELD",
-                              "name": "method_body",
+                              "name": "body",
                               "content": {
                                 "type": "SYMBOL",
                                 "name": "body_statement"
@@ -399,7 +399,7 @@
                   "members": [
                     {
                       "type": "FIELD",
-                      "name": "method_body",
+                      "name": "body",
                       "content": {
                         "type": "SYMBOL",
                         "name": "body_statement"
@@ -954,7 +954,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "namespace_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -1088,7 +1088,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "namespace_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -1144,7 +1144,7 @@
                   "members": [
                     {
                       "type": "FIELD",
-                      "name": "namespace_body",
+                      "name": "body",
                       "content": {
                         "type": "SYMBOL",
                         "name": "body_statement"
@@ -4905,7 +4905,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "do_block_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -341,7 +341,7 @@
                           "members": [
                             {
                               "type": "FIELD",
-                              "name": "body",
+                              "name": "method_body",
                               "content": {
                                 "type": "SYMBOL",
                                 "name": "body_statement"
@@ -399,7 +399,7 @@
                   "members": [
                     {
                       "type": "FIELD",
-                      "name": "body",
+                      "name": "method_body",
                       "content": {
                         "type": "SYMBOL",
                         "name": "body_statement"
@@ -954,7 +954,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "body",
+              "name": "namespace_body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -1017,7 +1017,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "body",
+              "name": "namespace_body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -1073,7 +1073,7 @@
                   "members": [
                     {
                       "type": "FIELD",
-                      "name": "body",
+                      "name": "namespace_body",
                       "content": {
                         "type": "SYMBOL",
                         "name": "body_statement"
@@ -4880,7 +4880,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "body",
+              "name": "do_block_body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -971,77 +971,6 @@
         }
       ]
     },
-    "body_statement": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_statements"
-            },
-            {
-              "type": "REPEAT",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "rescue"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "else"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ensure"
-                  }
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "_statements"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            },
-            {
-              "type": "REPEAT1",
-              "content": {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "rescue"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "else"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "ensure"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      ]
-    },
     "superclass": {
       "type": "SEQ",
       "members": [
@@ -3334,8 +3263,20 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_body_statement"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_body_statement"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "end"
         }
       ]
     },
@@ -3474,44 +3415,78 @@
         }
       ]
     },
+    "body_statement": {
+      "type": "SYMBOL",
+      "name": "_body_statement"
+    },
     "_body_statement": {
-      "type": "SEQ",
+      "type": "CHOICE",
       "members": [
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
               "type": "SYMBOL",
               "name": "_statements"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "rescue"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "else"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ensure"
+                  }
+                ]
+              }
             }
           ]
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "rescue"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "else"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "ensure"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_statements"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "REPEAT1",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "rescue"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "else"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "ensure"
+                  }
+                ]
               }
-            ]
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "end"
+            }
+          ]
         }
       ]
     },

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -945,12 +945,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "SYMBOL",
-                "name": "namespace_body"
-              }
+              "type": "SYMBOL",
+              "name": "namespace_body"
             },
             {
               "type": "BLANK"
@@ -1150,12 +1146,8 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "FIELD",
-              "name": "body",
-              "content": {
-                "type": "SYMBOL",
-                "name": "namespace_body"
-              }
+              "type": "SYMBOL",
+              "name": "namespace_body"
             },
             {
               "type": "BLANK"
@@ -1206,12 +1198,8 @@
                   "type": "CHOICE",
                   "members": [
                     {
-                      "type": "FIELD",
-                      "name": "body",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "namespace_body"
-                      }
+                      "type": "SYMBOL",
+                      "name": "namespace_body"
                     },
                     {
                       "type": "BLANK"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -360,7 +360,7 @@
                           "members": [
                             {
                               "type": "FIELD",
-                              "name": "method_body",
+                              "name": "body",
                               "content": {
                                 "type": "SYMBOL",
                                 "name": "body_statement"
@@ -418,7 +418,7 @@
                   "members": [
                     {
                       "type": "FIELD",
-                      "name": "method_body",
+                      "name": "body",
                       "content": {
                         "type": "SYMBOL",
                         "name": "body_statement"
@@ -987,7 +987,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "namespace_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -1050,7 +1050,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "namespace_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -1108,7 +1108,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "namespace_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"
@@ -4907,7 +4907,7 @@
           "members": [
             {
               "type": "FIELD",
-              "name": "do_block_body",
+              "name": "body",
               "content": {
                 "type": "SYMBOL",
                 "name": "body_statement"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1380,6 +1380,16 @@
     "type": "class",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "namespace_body",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
         "required": true,
@@ -1404,16 +1414,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "body",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -2429,6 +2429,16 @@
     "type": "module",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "namespace_body",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
         "required": true,
@@ -2443,13 +2453,34 @@
           }
         ]
       }
-    },
+    }
+  },
+  {
+    "type": "namespace_body",
+    "named": true,
+    "fields": {},
     "children": {
-      "multiple": false,
-      "required": false,
+      "multiple": true,
+      "required": true,
       "types": [
         {
-          "type": "body",
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "else",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "ensure",
+          "named": true
+        },
+        {
+          "type": "rescue",
           "named": true
         }
       ]
@@ -2989,6 +3020,16 @@
     "type": "singleton_class",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "namespace_body",
+            "named": true
+          }
+        ]
+      },
       "value": {
         "multiple": false,
         "required": true,
@@ -2999,16 +3040,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "body",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1055,6 +1055,16 @@
     "type": "block",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "block_body",
+            "named": true
+          }
+        ]
+      },
       "parameters": {
         "multiple": false,
         "required": false,
@@ -1065,16 +1075,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "block_body",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1380,6 +1380,16 @@
     "type": "class",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body_statement",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
         "required": true,
@@ -1390,16 +1400,6 @@
           },
           {
             "type": "scope_resolution",
-            "named": true
-          }
-        ]
-      },
-      "namespace_body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "body_statement",
             "named": true
           }
         ]
@@ -1596,7 +1596,7 @@
     "type": "do_block",
     "named": true,
     "fields": {
-      "do_block_body": {
+      "body": {
         "multiple": false,
         "required": false,
         "types": [
@@ -2338,7 +2338,7 @@
     "type": "method",
     "named": true,
     "fields": {
-      "method_body": {
+      "body": {
         "multiple": false,
         "required": false,
         "types": [
@@ -2435,6 +2435,16 @@
     "type": "module",
     "named": true,
     "fields": {
+      "body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body_statement",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
         "required": true,
@@ -2445,16 +2455,6 @@
           },
           {
             "type": "scope_resolution",
-            "named": true
-          }
-        ]
-      },
-      "namespace_body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "body_statement",
             "named": true
           }
         ]
@@ -2995,7 +2995,7 @@
     "type": "singleton_class",
     "named": true,
     "fields": {
-      "namespace_body": {
+      "body": {
         "multiple": false,
         "required": false,
         "types": [
@@ -3021,7 +3021,7 @@
     "type": "singleton_method",
     "named": true,
     "fields": {
-      "method_body": {
+      "body": {
         "multiple": false,
         "required": false,
         "types": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1067,15 +1067,11 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
+          "type": "block_body",
           "named": true
         }
       ]
@@ -1091,6 +1087,25 @@
       "types": [
         {
           "type": "_arg",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "block_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
           "named": true
         }
       ]
@@ -1165,6 +1180,37 @@
         },
         {
           "type": "splat_parameter",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "else",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "ensure",
+          "named": true
+        },
+        {
+          "type": "rescue",
           "named": true
         }
       ]
@@ -1360,27 +1406,11 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
+          "type": "body",
           "named": true
         }
       ]
@@ -1578,27 +1608,11 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
+          "type": "body",
           "named": true
         }
       ]
@@ -2346,7 +2360,7 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
@@ -2354,23 +2368,11 @@
           "named": true
         },
         {
-          "type": "_statement",
+          "type": "body",
           "named": true
         },
         {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
+          "type": "rescue_modifier",
           "named": true
         }
       ]
@@ -2443,27 +2445,11 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
+          "type": "body",
           "named": true
         }
       ]
@@ -3015,27 +3001,11 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
+          "type": "body",
           "named": true
         }
       ]
@@ -3081,7 +3051,7 @@
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
@@ -3089,23 +3059,11 @@
           "named": true
         },
         {
-          "type": "_statement",
+          "type": "body",
           "named": true
         },
         {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
+          "type": "rescue_modifier",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1186,7 +1186,7 @@
     }
   },
   {
-    "type": "body",
+    "type": "body_statement",
     "named": true,
     "fields": {},
     "children": {
@@ -1399,7 +1399,7 @@
         "required": false,
         "types": [
           {
-            "type": "body",
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -1601,7 +1601,7 @@
         "required": false,
         "types": [
           {
-            "type": "body",
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -2343,7 +2343,7 @@
         "required": false,
         "types": [
           {
-            "type": "body",
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -2454,7 +2454,7 @@
         "required": false,
         "types": [
           {
-            "type": "body",
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -3000,7 +3000,7 @@
         "required": false,
         "types": [
           {
-            "type": "body",
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -3026,7 +3026,7 @@
         "required": false,
         "types": [
           {
-            "type": "body",
+            "type": "body_statement",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1380,16 +1380,6 @@
     "type": "class",
     "named": true,
     "fields": {
-      "body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "body_statement",
-            "named": true
-          }
-        ]
-      },
       "name": {
         "multiple": false,
         "required": true,
@@ -1400,6 +1390,16 @@
           },
           {
             "type": "scope_resolution",
+            "named": true
+          }
+        ]
+      },
+      "namespace_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -1596,7 +1596,7 @@
     "type": "do_block",
     "named": true,
     "fields": {
-      "body": {
+      "do_block_body": {
         "multiple": false,
         "required": false,
         "types": [
@@ -2338,7 +2338,7 @@
     "type": "method",
     "named": true,
     "fields": {
-      "body": {
+      "method_body": {
         "multiple": false,
         "required": false,
         "types": [
@@ -2435,16 +2435,6 @@
     "type": "module",
     "named": true,
     "fields": {
-      "body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "body_statement",
-            "named": true
-          }
-        ]
-      },
       "name": {
         "multiple": false,
         "required": true,
@@ -2455,6 +2445,16 @@
           },
           {
             "type": "scope_resolution",
+            "named": true
+          }
+        ]
+      },
+      "namespace_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body_statement",
             "named": true
           }
         ]
@@ -2995,7 +2995,7 @@
     "type": "singleton_class",
     "named": true,
     "fields": {
-      "body": {
+      "namespace_body": {
         "multiple": false,
         "required": false,
         "types": [
@@ -3021,7 +3021,7 @@
     "type": "singleton_method",
     "named": true,
     "fields": {
-      "body": {
+      "method_body": {
         "multiple": false,
         "required": false,
         "types": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1186,37 +1186,6 @@
     }
   },
   {
-    "type": "body",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "break",
     "named": true,
     "fields": {},
@@ -1612,7 +1581,38 @@
       "required": false,
       "types": [
         {
-          "type": "body",
+          "type": "do_block_body",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "do_block_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "else",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "ensure",
+          "named": true
+        },
+        {
+          "type": "rescue",
           "named": true
         }
       ]
@@ -2368,11 +2368,42 @@
           "named": true
         },
         {
-          "type": "body",
+          "type": "method_body",
           "named": true
         },
         {
           "type": "rescue_modifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "method_body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "else",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "ensure",
+          "named": true
+        },
+        {
+          "type": "rescue",
           "named": true
         }
       ]
@@ -3090,7 +3121,7 @@
           "named": true
         },
         {
-          "type": "body",
+          "type": "method_body",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1186,6 +1186,37 @@
     }
   },
   {
+    "type": "body",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "_statement",
+          "named": true
+        },
+        {
+          "type": "else",
+          "named": true
+        },
+        {
+          "type": "empty_statement",
+          "named": true
+        },
+        {
+          "type": "ensure",
+          "named": true
+        },
+        {
+          "type": "rescue",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "break",
     "named": true,
     "fields": {},
@@ -1363,6 +1394,16 @@
           }
         ]
       },
+      "namespace_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
+      },
       "superclass": {
         "multiple": false,
         "required": false,
@@ -1373,16 +1414,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "namespace_body",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -1565,6 +1596,16 @@
     "type": "do_block",
     "named": true,
     "fields": {
+      "do_block_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
+      },
       "parameters": {
         "multiple": false,
         "required": false,
@@ -1575,47 +1616,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "do_block_body",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "do_block_body",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -2338,6 +2338,16 @@
     "type": "method",
     "named": true,
     "fields": {
+      "method_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
         "required": true,
@@ -2368,42 +2378,7 @@
           "named": true
         },
         {
-          "type": "method_body",
-          "named": true
-        },
-        {
           "type": "rescue_modifier",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "method_body",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
           "named": true
         }
       ]
@@ -2473,48 +2448,17 @@
             "named": true
           }
         ]
+      },
+      "namespace_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "namespace_body",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "namespace_body",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "_statement",
-          "named": true
-        },
-        {
-          "type": "else",
-          "named": true
-        },
-        {
-          "type": "empty_statement",
-          "named": true
-        },
-        {
-          "type": "ensure",
-          "named": true
-        },
-        {
-          "type": "rescue",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -3051,6 +2995,16 @@
     "type": "singleton_class",
     "named": true,
     "fields": {
+      "namespace_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
+      },
       "value": {
         "multiple": false,
         "required": true,
@@ -3061,22 +3015,22 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "namespace_body",
-          "named": true
-        }
-      ]
     }
   },
   {
     "type": "singleton_method",
     "named": true,
     "fields": {
+      "method_body": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "body",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
         "required": true,
@@ -3118,10 +3072,6 @@
       "types": [
         {
           "type": "_arg",
-          "named": true
-        },
-        {
-          "type": "method_body",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1380,16 +1380,6 @@
     "type": "class",
     "named": true,
     "fields": {
-      "body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_body",
-            "named": true
-          }
-        ]
-      },
       "name": {
         "multiple": false,
         "required": true,
@@ -1414,6 +1404,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "namespace_body",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -2429,16 +2429,6 @@
     "type": "module",
     "named": true,
     "fields": {
-      "body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_body",
-            "named": true
-          }
-        ]
-      },
       "name": {
         "multiple": false,
         "required": true,
@@ -2453,6 +2443,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "namespace_body",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -3020,16 +3020,6 @@
     "type": "singleton_class",
     "named": true,
     "fields": {
-      "body": {
-        "multiple": false,
-        "required": false,
-        "types": [
-          {
-            "type": "namespace_body",
-            "named": true
-          }
-        ]
-      },
       "value": {
         "multiple": false,
         "required": true,
@@ -3040,6 +3030,16 @@
           }
         ]
       }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "namespace_body",
+          "named": true
+        }
+      ]
     }
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -28,7 +28,7 @@ end
 
 ---
 
-(program (method (identifier) (method_body (identifier))))
+(program (method (identifier) (body (identifier))))
 
 =====================
 "end"-less method
@@ -91,7 +91,7 @@ end
 ---
 
 (program
-  (method (operator) (method_parameters (identifier)) (method_body (string (string_content))))
+  (method (operator) (method_parameters (identifier)) (body (string (string_content))))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
@@ -136,13 +136,13 @@ end
 ---
 
 (program
-  (method (identifier) (method_body (super)))
+  (method (identifier) (body (super)))
   (method
     (identifier)
-    (method_body (call (identifier) (identifier) (block (block_body (super))))))
+    (body (call (identifier) (identifier) (block (block_body (super))))))
   (method
     (identifier)
-    (method_body (call (super) (identifier) (argument_list (identifier) (identifier))))))
+    (body (call (super) (identifier) (argument_list (identifier) (identifier))))))
 
 ===========================
 method with args
@@ -275,10 +275,10 @@ end
   (method (identifier) (method_parameters (block_parameter (identifier))))
   (method (identifier) (method_parameters (block_parameter)))
   (method (identifier) (method_parameters (forward_parameter))
-    (method_body (call (super) (argument_list (forward_argument))))
+    (body (call (super) (argument_list (forward_argument))))
   )
   (method (identifier) (method_parameters (identifier) (identifier) (forward_parameter))
-    (method_body (call (identifier) (argument_list (identifier) (forward_argument))))
+    (body (call (identifier) (argument_list (identifier) (forward_argument))))
   )
 )
 
@@ -303,7 +303,7 @@ end
 
 ---
 
-(program (singleton_method (self) (identifier) (method_body (identifier))))
+(program (singleton_method (self) (identifier) (body (identifier))))
 
 
 =========================================
@@ -446,7 +446,7 @@ end
 
 ---
 
-(program (class (constant) (namespace_body (method (identifier)))))
+(program (class (constant) (body (method (identifier)))))
 
 =========================================
 class within dynamically-computed module
@@ -511,7 +511,7 @@ end
 
 ---
 
-(program (module (constant) (namespace_body (method (identifier)))))
+(program (module (constant) (body (method (identifier)))))
 
 ========================
 module without semicolon
@@ -561,9 +561,9 @@ end
 ---
 
 (program (module (constant)
-  (namespace_body
+  (body
     (class (constant) (superclass (constant))
-      (namespace_body
+      (body
         (call (identifier) (argument_list
           (call
             (call
@@ -574,7 +574,7 @@ end
       (call (identifier) (argument_list (simple_symbol)))
 
       (comment)
-      (method (identifier) (method_body (identifier)))
+      (method (identifier) (body (identifier)))
       (singleton_method (self) (identifier)))))))
 
 

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -28,7 +28,7 @@ end
 
 ---
 
-(program (method (identifier) (body (identifier))))
+(program (method (identifier) (body_statement (identifier))))
 
 =====================
 "end"-less method
@@ -91,7 +91,7 @@ end
 ---
 
 (program
-  (method (operator) (method_parameters (identifier)) (body (string (string_content))))
+  (method (operator) (method_parameters (identifier)) (body_statement (string (string_content))))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
@@ -136,13 +136,13 @@ end
 ---
 
 (program
-  (method (identifier) (body (super)))
+  (method (identifier) (body_statement (super)))
   (method
     (identifier)
-    (body (call (identifier) (identifier) (block (block_body (super))))))
+    (body_statement (call (identifier) (identifier) (block (block_body (super))))))
   (method
     (identifier)
-    (body (call (super) (identifier) (argument_list (identifier) (identifier))))))
+    (body_statement (call (super) (identifier) (argument_list (identifier) (identifier))))))
 
 ===========================
 method with args
@@ -275,10 +275,10 @@ end
   (method (identifier) (method_parameters (block_parameter (identifier))))
   (method (identifier) (method_parameters (block_parameter)))
   (method (identifier) (method_parameters (forward_parameter))
-    (body (call (super) (argument_list (forward_argument))))
+    (body_statement (call (super) (argument_list (forward_argument))))
   )
   (method (identifier) (method_parameters (identifier) (identifier) (forward_parameter))
-    (body (call (identifier) (argument_list (identifier) (forward_argument))))
+    (body_statement (call (identifier) (argument_list (identifier) (forward_argument))))
   )
 )
 
@@ -303,7 +303,7 @@ end
 
 ---
 
-(program (singleton_method (self) (identifier) (body (identifier))))
+(program (singleton_method (self) (identifier) (body_statement (identifier))))
 
 
 =========================================
@@ -446,7 +446,7 @@ end
 
 ---
 
-(program (class (constant) (body (method (identifier)))))
+(program (class (constant) (body_statement (method (identifier)))))
 
 =========================================
 class within dynamically-computed module
@@ -511,7 +511,7 @@ end
 
 ---
 
-(program (module (constant) (body (method (identifier)))))
+(program (module (constant) (body_statement (method (identifier)))))
 
 ========================
 module without semicolon
@@ -561,9 +561,9 @@ end
 ---
 
 (program (module (constant)
-  (body
+  (body_statement
     (class (constant) (superclass (constant))
-      (body
+      (body_statement
         (call (identifier) (argument_list
           (call
             (call
@@ -574,7 +574,7 @@ end
       (call (identifier) (argument_list (simple_symbol)))
 
       (comment)
-      (method (identifier) (body (identifier)))
+      (method (identifier) (body_statement (identifier)))
       (singleton_method (self) (identifier)))))))
 
 

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -28,7 +28,7 @@ end
 
 ---
 
-(program (method (identifier) (body (identifier))))
+(program (method (identifier) (method_body (identifier))))
 
 =====================
 "end"-less method
@@ -91,7 +91,7 @@ end
 ---
 
 (program
-  (method (operator) (method_parameters (identifier)) (body (string (string_content))))
+  (method (operator) (method_parameters (identifier)) (method_body (string (string_content))))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
@@ -136,13 +136,13 @@ end
 ---
 
 (program
-  (method (identifier) (body (super)))
+  (method (identifier) (method_body (super)))
   (method
     (identifier)
-    (body (call (identifier) (identifier) (block (block_body (super))))))
+    (method_body (call (identifier) (identifier) (block (block_body (super))))))
   (method
     (identifier)
-    (body (call (super) (identifier) (argument_list (identifier) (identifier))))))
+    (method_body (call (super) (identifier) (argument_list (identifier) (identifier))))))
 
 ===========================
 method with args
@@ -275,10 +275,10 @@ end
   (method (identifier) (method_parameters (block_parameter (identifier))))
   (method (identifier) (method_parameters (block_parameter)))
   (method (identifier) (method_parameters (forward_parameter))
-    (body (call (super) (argument_list (forward_argument))))
+    (method_body (call (super) (argument_list (forward_argument))))
   )
   (method (identifier) (method_parameters (identifier) (identifier) (forward_parameter))
-    (body (call (identifier) (argument_list (identifier) (forward_argument))))
+    (method_body (call (identifier) (argument_list (identifier) (forward_argument))))
   )
 )
 
@@ -303,7 +303,7 @@ end
 
 ---
 
-(program (singleton_method (self) (identifier) (body (identifier))))
+(program (singleton_method (self) (identifier) (method_body (identifier))))
 
 
 =========================================
@@ -574,7 +574,7 @@ end
       (call (identifier) (argument_list (simple_symbol)))
 
       (comment)
-      (method (identifier) (body (identifier)))
+      (method (identifier) (method_body (identifier)))
       (singleton_method (self) (identifier)))))))
 
 

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -435,12 +435,12 @@ class String def foo; end end
 (program
   (module
     name: (constant)
-    namespace_body: (body_statement
+    body: (body_statement
       (class
         name: (constant))))
   (class
     name: (constant)
-    namespace_body: (body_statement
+    body: (body_statement
       (method
         name: (identifier)))))
 

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -446,7 +446,7 @@ end
 
 ---
 
-(program (class (constant) (body (method (identifier)))))
+(program (class (constant) (namespace_body (method (identifier)))))
 
 =========================================
 class within dynamically-computed module
@@ -511,7 +511,7 @@ end
 
 ---
 
-(program (module (constant) (body (method (identifier)))))
+(program (module (constant) (namespace_body (method (identifier)))))
 
 ========================
 module without semicolon
@@ -561,9 +561,9 @@ end
 ---
 
 (program (module (constant)
-  (body
+  (namespace_body
     (class (constant) (superclass (constant))
-      (body
+      (namespace_body
         (call (identifier) (argument_list
           (call
             (call

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -28,7 +28,7 @@ end
 
 ---
 
-(program (method (identifier) (identifier)))
+(program (method (identifier) (body (identifier))))
 
 =====================
 "end"-less method
@@ -43,14 +43,14 @@ def foo() = bar rescue (print "error")
 
 ---
 
-(program 
+(program
   (method (identifier) (identifier))
   (method (identifier) (method_parameters) (identifier))
   (method (identifier) (method_parameters (identifier)) (identifier))
   (singleton_method (constant) (identifier) (identifier))
   (singleton_method (constant) (identifier) (method_parameters (identifier)) (identifier))
   (method (identifier) (method_parameters)
-    (rescue_modifier 
+    (rescue_modifier
       (identifier)
       (parenthesized_statements (call (identifier) (argument_list (string (string_content)))))
     )
@@ -91,7 +91,7 @@ end
 ---
 
 (program
-  (method (operator) (method_parameters (identifier)) (string (string_content)))
+  (method (operator) (method_parameters (identifier)) (body (string (string_content))))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
@@ -136,13 +136,13 @@ end
 ---
 
 (program
-  (method (identifier) (super))
+  (method (identifier) (body (super)))
   (method
     (identifier)
-    (call (identifier) (identifier) (block (super))))
+    (body (call (identifier) (identifier) (block (block_body (super))))))
   (method
     (identifier)
-    (call (super) (identifier) (argument_list (identifier) (identifier)))))
+    (body (call (super) (identifier) (argument_list (identifier) (identifier))))))
 
 ===========================
 method with args
@@ -275,10 +275,10 @@ end
   (method (identifier) (method_parameters (block_parameter (identifier))))
   (method (identifier) (method_parameters (block_parameter)))
   (method (identifier) (method_parameters (forward_parameter))
-    (call (super) (argument_list (forward_argument)))
-  )  
+    (body (call (super) (argument_list (forward_argument))))
+  )
   (method (identifier) (method_parameters (identifier) (identifier) (forward_parameter))
-    (call (identifier) (argument_list (identifier) (forward_argument)))
+    (body (call (identifier) (argument_list (identifier) (forward_argument))))
   )
 )
 
@@ -303,7 +303,7 @@ end
 
 ---
 
-(program (singleton_method (self) (identifier) (identifier)))
+(program (singleton_method (self) (identifier) (body (identifier))))
 
 
 =========================================
@@ -446,7 +446,7 @@ end
 
 ---
 
-(program (class (constant) (method (identifier))))
+(program (class (constant) (body (method (identifier)))))
 
 =========================================
 class within dynamically-computed module
@@ -511,7 +511,7 @@ end
 
 ---
 
-(program (module (constant) (method (identifier))))
+(program (module (constant) (body (method (identifier)))))
 
 ========================
 module without semicolon
@@ -561,19 +561,21 @@ end
 ---
 
 (program (module (constant)
-  (class (constant) (superclass (constant))
-    (call (identifier) (argument_list
-      (call
-        (call
-          (scope_resolution (constant) (constant))
-          (identifier))
-        (identifier))))
+  (body
+    (class (constant) (superclass (constant))
+      (body
+        (call (identifier) (argument_list
+          (call
+            (call
+              (scope_resolution (constant) (constant))
+              (identifier))
+            (identifier))))
 
-    (call (identifier) (argument_list (simple_symbol)))
+      (call (identifier) (argument_list (simple_symbol)))
 
-    (comment)
-    (method (identifier) (identifier))
-    (singleton_method (self) (identifier)))))
+      (comment)
+      (method (identifier) (body (identifier)))
+      (singleton_method (self) (identifier)))))))
 
 
 ===========

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1219,7 +1219,7 @@ end
           method: (identifier)
           block: (block
             parameters: (block_parameters (identifier))
-            (block_body (identifier))))
+            body: (block_body (identifier))))
         method: (identifier)
         block: (do_block
           do_block_body: (body_statement (identifier)))))))
@@ -1408,7 +1408,7 @@ foo(bar, baz) { quux }
     method: (identifier)
     block: (block
       parameters: (block_parameters (identifier))
-      (block_body (identifier))))
+      body: (block_body (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (call
@@ -1416,11 +1416,11 @@ foo(bar, baz) { quux }
       method: (identifier)
       block: (block
         parameters: (block_parameters (identifier))
-        (block_body (binary left: (identifier) right: (integer)))))))
+        body: (block_body (binary left: (identifier) right: (integer)))))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier) (identifier))
-    block: (block (block_body (identifier)))))
+    block: (block body: (block_body (identifier)))))
 
 ===============================
 method call with block shadow arguments

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -908,7 +908,7 @@ end
     receiver: (identifier)
     arguments: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
     block: (do_block
-      do_block_body: (body_statement (identifier)))))
+      body: (body_statement (identifier)))))
 
 ===============================
 call with operator method name
@@ -1211,7 +1211,7 @@ end
         (splat_argument (identifier)))
       block: (do_block
         parameters: (block_parameters (identifier))
-        do_block_body: (body_statement (identifier))))
+        body: (body_statement (identifier))))
     method: (identifier)
     arguments: (argument_list
       (call
@@ -1222,7 +1222,7 @@ end
             body: (block_body (identifier))))
         method: (identifier)
         block: (do_block
-          do_block_body: (body_statement (identifier)))))))
+          body: (body_statement (identifier)))))))
 
 ===============================
 method calls in binary expression
@@ -1357,7 +1357,7 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-    do_block_body: (body_statement
+    body: (body_statement
       (identifier)
         (rescue
           exceptions: (exceptions (constant))
@@ -1368,21 +1368,21 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-      do_block_body: (body_statement (identifier))))
+      body: (body_statement (identifier))))
   (call method: (identifier) block: (do_block))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      do_block_body: (body_statement (identifier))))
+      body: (body_statement (identifier))))
   (call
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      do_block_body: (body_statement (identifier))))
+      body: (body_statement (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -907,7 +907,7 @@ end
   (call
     receiver: (identifier)
     arguments: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
-    block: (do_block (identifier))))
+    block: (do_block (body (identifier)))))
 
 ===============================
 call with operator method name
@@ -1164,13 +1164,13 @@ foo :bar, -> (a) { where(:c => b) }
   (call (identifier)
     (argument_list
       (simple_symbol)
-      (lambda (lambda_parameters (identifier)) (block (integer)))))
+      (lambda (lambda_parameters (identifier)) (block (block_body (integer))))))
   (call (identifier)
     (argument_list
       (simple_symbol)
       (lambda
         (lambda_parameters (identifier))
-        (block (call (identifier) (argument_list (pair (simple_symbol) (identifier)))))))))
+        (block (block_body (call (identifier) (argument_list (pair (simple_symbol) (identifier))))))))))
 
 ===============================
 method call lambda argument and do block
@@ -1183,7 +1183,7 @@ end
 
 (program
   (call (identifier)
-    (argument_list (simple_symbol) (lambda (lambda_parameters (identifier)) (block (integer))))
+    (argument_list (simple_symbol) (lambda (lambda_parameters (identifier)) (block (block_body (integer)))))
     (do_block)))
 
 ===============================================
@@ -1210,7 +1210,7 @@ end
         (splat_argument (identifier)))
       block: (do_block
         parameters: (block_parameters (identifier))
-        (identifier)))
+        (body (identifier))))
     method: (identifier)
     arguments: (argument_list
       (call
@@ -1218,9 +1218,9 @@ end
           method: (identifier)
           block: (block
             parameters: (block_parameters (identifier))
-            (identifier)))
+            (block_body (identifier))))
         method: (identifier)
-        block: (do_block (identifier))))))
+        block: (do_block (body (identifier)))))))
 
 ===============================
 method calls in binary expression
@@ -1355,31 +1355,32 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-    (identifier)
-      (rescue
-        exceptions: (exceptions (constant))
-        body: (then (identifier)))
-      (ensure
-        (identifier))))
+    (body
+      (identifier)
+        (rescue
+          exceptions: (exceptions (constant))
+          body: (then (identifier)))
+        (ensure
+          (identifier)))))
   (call
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-      (identifier)))
+      (body (identifier))))
   (call method: (identifier) block: (do_block))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      (identifier)))
+      (body (identifier))))
   (call
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      (identifier)))
+      (body (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
@@ -1405,7 +1406,7 @@ foo(bar, baz) { quux }
     method: (identifier)
     block: (block
       parameters: (block_parameters (identifier))
-      (identifier)))
+      (block_body (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (call
@@ -1413,11 +1414,11 @@ foo(bar, baz) { quux }
       method: (identifier)
       block: (block
         parameters: (block_parameters (identifier))
-        (binary left: (identifier) right: (integer))))))
+        (block_body (binary left: (identifier) right: (integer)))))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier) (identifier))
-    block: (block (identifier))))
+    block: (block (block_body (identifier)))))
 
 ===============================
 method call with block shadow arguments
@@ -1517,14 +1518,14 @@ d.find { |x| x > 1 } [0] == 0
     (call
       (identifier)
       (identifier)
-      (block (block_parameters (identifier)) (binary (identifier) (integer))))
+      (block (block_parameters (identifier)) (block_body (binary (identifier) (integer)))))
     (integer))
   (binary
     (element_reference
       (call
         (identifier)
         (identifier)
-        (block (block_parameters (identifier)) (binary (identifier) (integer))))
+        (block (block_parameters (identifier)) (block_body (binary (identifier) (integer)))))
       (integer))
     (integer)))
 
@@ -1544,12 +1545,12 @@ end
   (call
     (identifier)
     (argument_list (array (integer)))
-    (block (block_parameters (identifier)) (identifier)))
+    (block (block_parameters (identifier)) (block_body (identifier))))
   (call
     (identifier)
     (argument_list (array (integer)))
     (do_block
-      (call (identifier) (argument_list (integer))))))
+      (body (call (identifier) (argument_list (integer)))))))
 
 
 ========================================================================
@@ -1560,7 +1561,7 @@ render "foo/bars/show", locals: { display_text: dt, safe_text: "hello" }
 
 ---
 
-(program 
+(program
   (call (identifier) (argument_list (string (string_content)) (pair (hash_key_symbol) (hash))))
   (call (identifier) (argument_list (string (string_content)) (pair (hash_key_symbol) (hash (pair (hash_key_symbol) (identifier)) (pair (hash_key_symbol) (string (string_content)))))))
 )
@@ -1666,8 +1667,8 @@ lambda(&lambda{})
 ---
 
 (program
-  (call (identifier) (block (identifier)))
-  (call (identifier) (argument_list (block_argument (identifier))) (block (identifier)))
+  (call (identifier) (block (block_body (identifier))))
+  (call (identifier) (argument_list (block_argument (identifier))) (block (block_body (identifier))))
   (call (identifier) (argument_list (block_argument (call (identifier) (block))))))
 
 ====================
@@ -1678,7 +1679,7 @@ lambda { |foo| 1 }
 
 ---
 
-(program (call (identifier) (block (block_parameters (identifier)) (integer))))
+(program (call (identifier) (block (block_parameters (identifier)) (block_body (integer)))))
 
 ===========================
 lambda expression with multiple args
@@ -1691,7 +1692,7 @@ lambda { |a, b, c|
 
 ---
 
-(program (call (identifier) (block (block_parameters (identifier) (identifier) (identifier)) (integer) (integer))))
+(program (call (identifier) (block (block_parameters (identifier) (identifier) (identifier)) (block_body (integer) (integer)))))
 
 ===========================
 lambda expression with trailing comma
@@ -1703,7 +1704,7 @@ lambda { |a, b,|
 
 ---
 
-(program (call (identifier) (block (block_parameters (identifier) (identifier)) (integer))))
+(program (call (identifier) (block (block_parameters (identifier) (identifier)) (block_body (integer)))))
 
 ===========================
 lambda expression with optional arg
@@ -1715,7 +1716,7 @@ lambda { |a, b=nil|
 
 ---
 
-(program (call (identifier) (block (block_parameters (identifier) (optional_parameter (identifier) (nil))) (integer))))
+(program (call (identifier) (block (block_parameters (identifier) (optional_parameter (identifier) (nil))) (block_body (integer)))))
 
 ===========================
 lambda expression with keyword arg
@@ -1729,7 +1730,7 @@ lambda { |a, b: nil|
 
 (program (call
   (identifier)
-  (block (block_parameters (identifier) (keyword_parameter (identifier) (nil))) (integer))))
+  (block (block_parameters (identifier) (keyword_parameter (identifier) (nil))) (block_body (integer)))))
 
 ====================
 lambda expression with do end
@@ -1741,7 +1742,7 @@ end
 
 ---
 
-(program (call (identifier) (do_block (block_parameters (identifier)) (integer))))
+(program (call (identifier) (do_block (block_parameters (identifier)) (body (integer)))))
 
 ============================
 lambda and proc as variables

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -908,7 +908,7 @@ end
     receiver: (identifier)
     arguments: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
     block: (do_block
-      do_block_body: (body (identifier)))))
+      do_block_body: (body_statement (identifier)))))
 
 ===============================
 call with operator method name
@@ -1211,7 +1211,7 @@ end
         (splat_argument (identifier)))
       block: (do_block
         parameters: (block_parameters (identifier))
-        do_block_body: (body (identifier))))
+        do_block_body: (body_statement (identifier))))
     method: (identifier)
     arguments: (argument_list
       (call
@@ -1222,7 +1222,7 @@ end
             (block_body (identifier))))
         method: (identifier)
         block: (do_block
-          do_block_body: (body (identifier)))))))
+          do_block_body: (body_statement (identifier)))))))
 
 ===============================
 method calls in binary expression
@@ -1357,7 +1357,7 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-    do_block_body: (body
+    do_block_body: (body_statement
       (identifier)
         (rescue
           exceptions: (exceptions (constant))
@@ -1368,21 +1368,21 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-      do_block_body: (body (identifier))))
+      do_block_body: (body_statement (identifier))))
   (call method: (identifier) block: (do_block))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      do_block_body: (body (identifier))))
+      do_block_body: (body_statement (identifier))))
   (call
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      do_block_body: (body (identifier))))
+      do_block_body: (body_statement (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
@@ -1552,7 +1552,7 @@ end
     (identifier)
     (argument_list (array (integer)))
     (do_block
-      (body (call (identifier) (argument_list (integer)))))))
+      (body_statement (call (identifier) (argument_list (integer)))))))
 
 
 ========================================================================
@@ -1744,7 +1744,7 @@ end
 
 ---
 
-(program (call (identifier) (do_block (block_parameters (identifier)) (body (integer)))))
+(program (call (identifier) (do_block (block_parameters (identifier)) (body_statement (integer)))))
 
 ============================
 lambda and proc as variables

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -907,7 +907,7 @@ end
   (call
     receiver: (identifier)
     arguments: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
-    block: (do_block (body (identifier)))))
+    block: (do_block (do_block_body (identifier)))))
 
 ===============================
 call with operator method name
@@ -1210,7 +1210,7 @@ end
         (splat_argument (identifier)))
       block: (do_block
         parameters: (block_parameters (identifier))
-        (body (identifier))))
+        (do_block_body (identifier))))
     method: (identifier)
     arguments: (argument_list
       (call
@@ -1220,7 +1220,7 @@ end
             parameters: (block_parameters (identifier))
             (block_body (identifier))))
         method: (identifier)
-        block: (do_block (body (identifier)))))))
+        block: (do_block (do_block_body (identifier)))))))
 
 ===============================
 method calls in binary expression
@@ -1355,7 +1355,7 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-    (body
+    (do_block_body
       (identifier)
         (rescue
           exceptions: (exceptions (constant))
@@ -1366,21 +1366,21 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-      (body (identifier))))
+      (do_block_body (identifier))))
   (call method: (identifier) block: (do_block))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      (body (identifier))))
+      (do_block_body (identifier))))
   (call
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      (body (identifier))))
+      (do_block_body (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
@@ -1550,7 +1550,7 @@ end
     (identifier)
     (argument_list (array (integer)))
     (do_block
-      (body (call (identifier) (argument_list (integer)))))))
+      (do_block_body (call (identifier) (argument_list (integer)))))))
 
 
 ========================================================================
@@ -1742,7 +1742,7 @@ end
 
 ---
 
-(program (call (identifier) (do_block (block_parameters (identifier)) (body (integer)))))
+(program (call (identifier) (do_block (block_parameters (identifier)) (do_block_body (integer)))))
 
 ============================
 lambda and proc as variables

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -907,7 +907,8 @@ end
   (call
     receiver: (identifier)
     arguments: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
-    block: (do_block (do_block_body (identifier)))))
+    block: (do_block
+      do_block_body: (body (identifier)))))
 
 ===============================
 call with operator method name
@@ -1210,7 +1211,7 @@ end
         (splat_argument (identifier)))
       block: (do_block
         parameters: (block_parameters (identifier))
-        (do_block_body (identifier))))
+        do_block_body: (body (identifier))))
     method: (identifier)
     arguments: (argument_list
       (call
@@ -1220,7 +1221,8 @@ end
             parameters: (block_parameters (identifier))
             (block_body (identifier))))
         method: (identifier)
-        block: (do_block (do_block_body (identifier)))))))
+        block: (do_block
+          do_block_body: (body (identifier)))))))
 
 ===============================
 method calls in binary expression
@@ -1355,7 +1357,7 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-    (do_block_body
+    do_block_body: (body
       (identifier)
         (rescue
           exceptions: (exceptions (constant))
@@ -1366,21 +1368,21 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-      (do_block_body (identifier))))
+      do_block_body: (body (identifier))))
   (call method: (identifier) block: (do_block))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      (do_block_body (identifier))))
+      do_block_body: (body (identifier))))
   (call
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      (do_block_body (identifier))))
+      do_block_body: (body (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
@@ -1550,7 +1552,7 @@ end
     (identifier)
     (argument_list (array (integer)))
     (do_block
-      (do_block_body (call (identifier) (argument_list (integer)))))))
+      (body (call (identifier) (argument_list (integer)))))))
 
 
 ========================================================================
@@ -1742,7 +1744,7 @@ end
 
 ---
 
-(program (call (identifier) (do_block (block_parameters (identifier)) (do_block_body (integer)))))
+(program (call (identifier) (do_block (block_parameters (identifier)) (body (integer)))))
 
 ============================
 lambda and proc as variables

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -908,7 +908,7 @@ end
     receiver: (identifier)
     arguments: (argument_list (pair key: (hash_key_symbol) value: (identifier)))
     block: (do_block
-      body: (body_statement (identifier)))))
+      do_block_body: (body_statement (identifier)))))
 
 ===============================
 call with operator method name
@@ -1211,7 +1211,7 @@ end
         (splat_argument (identifier)))
       block: (do_block
         parameters: (block_parameters (identifier))
-        body: (body_statement (identifier))))
+        do_block_body: (body_statement (identifier))))
     method: (identifier)
     arguments: (argument_list
       (call
@@ -1222,7 +1222,7 @@ end
             body: (block_body (identifier))))
         method: (identifier)
         block: (do_block
-          body: (body_statement (identifier)))))))
+          do_block_body: (body_statement (identifier)))))))
 
 ===============================
 method calls in binary expression
@@ -1357,7 +1357,7 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-    body: (body_statement
+    do_block_body: (body_statement
       (identifier)
         (rescue
           exceptions: (exceptions (constant))
@@ -1368,21 +1368,21 @@ end
     method: (identifier)
     block: (do_block
       parameters: (block_parameters (identifier))
-      body: (body_statement (identifier))))
+      do_block_body: (body_statement (identifier))))
   (call method: (identifier) block: (do_block))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      body: (body_statement (identifier))))
+      do_block_body: (body_statement (identifier))))
   (call
     receiver: (identifier)
     method: (identifier)
     arguments: (argument_list (identifier))
     block: (do_block
       parameters: (block_parameters (identifier))
-      body: (body_statement (identifier))))
+      do_block_body: (body_statement (identifier))))
   (call
     method: (identifier)
     arguments: (argument_list (identifier))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -860,7 +860,7 @@ end
 ---
 
 (program (method (identifier)
-  (method_body
+  (body
     (call (identifier) (argument_list (heredoc_beginning)))
     (heredoc_body (heredoc_content) (heredoc_end)))))
 
@@ -1606,7 +1606,7 @@ end
 
 ---
 
-(program (lambda (lambda_parameters (identifier)) (do_block (do_block_body (integer)))))
+(program (lambda (lambda_parameters (identifier)) (do_block (body (integer)))))
 
 ====================
 non-ascii identifiers

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1166,7 +1166,7 @@ array as object
     method: (identifier)
     block: (block
       parameters: (block_parameters (identifier))
-      (block_body (binary left: (identifier) right: (integer))))))
+      body: (block_body (binary left: (identifier) right: (integer))))))
 
 =========================
 array with trailing comma

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -860,8 +860,9 @@ end
 ---
 
 (program (method (identifier)
-  (call (identifier) (argument_list (heredoc_beginning)))
-  (heredoc_body (heredoc_content) (heredoc_end))))
+  (body
+    (call (identifier) (argument_list (heredoc_beginning)))
+    (heredoc_body (heredoc_content) (heredoc_end)))))
 
 ========================================
 heredocs with method continuation
@@ -1083,10 +1084,11 @@ heredoc content that starts with a dot
 
 (program
   (lambda (block
-    (call
-      (identifier)
-      (argument_list (heredoc_beginning)))
-    (heredoc_body (heredoc_content) (heredoc_end)))))
+    (block_body
+      (call
+        (identifier)
+        (argument_list (heredoc_beginning)))
+      (heredoc_body (heredoc_content) (heredoc_end))))))
 
 ========================================
 un-terminated heredocs
@@ -1164,7 +1166,7 @@ array as object
     method: (identifier)
     block: (block
       parameters: (block_parameters (identifier))
-      (binary left: (identifier) right: (integer)))))
+      (block_body (binary left: (identifier) right: (integer))))))
 
 =========================
 array with trailing comma
@@ -1557,7 +1559,7 @@ lambda literal with body
 
 ---
 
-(program (lambda (block (identifier))))
+(program (lambda (block (block_body (identifier)))))
 
 ====================
 lambda literal with an arg
@@ -1572,11 +1574,11 @@ lambda literal with an arg
 ---
 
 (program
-  (lambda (lambda_parameters (identifier)) (block (integer)))
-  (lambda (lambda_parameters (identifier)) (block (integer)))
-  (lambda (lambda_parameters (splat_parameter (identifier))) (block (integer)))
-  (lambda (lambda_parameters (keyword_parameter (identifier) (integer))) (block (integer)))
-  (lambda (lambda_parameters (identifier) (identifier)) (block (integer))))
+  (lambda (lambda_parameters (identifier)) (block (block_body (integer))))
+  (lambda (lambda_parameters (identifier)) (block (block_body (integer))))
+  (lambda (lambda_parameters (splat_parameter (identifier))) (block (block_body (integer))))
+  (lambda (lambda_parameters (keyword_parameter (identifier) (integer))) (block (block_body (integer))))
+  (lambda (lambda_parameters (identifier) (identifier)) (block (block_body (integer)))))
 
 ===========================
 lambda literal with multiple args
@@ -1590,8 +1592,9 @@ lambda literal with multiple args
 ---
 
 (program (lambda (lambda_parameters (identifier) (identifier) (identifier)) (block
-  (integer)
-  (integer))))
+  (block_body
+    (integer)
+    (integer)))))
 
 ====================
 lambda literal with do end
@@ -1603,7 +1606,7 @@ end
 
 ---
 
-(program (lambda (lambda_parameters (identifier)) (do_block (integer))))
+(program (lambda (lambda_parameters (identifier)) (do_block (body (integer)))))
 
 ====================
 non-ascii identifiers

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -860,7 +860,7 @@ end
 ---
 
 (program (method (identifier)
-  (body
+  (body_statement
     (call (identifier) (argument_list (heredoc_beginning)))
     (heredoc_body (heredoc_content) (heredoc_end)))))
 
@@ -1606,7 +1606,7 @@ end
 
 ---
 
-(program (lambda (lambda_parameters (identifier)) (do_block (body (integer)))))
+(program (lambda (lambda_parameters (identifier)) (do_block (body_statement (integer)))))
 
 ====================
 non-ascii identifiers

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -860,7 +860,7 @@ end
 ---
 
 (program (method (identifier)
-  (body
+  (method_body
     (call (identifier) (argument_list (heredoc_beginning)))
     (heredoc_body (heredoc_content) (heredoc_end)))))
 
@@ -1606,7 +1606,7 @@ end
 
 ---
 
-(program (lambda (lambda_parameters (identifier)) (do_block (body (integer)))))
+(program (lambda (lambda_parameters (identifier)) (do_block (do_block_body (integer)))))
 
 ====================
 non-ascii identifiers

--- a/test/corpus/patterns.txt
+++ b/test/corpus/patterns.txt
@@ -17,63 +17,63 @@ end
 
 case expr
   in 5
-  in 5, 
-  in 1, 2 
-  in 1, 2, 
-  in 1, 2, 3 
-  in 1, 2, 3, 
-  in 1, 2, 3, * 
-  in 1, *x, 3 
-  in * 
-  in *, 3, 4 
-  in *, 3, * 
-  in *a, 3, *b 
-  in a: 
-  in a: 5 
-  in a: 5, 
-  in a: 5, b:, ** 
-  in a: 5, b:, **map 
-  in a: 5, b:, **nil 
-  in **nil 
-  in [5] 
-  in [5,] 
-  in [1, 2] 
-  in [1, 2,] 
-  in [1, 2, 3] 
-  in [1, 2, 3,] 
-  in [1, 2, 3, *] 
-  in [1, *x, 3] 
-  in [*] 
-  in [*, 3, 4] 
-  in [*, 3, *] 
-  in [*a, 3, *b] 
-  in {a:} 
-  in {a: 5} 
-  in {a: 5,} 
-  in {a: 5, b:, **} 
-  in {a: 5, b:, **map} 
-  in {a: 5, b:, **nil} 
-  in {**nil} 
-  in {} 
-  in [] 
+  in 5,
+  in 1, 2
+  in 1, 2,
+  in 1, 2, 3
+  in 1, 2, 3,
+  in 1, 2, 3, *
+  in 1, *x, 3
+  in *
+  in *, 3, 4
+  in *, 3, *
+  in *a, 3, *b
+  in a:
+  in a: 5
+  in a: 5,
+  in a: 5, b:, **
+  in a: 5, b:, **map
+  in a: 5, b:, **nil
+  in **nil
+  in [5]
+  in [5,]
+  in [1, 2]
+  in [1, 2,]
+  in [1, 2, 3]
+  in [1, 2, 3,]
+  in [1, 2, 3, *]
+  in [1, *x, 3]
+  in [*]
+  in [*, 3, 4]
+  in [*, 3, *]
+  in [*a, 3, *b]
+  in {a:}
+  in {a: 5}
+  in {a: 5,}
+  in {a: 5, b:, **}
+  in {a: 5, b:, **map}
+  in {a: 5, b:, **nil}
+  in {**nil}
+  in {}
+  in []
 end
 
 -----
 
-(program 
-  (case_match (identifier) 
-    (in_clause 
+(program
+  (case_match (identifier)
+    (in_clause
       (integer)
       (then (true))
     )
-    (else (false))) 
-  (case_match (identifier) 
-    (in_clause 
+    (else (false)))
+  (case_match (identifier)
+    (in_clause
       (identifier)
       (unless_guard (binary (identifier) (integer)))
       (then (true))
     )
-    (in_clause 
+    (in_clause
       (identifier)
       (if_guard (binary (identifier) (integer)))
       (then (true))
@@ -82,54 +82,54 @@ end
   )
 
   (case_match (identifier)
-    (in_clause (integer)) 
-    (in_clause (array_pattern (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (integer))) 
-    (in_clause (array_pattern (integer) (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (integer) (integer))) 
-    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (splat_parameter (identifier)) (integer))) 
-    (in_clause (array_pattern (splat_parameter))) 
-    (in_clause (array_pattern (splat_parameter) (integer) (integer))) 
-    (in_clause (find_pattern (splat_parameter) (integer) (splat_parameter))) 
-    (in_clause (find_pattern (splat_parameter (identifier)) (integer) (splat_parameter (identifier)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter (identifier)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_nil))) 
-    (in_clause (hash_pattern (hash_splat_nil))) 
-    (in_clause (array_pattern (integer))) 
-    (in_clause (array_pattern (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (integer))) 
-    (in_clause (array_pattern (integer) (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (integer) (integer))) 
-    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter))) 
-    (in_clause (array_pattern (integer) (splat_parameter (identifier)) (integer))) 
-    (in_clause (array_pattern (splat_parameter))) 
-    (in_clause (array_pattern (splat_parameter) (integer) (integer))) 
-    (in_clause (find_pattern (splat_parameter) (integer) (splat_parameter))) 
-    (in_clause (find_pattern (splat_parameter (identifier)) (integer) (splat_parameter (identifier)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter (identifier)))) 
-    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_nil))) 
-    (in_clause (hash_pattern (hash_splat_nil))) 
-    (in_clause (hash_pattern)) 
+    (in_clause (integer))
+    (in_clause (array_pattern (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (integer)))
+    (in_clause (array_pattern (integer) (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (integer) (integer)))
+    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (splat_parameter (identifier)) (integer)))
+    (in_clause (array_pattern (splat_parameter)))
+    (in_clause (array_pattern (splat_parameter) (integer) (integer)))
+    (in_clause (find_pattern (splat_parameter) (integer) (splat_parameter)))
+    (in_clause (find_pattern (splat_parameter (identifier)) (integer) (splat_parameter (identifier))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter)))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter (identifier))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_nil)))
+    (in_clause (hash_pattern (hash_splat_nil)))
+    (in_clause (array_pattern (integer)))
+    (in_clause (array_pattern (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (integer)))
+    (in_clause (array_pattern (integer) (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (integer) (integer)))
+    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (integer) (integer) (splat_parameter)))
+    (in_clause (array_pattern (integer) (splat_parameter (identifier)) (integer)))
+    (in_clause (array_pattern (splat_parameter)))
+    (in_clause (array_pattern (splat_parameter) (integer) (integer)))
+    (in_clause (find_pattern (splat_parameter) (integer) (splat_parameter)))
+    (in_clause (find_pattern (splat_parameter (identifier)) (integer) (splat_parameter (identifier))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter)))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_parameter (identifier))))
+    (in_clause (hash_pattern (keyword_pattern (hash_key_symbol) (integer)) (keyword_pattern (hash_key_symbol)) (hash_splat_nil)))
+    (in_clause (hash_pattern (hash_splat_nil)))
+    (in_clause (hash_pattern))
     (in_clause (array_pattern))
   )
 )
 
 =====================
-more pattern matching 
+more pattern matching
 =====================
 
-case expr 
+case expr
   in 5
   in ^foo
   in ^$foo
@@ -160,7 +160,7 @@ end
 
 --------
 
- (program 
+ (program
    (case_match (identifier)
      (in_clause (integer))
      (in_clause (variable_reference_pattern (identifier)))
@@ -179,8 +179,8 @@ end
      (in_clause (range (integer)))
      (in_clause (range (integer)))
      (in_clause (as_pattern (integer) (identifier)))
-     (in_clause 
-       (alternative_pattern 
+     (in_clause
+       (alternative_pattern
          (integer)
          (variable_reference_pattern (identifier))
          (identifier)
@@ -190,9 +190,9 @@ end
      (in_clause (constant))
      (in_clause (scope_resolution (constant) (constant)))
      (in_clause (scope_resolution (scope_resolution (constant)) (constant)))
-     (in_clause 
-       (parenthesized_pattern 
-         (alternative_pattern 
+     (in_clause
+       (parenthesized_pattern
+         (alternative_pattern
            (nil)
            (self)
            (true)
@@ -203,7 +203,7 @@ end
          )
        )
      )
-     (in_clause (lambda (lambda_parameters (identifier)) (block (binary (identifier) (integer)))))
+     (in_clause (lambda (lambda_parameters (identifier)) (block (block_body (binary (identifier) (integer))))))
      (in_clause (simple_symbol))
      (in_clause (delimited_symbol (string_content)))
      (in_clause
@@ -218,7 +218,7 @@ end
 ==============
 array patterns
 ==============
-case expr 
+case expr
   in [];
   in [x];
   in [x, ];
@@ -230,7 +230,7 @@ end
 
 --------------
 
-(program 
+(program
   (case_match (identifier)
     (in_clause (array_pattern))
     (in_clause (array_pattern (identifier)))
@@ -238,8 +238,8 @@ end
     (in_clause (array_pattern (scope_resolution (constant) (constant))))
     (in_clause (array_pattern (constant)))
     (in_clause (array_pattern (constant) (splat_parameter)))
-    (in_clause 
-      (array_pattern 
+    (in_clause
+      (array_pattern
         (constant)
         (identifier)
         (identifier)
@@ -249,13 +249,13 @@ end
       )
     )
   )
-) 
+)
 
 =============
 find patterns
 =============
 
-case expr 
+case expr
   in [*, x, *];
   in [*x, 1, 2, *y];
   in Foo::Bar[*, 1, *];
@@ -264,11 +264,11 @@ end
 
 -------------
 
-(program 
+(program
   (case_match (identifier)
     (in_clause (find_pattern (splat_parameter) (identifier) (splat_parameter)))
     (in_clause (find_pattern (splat_parameter (identifier)) (integer) (integer) (splat_parameter (identifier))))
-    (in_clause (find_pattern 
+    (in_clause (find_pattern
        (scope_resolution (constant) (constant))
        (splat_parameter)
        (integer)
@@ -276,13 +276,13 @@ end
     )
     (in_clause (find_pattern (constant) (splat_parameter) (constant) (splat_parameter)))
   )
-) 
+)
 
 =============
 hash patterns
 =============
 
-case expr 
+case expr
   in {};
   in {x:};
   in Foo::Bar[ x:1 ];
@@ -297,11 +297,11 @@ end
 (program (case_match (identifier)
   (in_clause (hash_pattern))
   (in_clause (hash_pattern (keyword_pattern (hash_key_symbol))))
-  (in_clause (hash_pattern 
+  (in_clause (hash_pattern
         (scope_resolution (constant) (constant))
         (keyword_pattern (hash_key_symbol) (integer))
   ))
-  (in_clause (hash_pattern 
+  (in_clause (hash_pattern
     (scope_resolution (constant) (constant))
     (keyword_pattern (hash_key_symbol) (integer))
     (keyword_pattern (hash_key_symbol))
@@ -317,7 +317,7 @@ end
 pattern matching with fancy string literals
 =====================
 
-case expr 
+case expr
   in "string";
   in `ls`;
   in <<"DOC" then end


### PR DESCRIPTION
A majority of other languages I noticed wrap class and function bodies in their own named node that can be easily queried(checked javascript, Lua, java, etc). Without this named node it makes targeting the contents of these structures difficult, cumbersome, and realllyyyy slow.  

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
