### PR TITLE
Add body field for end-less methods

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -196,10 +196,11 @@ module.exports = grammar({
     _body_expr: $ =>
       seq(
         '=',
-        choice(
-          $._arg,
-          alias($.rescue_modifier_arg, $.rescue_modifier),
-        )
+        field('body',
+          choice(
+            $._arg,
+            alias($.rescue_modifier_arg, $.rescue_modifier),
+          ))
       ),
 
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -505,22 +505,26 @@
           "value": "="
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_arg"
-            },
-            {
-              "type": "ALIAS",
-              "content": {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
                 "type": "SYMBOL",
-                "name": "rescue_modifier_arg"
+                "name": "_arg"
               },
-              "named": true,
-              "value": "rescue_modifier"
-            }
-          ]
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "rescue_modifier_arg"
+                },
+                "named": true,
+                "value": "rescue_modifier"
+              }
+            ]
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2347,7 +2347,15 @@
         "required": false,
         "types": [
           {
+            "type": "_arg",
+            "named": true
+          },
+          {
             "type": "body_statement",
+            "named": true
+          },
+          {
+            "type": "rescue_modifier",
             "named": true
           }
         ]
@@ -2372,20 +2380,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "_arg",
-          "named": true
-        },
-        {
-          "type": "rescue_modifier",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -3030,7 +3024,15 @@
         "required": false,
         "types": [
           {
+            "type": "_arg",
+            "named": true
+          },
+          {
             "type": "body_statement",
+            "named": true
+          },
+          {
+            "type": "rescue_modifier",
             "named": true
           }
         ]
@@ -3069,20 +3071,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "_arg",
-          "named": true
-        },
-        {
-          "type": "rescue_modifier",
-          "named": true
-        }
-      ]
     }
   },
   {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -44,13 +44,13 @@ def foo() = bar rescue (print "error")
 ---
 
 (program
-  (method name: (identifier) (identifier))
-  (method name: (identifier) parameters: (method_parameters) (identifier))
-  (method name: (identifier) parameters: (method_parameters (identifier)) (identifier))
-  (singleton_method object: (constant) name: (identifier) (identifier))
-  (singleton_method object: (constant) name: (identifier) parameters: (method_parameters (identifier)) (identifier))
+  (method name: (identifier) body: (identifier))
+  (method name: (identifier) parameters: (method_parameters) body: (identifier))
+  (method name: (identifier) parameters: (method_parameters (identifier)) body: (identifier))
+  (singleton_method object: (constant) name: (identifier) body: (identifier))
+  (singleton_method object: (constant) name: (identifier) parameters: (method_parameters (identifier)) body: (identifier))
   (method name: (identifier) parameters: (method_parameters)
-    (rescue_modifier
+    body: (rescue_modifier
       body: (identifier)
       handler: (parenthesized_statements (call method: (identifier) arguments: (argument_list (string (string_content)))))
     )

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -44,15 +44,15 @@ def foo() = bar rescue (print "error")
 ---
 
 (program
-  (method (identifier) (identifier))
-  (method (identifier) (method_parameters) (identifier))
-  (method (identifier) (method_parameters (identifier)) (identifier))
-  (singleton_method (constant) (identifier) (identifier))
-  (singleton_method (constant) (identifier) (method_parameters (identifier)) (identifier))
-  (method (identifier) (method_parameters)
+  (method name: (identifier) (identifier))
+  (method name: (identifier) parameters: (method_parameters) (identifier))
+  (method name: (identifier) parameters: (method_parameters (identifier)) (identifier))
+  (singleton_method object: (constant) name: (identifier) (identifier))
+  (singleton_method object: (constant) name: (identifier) parameters: (method_parameters (identifier)) (identifier))
+  (method name: (identifier) parameters: (method_parameters)
     (rescue_modifier
-      (identifier)
-      (parenthesized_statements (call (identifier) (argument_list (string (string_content)))))
+      body: (identifier)
+      handler: (parenthesized_statements (call method: (identifier) arguments: (argument_list (string (string_content)))))
     )
   )
 )


### PR DESCRIPTION
#224 added a `body` field for method bodies. However, we forgot about `end`-less methods., such as:
```
def foo = bar
def Object.foo = bar
```

As a result their bodies are still represented as unnamed children. 

@npezza93 @maxbrunsfeld 

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
