### PR TITLE
fix: rename reserved word “arguments”

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -749,12 +749,12 @@ module.exports = grammar({
         $._call,
         field('method', choice($._variable, $._function_identifier))
       )
-      const arguments = field('arguments', alias($.command_argument_list, $.argument_list))
+      const args = field('arguments', alias($.command_argument_list, $.argument_list))
       const block = field('block', $.block)
       const doBlock = field('block', $.do_block)
       return choice(
-        seq(receiver, prec(PREC.CURLY_BLOCK, seq(arguments, block))),
-        seq(receiver, prec(PREC.DO_BLOCK, seq(arguments, doBlock))),
+        seq(receiver, prec(PREC.CURLY_BLOCK, seq(args, block))),
+        seq(receiver, prec(PREC.DO_BLOCK, seq(args, doBlock))),
       )
     },
 
@@ -772,7 +772,7 @@ module.exports = grammar({
         ))
       )
 
-      const arguments = field('arguments', $.argument_list)
+      const args = field('arguments', $.argument_list)
       const receiver_arguments =
         seq(
           choice(
@@ -782,7 +782,7 @@ module.exports = grammar({
               field('operator', $._call_operator)
             ))
           ),
-          arguments
+          args
         )
 
       const block = field('block', $.block)


### PR DESCRIPTION
Fixes #228. `arguments` is a reserved word in JavaScript and throws errors in many parsers.

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
