### PR TITLE
Anonymous (hash) splat arguments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -819,8 +819,8 @@ module.exports = grammar({
     )),
 
     forward_argument: $ => '...',
-    splat_argument: $ => seq(alias($._splat_star, '*'), $._arg),
-    hash_splat_argument: $ => seq(alias($._hash_splat_star_star, '**'), $._arg),
+    splat_argument: $ => prec.right(seq(alias($._splat_star, '*'), optional($._arg))),
+    hash_splat_argument: $ => prec.right(seq(alias($._hash_splat_star_star, '**'), optional($._arg))),
     block_argument: $ => prec.right(seq(alias($._block_ampersand, '&'), optional($._arg))),
 
     do_block: $ => seq(

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "nan": "^2.14.1",
+    "node-gyp": "^9.0.0",
     "prebuild-install": "^5.0.0"
   },
   "devDependencies": {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4789,40 +4789,64 @@
       "value": "..."
     },
     "splat_argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_splat_star"
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_splat_star"
+            },
+            "named": false,
+            "value": "*"
           },
-          "named": false,
-          "value": "*"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "hash_splat_argument": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_hash_splat_star_star"
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_hash_splat_star_star"
+            },
+            "named": false,
+            "value": "**"
           },
-          "named": false,
-          "value": "**"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_arg"
-        }
-      ]
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_arg"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "block_argument": {
       "type": "PREC_RIGHT",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1960,7 +1960,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_arg",
@@ -3079,7 +3079,7 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "_arg",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1272,7 +1272,10 @@ foo(x, *bar)
 foo(*bar.baz)
 foo(**baz)
 foo **bar, baz
-
+foo(*)
+foo(x, *)
+foo(**)
+foo x, **
 ---
 
 (program
@@ -1281,7 +1284,11 @@ foo **bar, baz
   (call (identifier) (argument_list (identifier) (splat_argument (identifier))))
   (call (identifier) (argument_list (splat_argument (call (identifier) (identifier)))))
   (call (identifier) (argument_list (hash_splat_argument (identifier))))
-  (call (identifier) (argument_list (hash_splat_argument (identifier)) (identifier))))
+  (call (identifier) (argument_list (hash_splat_argument (identifier)) (identifier)))
+  (call (identifier) (argument_list (splat_argument)))
+  (call (identifier) (argument_list (identifier) (splat_argument)))
+  (call (identifier) (argument_list (hash_splat_argument)))
+  (call (identifier) (argument_list (identifier) (hash_splat_argument))))
 
 ============================
 method call without parens


### PR DESCRIPTION
From [Ruby 3.2 release notes](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)
> Anonymous rest and keyword rest arguments can now be passed as arguments, instead of just used in method parameters. [[Feature #18351](https://bugs.ruby-lang.org/issues/18351)]
> ```ruby
>  def foo(*)
>    bar(*)
>  end
>  def baz(**)
>    quux(**)
>  end
>```

This PR also upgrade the node-gyp version to solve a CI failure on the latest version of OSX: https://github.com/tree-sitter/tree-sitter-ruby/actions/runs/3873495109/jobs/6603577164

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
