### PR TITLE
Remove a prohibited empty string token definition

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -104,7 +104,7 @@ module.exports = grammar({
       optional(
         choice(
           seq(/__END__[\r\n]/, $.uninterpreted),
-          seq('__END__', alias('', $.uninterpreted))
+          seq('__END__', $.uninterpreted),
         )
       )
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -44,13 +44,8 @@
                       "value": "__END__"
                     },
                     {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "STRING",
-                        "value": ""
-                      },
-                      "named": true,
-                      "value": "uninterpreted"
+                      "type": "SYMBOL",
+                      "name": "uninterpreted"
                     }
                   ]
                 }


### PR DESCRIPTION
Empty string tokens will be prohibited in Tree-sitter soon, this PR removes them because this repo is a tree-sitter dependency for corpus tests and it breaks tests in the tree-sitter main repo.

_Tree-sitter error report:_
```
Error processing rule 

Caused by:
    Empty string token don't allowed
```