### PR TITLE
Scanner: do not skip LINE_BREAKs before .. and ...

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -247,8 +247,17 @@ struct Scanner {
           }
           break;
         default:
-          if (crossed_newline && lexer->lookahead != '.' && lexer->lookahead != '&' && lexer->lookahead != '#') {
-            lexer->result_symbol = LINE_BREAK;
+          if (crossed_newline) {
+            if (lexer->lookahead != '.' && lexer->lookahead != '&' && lexer->lookahead != '#') {
+              lexer->result_symbol = LINE_BREAK;
+            }
+            // the '..' and '...' operators are special cases
+            if (lexer->lookahead == '.') {
+              advance(lexer);
+              if (lexer->lookahead == '.') {
+                lexer->result_symbol = LINE_BREAK;
+              }
+            }
           }
           return true;
       }

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -271,6 +271,18 @@ def foo(a, b, ...)
   bar(b, ...)
 end
 
+def foo ...
+  3
+end
+
+def foo
+  ... 3
+end
+
+def foo
+  .. 3
+end
+
 ---
 
 (program
@@ -288,6 +300,11 @@ end
   (method (identifier) (method_parameters (identifier) (identifier) (forward_parameter))
     (body_statement (call (identifier) (argument_list (identifier) (forward_argument))))
   )
+  (method (identifier) (method_parameters (forward_parameter))
+    (body_statement (integer))
+  )
+  (method (identifier) (body_statement (range (integer))))
+  (method (identifier) (body_statement (range (integer))))
 )
 
 =========================================


### PR DESCRIPTION
Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).

See also: https://github.com/tree-sitter/tree-sitter-ruby/issues/237
