### PR TITLE
Fix non-termination in parser

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -250,12 +250,13 @@ struct Scanner {
           if (crossed_newline) {
             if (lexer->lookahead != '.' && lexer->lookahead != '&' && lexer->lookahead != '#') {
               lexer->result_symbol = LINE_BREAK;
-            }
-            // the '..' and '...' operators are special cases
-            if (lexer->lookahead == '.') {
+            } else if (lexer->lookahead == '.') {
+              // Don't return LINE_BREAK for the call operator (`.`) but do return one for range operators (`..` and `...`)
               advance(lexer);
-              if (lexer->lookahead == '.') {
+              if (!lexer->eof(lexer) && lexer->lookahead == '.') {
                 lexer->result_symbol = LINE_BREAK;
+              } else {
+                return false;
               }
             }
           }

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1305,7 +1305,7 @@ method call with line break
 ============================
 
 Foo
-  .bar
+  .bar!
   .baz
 
 Foo \


### PR DESCRIPTION
My earlier changes https://github.com/tree-sitter/tree-sitter-ruby/pull/238 somehow caused the parser to hang on some inputs. I'm not sure how it ended up in an infinite loop, but the changes I made to the scanner were not entirely right. I changed the scanner to `return false` if it sees a newline before a `.` character that has no following `.` character otherwise we'd end up calling `mark_end`, `advancing` a bit, and subsequently trying to scan a next token which makes no sense. 

@hendrikvanantwerpen 

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
