### PR TITLE
Fix scanning of division vs regex before line ending

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "nan": "^2.14.1",
-    "node-gyp": "^9.0.0",
+    "node-gyp": "^10.0.1",
     "prebuild-install": "^5.0.0"
   },
   "devDependencies": {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -434,7 +434,7 @@ struct Scanner {
         if (valid_symbols[FORWARD_SLASH]) {
           if (!has_leading_whitespace)
             return false;
-          if (lexer->lookahead == ' ' || lexer->lookahead == '\t')
+          if (lexer->lookahead == ' ' || lexer->lookahead == '\t' || lexer->lookahead == '\n' || lexer->lookahead == '\r')
             return false;
           if (lexer->lookahead == '=')
             return false;

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1797,10 +1797,16 @@ basic division
 ===============================
 
 10 / 5
-
+x / y
+x /
+5
 ---
 
-(program (binary (integer) (integer)))
+(program
+  (binary (integer) (integer))
+  (binary (identifier) (identifier))
+  (binary (identifier) (integer))
+)
 
 ===============================
 division without spaces


### PR DESCRIPTION
This should improve parsing of expressions with a division (`/`) operator before a line break. Previously the scanner treated those as the start of a regular expression literal (`/..../`).

For example:
```ruby
foo /
5
```

Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
