### PR TITLE
Fix 'case' with newlines before expression

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -363,7 +363,7 @@ module.exports = grammar({
 
     case: $ => seq(
       'case',
-      field('value', optional($._statement)),
+      optional(seq(optional($._line_break),  field('value', $._statement))),
       optional($._terminator),
       repeat($.when),
       optional($.else),
@@ -372,7 +372,7 @@ module.exports = grammar({
 
     case_match: $ => seq(
       'case',
-      field('value', $._statement),
+      seq(optional($._line_break),  field('value', $._statement)),
       optional($._terminator),
       repeat1(field('clauses', $.in_clause)),
       optional(field('else', $.else)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1663,20 +1663,37 @@
           "value": "case"
         },
         {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_statement"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_line_break"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "FIELD",
+                  "name": "value",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_statement"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "CHOICE",
@@ -1723,12 +1740,29 @@
           "value": "case"
         },
         {
-          "type": "FIELD",
-          "name": "value",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_statement"
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "_line_break"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "FIELD",
+              "name": "value",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_statement"
+              }
+            }
+          ]
         },
         {
           "type": "CHOICE",

--- a/test/corpus/control-flow.txt
+++ b/test/corpus/control-flow.txt
@@ -569,9 +569,16 @@ case foo
 when bar
 end
 
+case 
+  foo
+when bar
+end
+
 ---
 
 (program
+  (case (identifier)
+  (when (pattern (identifier))))
   (case (identifier)
   (when (pattern (identifier)))))
 
@@ -689,3 +696,30 @@ end
   (case (assignment (identifier) (binary (identifier) (identifier)))
     (when (pattern (identifier)))
     (else))))
+
+==============================
+case without expression
+==============================
+
+case when b
+ c end
+
+case 
+when b then c
+end
+
+---
+
+(program
+  (case
+    (when
+      (pattern
+        (identifier))
+      (then
+        (identifier))))
+  (case
+    (when
+      (pattern
+        (identifier))
+      (then
+        (identifier)))))


### PR DESCRIPTION
This PR fixes syntax errors in `case` statements with a newline before its value expression. For example
```ruby
case
   foo
when ....
end
```
Checklist:
- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
