### PR TITLE
Allow invocations of indexes to accept block arguments.

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -724,6 +724,12 @@ module.exports = grammar({
       alias($._element_reference_bracket, '['),
       optional($._argument_list_with_trailing_comma),
       ']',
+      optional(
+        choice(
+          field('block', $.block),
+          field('block', $.do_block)
+        )
+      )
     )),
 
     scope_resolution: $ => prec.left(PREC.CALL + 1, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4118,6 +4118,35 @@
           {
             "type": "STRING",
             "value": "]"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "block",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "block"
+                    }
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "block",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "do_block"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1630,6 +1630,20 @@
     "type": "element_reference",
     "named": true,
     "fields": {
+      "block": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          },
+          {
+            "type": "do_block",
+            "named": true
+          }
+        ]
+      },
       "object": {
         "multiple": false,
         "required": true,

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1872,3 +1872,37 @@ multiline regex
 ---
 
 (program (regex (string_content)))
+
+======================================
+method call index with block - braced
+======================================
+
+Constant[:key_value] { default_value }
+
+---
+
+    (program
+      (element_reference
+        (constant)
+        (simple_symbol)
+        (block
+          (block_body
+            (identifier)))))
+
+======================================
+method call index with block - do
+======================================
+
+Constant[:key_value] do
+ default_value
+end
+
+---
+
+    (program
+      (element_reference
+        (constant)
+        (simple_symbol)
+        (do_block
+          (body_statement
+            (identifier)))))


### PR DESCRIPTION
Indexing of elements in Ruby is really just an invocation of the `[]` method on an object. As such, element indexing should accept a block.

The pull request contains tests as well as an extension of the grammar.