### PR TITLE
Do not require newline after block comment `=end`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1065,7 +1065,6 @@ module.exports = grammar({
           /=en[^d]/,
         )),
         /[\s*]*=end.*/,
-        /\r?\n/,
       ),
     ))),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7131,10 +7131,6 @@
                 {
                   "type": "PATTERN",
                   "value": "[\\s*]*=end.*"
-                },
-                {
-                  "type": "PATTERN",
-                  "value": "\\r?\\n"
                 }
               ]
             }

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -92,3 +92,14 @@ multi-line block comments with almost end
 ---
 
 (program (comment))
+
+=========================
+block comment without newline after end
+=========================
+
+=begin
+comment
+=end
+---
+
+(program (comment))


### PR DESCRIPTION
Reverts a change made on https://github.com/tree-sitter/tree-sitter-ruby/pull/255, cc @amaanq .