### PR TITLE
Add support for `!=` method definitions

### DIFF
--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6903,6 +6903,10 @@
         },
         {
           "type": "STRING",
+          "value": "!="
+        },
+        {
+          "type": "STRING",
           "value": "**"
         },
         {

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -94,10 +94,14 @@ end
 def !~(a)
 end
 
+def !=(a)
+end
+
 ---
 
 (program
   (method (operator) (method_parameters (identifier)) (body_statement (string (string_content))))
+  (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))
   (method (operator) (method_parameters (identifier)))


### PR DESCRIPTION
Hey, I have absolutely no idea what I’m doing, but I think this adds support for defining `!=` methods and closes #174. I added a test which previously failed and now passes with the grammar changes.

It seemed strange to include build artefacts in the commit, but they hadn’t been gitignored and that seems to be the process.