### PR TITLE
Handle chained method calls with command call receivers

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -636,7 +636,7 @@ module.exports = grammar({
     //
     // Because of this distinction, a lot of rules have two variants: the
     // normal variant, which can appear anywhere that an expression is valid,
-    // and the "command" varaint, which is only valid in a more limited set of
+    // and the "command" variant, which is only valid in a more limited set of
     // positions, because it can contain "command calls".
     //
     // The `_expression` rule can appear in relatively few places, but can
@@ -777,6 +777,7 @@ module.exports = grammar({
     call: $ => {
       const receiver = choice(
         $._call,
+        $._chained_command_call,
         field('method', choice(
           $._variable, $._function_identifier,
         )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4506,6 +4506,10 @@
                       "name": "_call"
                     },
                     {
+                      "type": "SYMBOL",
+                      "name": "_chained_command_call"
+                    },
+                    {
                       "type": "FIELD",
                       "name": "method",
                       "content": {
@@ -4579,6 +4583,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "_call"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_chained_command_call"
                           },
                           {
                             "type": "FIELD",
@@ -4665,6 +4673,10 @@
                           {
                             "type": "SYMBOL",
                             "name": "_call"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "_chained_command_call"
                           },
                           {
                             "type": "FIELD",
@@ -4747,6 +4759,10 @@
                     "name": "_call"
                   },
                   {
+                    "type": "SYMBOL",
+                    "name": "_chained_command_call"
+                  },
+                  {
                     "type": "FIELD",
                     "name": "method",
                     "content": {
@@ -4788,6 +4804,10 @@
                   {
                     "type": "SYMBOL",
                     "name": "_call"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_chained_command_call"
                   },
                   {
                     "type": "FIELD",

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1864,6 +1864,18 @@ end.g h { |i|
   k
 end
 
+foo bar do |x|
+  x
+end.each &:sort
+
+foo do |x|
+  x
+end.each(&:sort)
+
+foo bar do |x|
+  x
+end.each(&:sort)
+
 ---
 
 (program
@@ -1893,7 +1905,47 @@ end
         method: (identifier)
         block: (do_block
           body: (body_statement
-            (identifier)))))))
+            (identifier))))))
+  (call
+    receiver: (call
+      method: (identifier)
+      arguments: (argument_list
+        (identifier))
+      block: (do_block
+        parameters: (block_parameters
+          (identifier))
+        body: (body_statement
+          (identifier))))
+    method: (identifier)
+    arguments: (argument_list
+      (block_argument
+        (simple_symbol))))
+  (call
+    receiver: (call
+      method: (identifier)
+      block: (do_block
+        parameters: (block_parameters
+          (identifier))
+        body: (body_statement
+          (identifier))))
+    method: (identifier)
+    arguments: (argument_list
+      (block_argument
+        (simple_symbol))))
+  (call
+    receiver: (call
+      method: (identifier)
+      arguments: (argument_list
+        (identifier))
+      block: (do_block
+        parameters: (block_parameters
+          (identifier))
+        body: (body_statement
+          (identifier))))
+    method: (identifier)
+    arguments: (argument_list
+      (block_argument
+        (simple_symbol)))))
 
 ===============================
 method calls in binary expression


### PR DESCRIPTION
Means we can now parse
```rb
foo bar do |x|
  x
end.each(&:sort)
```

The increase in `parser.c` is worrisome; is there perhaps a better way?