### PR TITLE
Highlight private|protected|public as a methods

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -33,8 +33,8 @@
   "yield"
 ] @keyword
 
-((identifier) @keyword
- (#match? @keyword "^(private|protected|public)$"))
+((identifier) @function.builtin
+ (#match? @function.builtin "^(private|protected|public)$"))
 
 (constant) @constructor
 


### PR DESCRIPTION
These identifiers is not a keywords in Ruby programming language.

For comparison RubyMine and Vscode+RubyLSP examples:

![image](https://github.com/user-attachments/assets/ad8c34b0-cd6a-4f08-8452-5b547b16632d)
![image](https://github.com/user-attachments/assets/d78b17c7-7b9e-44eb-bbec-f7766eed02c1)
