### PR TITLE
Update tree-sitter/setup-action/cli to try to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up tree-sitter
-        uses: tree-sitter/setup-action/cli@v1
+        uses: tree-sitter/setup-action/cli@v2
       - name: Set up examples
         run: |
           git clone https://github.com/ruby/spec examples/ruby_spec --single-branch --depth=1 --filter=blob:none


### PR DESCRIPTION
The error is likely fixed by this commit: https://github.com/tree-sitter/setup-action/commit/2a73b299fd6fb356d3b156013b1f0d2ece0e47c1
